### PR TITLE
Refactor inner_hits queries to fix numItemsTotal

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -14,7 +14,7 @@ const ResponseMassager = require('./response_massager.js')
 const DeliveryLocationsResolver = require('./delivery-locations-resolver')
 const AvailableDeliveryLocationTypes = require('./available_delivery_location_types')
 
-const { parseParams, backslashes, checkForNestedHitsAndSource } = require('../lib/util')
+const { parseParams, backslashes, deepValue } = require('../lib/util')
 
 const errors = require('./errors')
 
@@ -126,7 +126,7 @@ const FILTER_CONFIG = {
   materialType: { operator: 'match', field: 'materialType_packed', repeatable: true },
   mediaType: { operator: 'match', field: 'mediaType_packed', repeatable: true },
   carrierType: { operator: 'match', field: 'carrierType_packed', repeatable: true },
-  publisher: { operator: 'match', field: 'publisher', repeatable: true },
+  publisher: { operator: 'match', field: 'publisherLiteral.raw', repeatable: true },
   contributorLiteral: { operator: 'match', field: 'contributorLiteral.raw', repeatable: true },
   creatorLiteral: { operator: 'match', field: 'creatorLiteral.raw', repeatable: true },
   issuance: { operator: 'match', field: 'issuance_packed', repeatable: true },
@@ -239,28 +239,22 @@ module.exports = function (app, _private = null) {
           }
         }
 
-        // Are we selecting a specific item?
-        if (params.itemUri) {
-          // Add that item uri as a term query to the ES body:
-          body = addItemQuery(body, params.itemUri)
-        } else {
-          // No specific item requested, so add pagination and matching params:
-          const itemsOptions = {
-            size: params.items_size,
-            from: params.items_from,
-            merge_checkin_card_items: params.merge_checkin_card_items,
-            removeElectronicResourcesFromItemsArray: true,
-            query: {
-              volume: params.item_volume,
-              date: params.item_date,
-              format: params.item_format,
-              location: params.item_location,
-              status: params.item_status
-            },
-            unavailable_recap_barcodes: recapBarcodesByStatus['Not Available']
-          }
-          body = addInnerHits(body, itemsOptions)
+        // No specific item requested, so add pagination and matching params:
+        const itemsOptions = {
+          size: params.items_size,
+          from: params.items_from,
+          merge_checkin_card_items: params.merge_checkin_card_items,
+          query: {
+            volume: params.item_volume,
+            date: params.item_date,
+            format: params.item_format,
+            location: params.item_location,
+            status: params.item_status,
+            itemUri: params.itemUri
+          },
+          unavailable_recap_barcodes: recapBarcodesByStatus['Not Available']
         }
+        body = addInnerHits(body, itemsOptions)
 
         if (params.include_item_aggregations) {
           body.aggregations = ITEM_FILTER_AGGREGATIONS
@@ -269,14 +263,6 @@ module.exports = function (app, _private = null) {
         app.logger.debug('Resources#findByUri', body)
         return app.esClient.search(body)
           .then((resp) => {
-            if (checkForNestedHitsAndSource(resp, 'items')) {
-              resp.hits.hits[0]._source.items = resp.hits.hits[0].inner_hits.items.hits.hits.map((item) => item._source)
-            }
-            if (checkForNestedHitsAndSource(resp, 'electronicResources')) {
-              resp.hits.hits[0]._source.electronicResources = resp.hits.hits[0].inner_hits.electronicResources.hits.hits
-                .map((resource) => resource._source.electronicLocator)
-                .reduce((acc, el) => acc.concat(el), [])
-            }
             // Mindfully throw errors for known issues:
             if (!resp || !resp.hits) {
               throw new Error('Error connecting to index')
@@ -284,7 +270,7 @@ module.exports = function (app, _private = null) {
               throw new errors.NotFoundError(`Record not found: ${params.uri}`)
             } else {
               let massagedResponse = new ResponseMassager(resp)
-              return massagedResponse.massagedResponse(request, { queryRecapCustomerCode: !!params.itemUri, recapBarcodesByStatus, electronicResourcesAlreadyRemoved: true })
+              return massagedResponse.massagedResponse(request, { queryRecapCustomerCode: !!params.itemUri, recapBarcodesByStatus })
                 .catch((e) => {
                   // If error hitting HTC, just return response un-modified:
                   return resp
@@ -337,7 +323,7 @@ module.exports = function (app, _private = null) {
     }
     if (opts._source) body._source = opts._source
 
-    app.logger.debug('Resources#search', body)
+    app.logger.debug('Resources#itemsByFilter', body)
     return app.esClient.search(body)
       .then((resp) => {
         if (!resp || !resp.hits || resp.hits.total === 0) return Promise.reject('No matching items')
@@ -419,6 +405,11 @@ module.exports = function (app, _private = null) {
       merge_checkin_card_items: false
     }, _options)
 
+    // Make sure necessary structure exists:
+    if (!deepValue(body, 'query.bool') && !deepValue(body, 'query.function_score.query.bool')) {
+      body.query = { bool: {} }
+    }
+
     // The place to add the filter depends on the query built to this point:
     const placeToAddFilter = (body.query.bool || body.query.function_score.query.bool)
     // Initialize filter object if it doesn't already exist:
@@ -433,7 +424,7 @@ module.exports = function (app, _private = null) {
       )
     }
 
-    placeToAddFilter.filter.push({
+    const wrappedItemsQuery = {
       bool: {
         should: [
           {
@@ -452,13 +443,9 @@ module.exports = function (app, _private = null) {
             nested: {
               path: 'items',
               query: {
-                exists: {
-                  field: 'items.electronicLocator'
-                }
+                exists: { field: 'items.electronicLocator' }
               },
-              inner_hits: {
-                name: 'electronicResources'
-              }
+              inner_hits: { name: 'electronicResources' }
             }
           },
           // Add a catch-all to ensure we return the bib document even when
@@ -466,7 +453,24 @@ module.exports = function (app, _private = null) {
           { match_all: {} }
         ]
       }
-    })
+    }
+    placeToAddFilter.filter.push(wrappedItemsQuery)
+
+    // If there is any item query at all, run an additional inner_hits query
+    // to retrieve the total number of items without filtering:
+    if (itemsQuery.bool.filter) {
+      wrappedItemsQuery.bool.should.push({
+        nested: {
+          path: 'items',
+          query: {
+            bool: {
+              must_not: [ { exists: { field: 'items.electronicLocator' } } ]
+            }
+          },
+          inner_hits: { name: 'allItems' }
+        }
+      })
+    }
 
     return body
   }
@@ -555,6 +559,9 @@ module.exports = function (app, _private = null) {
             }
           }
         }
+      },
+      itemUri: (uri) => {
+        return { term: { 'items.uri': uri } }
       }
     }
 
@@ -679,62 +686,32 @@ module.exports = function (app, _private = null) {
   const itemsQueryContext = (options) => {
     const excludeClauses = []
 
-    if (options.removeElectronicResourcesFromItemsArray) excludeClauses.push({ exists: { field: 'items.electronicLocator' } })
+    // Always remove electronicResources from items because (if they exist
+    // there, the "electronicResources" inner_hits query will extract them)
+    excludeClauses.push({ exists: { field: 'items.electronicLocator' } })
 
     if (!options.merge_checkin_card_items) excludeClauses.push({ term: { 'items.type': 'nypl:CheckinCardItem' } })
 
     return excludeClauses.length ? { must_not: excludeClauses } : { must: { match_all: {} } }
   }
 
-  const addItemQuery = (body, itemUri) => {
-    body.query.bool.must.push({
-      nested: {
-        path: 'items',
-        query: { term: { 'items.uri': itemUri } },
-        inner_hits: { name: 'items' }
-      }
-    })
-
-    return body
-  }
-
   // Conduct a search across resources:
   app.resources.search = function (params, opts, request) {
     params = parseSearchParams(params)
 
-    var body = buildElasticBody(params)
+    let body = buildElasticBody(params)
 
-    // Make sure query body has a structure we can attach an inner_hits query to:
-    const shouldAddInnerHits = body.query &&
-      (
-        body.query.bool ||
-        (
-          body.query.function_score &&
-          body.query.function_score.query &&
-          body.query.function_score.query.bool
-        )
-      )
     // Strip unnecessary _source fields
     body._source = {
-      excludes: EXCLUDE_FIELDS.concat(shouldAddInnerHits ? ['items'] : [])
+      excludes: EXCLUDE_FIELDS.concat(['items'])
     }
 
-    if (shouldAddInnerHits) {
-      body = addInnerHits(body, { merge_checkin_card_items: params['merge_checkin_card_items'] })
-    }
+    body = addInnerHits(body, { merge_checkin_card_items: params['merge_checkin_card_items'] })
 
     app.logger.debug('Resources#search', RESOURCES_INDEX, body)
 
     return app.esClient.search(body)
     .then((resp) => {
-      if (shouldAddInnerHits) {
-        resp.hits.hits.forEach((hit) => {
-          if (hit.inner_hits) {
-            hit._source.items = hit.inner_hits.items.hits.hits.map((itemHit) => itemHit._source)
-            delete hit['inner_hits']
-          }
-        })
-      }
       let massagedResponse = new ResponseMassager(resp)
       return massagedResponse.massagedResponse(request)
         .catch((e) => {
@@ -1193,30 +1170,33 @@ const buildElasticQueryForFilters = function (params) {
   }
 
   // Gather root (not nested) filters:
-  let rootFilterClauses = filterClausesWithPaths
+  let filterClauses = filterClausesWithPaths
     .filter((clauseWithPath) => !clauseWithPath.path)
     .map((clauseWithPath) => clauseWithPath.clause)
 
-  const query = {}
-
   // Add nested filters:
-  filterClausesWithPaths
-    // Nested filters have a `path` property:
-    .filter((clauseWithPath) => clauseWithPath.path)
-    .forEach((clauseWithPath) => {
-      // TODO: Note we seem to lack support for applying multiple nested filters
-      query.nested = {
-        path: clauseWithPath.path,
-        query: {
-          constant_score: {
-            filter: clauseWithPath.clause
+  filterClauses = filterClauses.concat(
+    filterClausesWithPaths
+      // Nested filters have a `path` property:
+      .filter((clauseWithPath) => clauseWithPath.path)
+      .map((clauseWithPath) => {
+        return {
+          nested: {
+            path: clauseWithPath.path,
+            query: {
+              constant_score: {
+                filter: clauseWithPath.clause
+              }
+            }
           }
         }
-      }
-    })
+      })
+  )
 
-  if (rootFilterClauses.length > 0) {
-    query.bool = { filter: rootFilterClauses }
+  const query = {}
+
+  if (filterClauses.length > 0) {
+    query.bool = { filter: filterClauses }
   }
 
   return query

--- a/lib/response_massager.js
+++ b/lib/response_massager.js
@@ -1,19 +1,84 @@
 const LocationLabelUpdater = require('./location_label_updater')
 const AvailabilityResolver = require('./availability_resolver.js')
 const parallelFieldsExtractor = require('./parallel-fields-extractor')
-const addNumItemsMatched = require('./item-match-numerator')
+// const addNumItemsMatched = require('./item-match-numerator')
 
 class ResponseMassager {
   constructor (responseReceived) {
     this.elasticSearchResponse = responseReceived
   }
 
+  /**
+   *  Given a ES response,
+   *  if it contains hits that have "items" or "electronicResources" inner_hits,
+   *  reassigns those hits to ".items" and ".electronicResources" so that later
+   *  code can access them as if that's where they were indexed that way.
+   *
+   *  Also copies ".total" properties into convenient places for serialization.
+   */
+  processInnerHitsProperties (response) {
+    response.hits.hits.forEach((hit) => {
+      // Process "items" inner_hits
+      if (hit.inner_hits && hit.inner_hits.items) {
+        // Reassign items inner_hits to .items
+        hit._source.items = hit.inner_hits.items.hits.hits.map((itemHit) => itemHit._source)
+
+        // Grab the "items" inner_hits total as numItemsMatched:
+        hit._source.numItemsMatched = [hit.inner_hits.items.hits.total]
+
+        // If response includes an "allItems" inner_hits query, use the total
+        // from that to get numItemsTotal. If "allItems inner_hits query
+        // doesn't exist (because no item filters are in play) just use "items"
+        // inner_hits query:
+        const unfilteredItems = (hit.inner_hits.allItems || hit.inner_hits.items)
+        hit._source.numItemsTotal = [unfilteredItems.hits.total]
+      }
+      // Process "electronicResources" inner_hits
+      if (hit.inner_hits && hit.inner_hits.electronicResources) {
+        // If record doesn't have indexed electronicResources...
+        if (!hit._source.electronicResources || hit._source.electronicResource.length === 0) {
+          // Gather up all records in the electronicResources inner_hit,
+          // collect all of the electronicLocator values
+          // and save the resulting array to .electronicResources:
+          hit._source.electronicResources = hit.inner_hits.electronicResources.hits.hits
+            .map((resource) => resource._source.electronicLocator)
+            .reduce((acc, el) => acc.concat(el), [])
+          hit._source.numElectronicResources = [hit.inner_hits.electronicResources.hits.total]
+        }
+      }
+      delete hit['inner_hits']
+    })
+
+    return response
+  }
+
   massagedResponse (request, options = {}) {
     let response = this.elasticSearchResponse
 
+    // Inspect response inner_hits queries and move properties around to ease
+    // serialization:
+    response = this.processInnerHitsProperties(response)
+
     // For findByUri calls, copy numItemsMatched into document so it's included
     // in response:
-    response = addNumItemsMatched(response, request, options.electronicResourcesAlreadyRemoved)
+    // response = addNumItemsMatched(response, request, options.electronicResourcesAlreadyRemoved)
+
+    response.hits.hits = response.hits.hits.map((hit) => {
+      if (!hit._source.numElectronicResources) {
+        let eResources = hit._source.electronicResources
+        if (!eResources) {
+          const eResourcesItem = (hit._source.items || []).find((i) => i.electronicLocator)
+          if (eResourcesItem) {
+            eResources = eResourcesItem.electronicLocator
+          }
+        }
+        if (eResources) {
+          hit._source.numElectronicResources = eResources.length
+        }
+      }
+
+      return hit
+    })
 
     // Rename parallel fields:
     response = parallelFieldsExtractor(response)

--- a/test/fixtures/query-057ee82dfa7a1b7a0707d7ac3c24a7f9.json
+++ b/test/fixtures/query-057ee82dfa7a1b7a0707d7ac3c24a7f9.json
@@ -1,0 +1,918 @@
+{
+  "took": 14,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 29.807812,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 29.807812,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-07b0a0ce586c2ff118074e3733e386a6.json
+++ b/test/fixtures/query-07b0a0ce586c2ff118074e3733e386a6.json
@@ -1,0 +1,13355 @@
+{
+  "took": 1009,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.52571,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10833141",
+        "_score": 13.52571,
+        "_source": {
+          "extent": [
+            "volumes : illustrations ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Some issues bear also thematic titles.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Editors: Harold Ross, 1925-1951; William Shawn, 1951-1987; Robert Gotllieb, 1987-1992, Tina Brown, 1992-1998; David Remnick, 1998-",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Vol. 73, no. 1 never published.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Has occasional supplements.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Vol. 90, no. 24 (Aug. 25, 2014).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Began with issue for Feb. 21, 1925."
+          ],
+          "subjectLiteral_exploded": [
+            "Literature",
+            "Literature -- Periodicals",
+            "Intellectual life",
+            "Electronic journals",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- Intellectual life",
+            "New York (N.Y.) -- Intellectual life -- Directories",
+            "New York (State)",
+            "New York (State) -- New York"
+          ],
+          "numItemDatesParsed": [
+            892
+          ],
+          "publisherLiteral": [
+            "F-R Pub. Corp.",
+            "D. Carey",
+            "Condé Nast Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            898
+          ],
+          "createdYear": [
+            1925
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The New Yorker."
+          ],
+          "shelfMark": [
+            "*DA+ (New Yorker)"
+          ],
+          "numItemVolumesParsed": [
+            828
+          ],
+          "createdString": [
+            "1925"
+          ],
+          "idLccn": [
+            "   28005329"
+          ],
+          "idIssn": [
+            "0028-792X"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ross, Harold Wallace, 1892-1951",
+            "Shawn, William",
+            "Brown, Tina",
+            "Remnick, David",
+            "White, Katharine Sergeant Angell",
+            "White, E. B. (Elwyn Brooks), 1899-1985",
+            "Irvin, Rea, 1881-1972",
+            "Angell, Roger"
+          ],
+          "dateStartYear": [
+            1925
+          ],
+          "donor": [
+            "Gift of the DeWitt Wallace Endowment Fund, named in honor of the founder of Reader's Digest (copy held in Per. Sect.)"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*DA+ (New Yorker)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10833141"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0028-792X"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   28005329"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1760231"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1760231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1760231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)228666271 (OCoLC)315923316 (OCoLC)813435753 (OCoLC)972367546 (OCoLC)973902298 (OCoLC)1032835230 (OCoLC)1038943160 (OCoLC)1041661831 (OCoLC)1054975031 (OCoLC)1058338019 (OCoLC)1065410087 (OCoLC)1078551167 (OCoLC)1081045337 (OCoLC)1082980679 (OCoLC)1114402509 (OCoLC)1134878896 (OCoLC)1134879337 (OCoLC)1144737766 (OCoLC)1167086187 (OCoLC)1294152325 (OCoLC)1302429095 (OCoLC)1319602865 (OCoLC)1322139476 (OCoLC)1332666305"
+            }
+          ],
+          "idOclc": [
+            "1760231"
+          ],
+          "uniformTitle": [
+            "New Yorker (New York, N.Y. : 1925)"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "97(2021)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 97 No. 25 (Aug. 23, 2021)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 26 (Aug. 30, 2021)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 27 (Sep. 6, 2021)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 28 (Sep. 13, 2021)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 29 (Sep. 20, 2021)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 30 (Sep. 27, 2021)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 31 (Oct. 4, 2021)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 32 (Oct. 11, 2021)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 33 (Oct. 18, 2021)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 34 (Oct. 25, 2021)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 35 (Nov. 1, 2021)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 36 (Nov. 8, 2021)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 37 (Nov. 15, 2021)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 38 (Nov. 22, 2021)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 39 (Nov. 29, 2021)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 40 (Dec. 6, 2021)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 41 (Dec. 13, 2021)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 42 (Dec. 20, 2021)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 97 No. 43 (Dec. 27, 2021)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 44 (Jan. 3, 2022 - Jan. 10, 2022)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 45 (Jan. 10, 2022)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 46 (Jan. 24, 2022)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 47 (Jan. 31, 2022)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 48 (Feb. 7, 2022)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 1 (Feb. 14, 2022)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 2 (Feb. 28, 2022)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 3 (Mar. 7, 2022)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 4 (Mar. 14, 2022)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 5 (Mar. 21, 2022)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 6 (Mar. 28, 2022)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 7 (Apr. 4, 2022)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 8 (Apr. 11, 2022)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 9 (Apr. 18, 2022)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 10 (Apr. 25, 2022)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 11 (May. 9, 2022)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 12 (May. 16, 2022)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 13 (May. 23, 2022)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 14 (May. 30, 2022)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 15 (Jun. 6, 2022)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 16 (Jun. 13, 2022)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 17 (Jun. 20, 2022)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 18 (Jun. 27, 2022)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 19 (Jul. 4, 2022)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 20 (Jul. 11, 2022)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 21 (Jul. 25, 2022)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 22 (Aug. 1, 2022)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 23 (Aug. 8, 2022)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 24 (Aug. 15, 2022)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 25 (Aug. 22, 2022)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 26 (Aug. 29, 2022)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 27 (Sep. 5, 2022)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 28 (Sep. 12, 2022)",
+                  "position": "52",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 29 (Sep. 19, 2022)",
+                  "position": "53",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 30 (Sep. 26, 2022)",
+                  "position": "54",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 31 (Oct. 3, 2022)",
+                  "position": "55",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 32 (Oct. 10, 2022)",
+                  "position": "56",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 33 (Oct. 17, 2022)",
+                  "position": "57",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 34 (Oct. 24, 2022)",
+                  "position": "58",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 35 (Oct. 31, 2022)",
+                  "position": "59",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 36 (Nov. 7, 2022)",
+                  "position": "60",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 37 (Nov. 14, 2022)",
+                  "position": "61",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 38 (Nov. 21, 2022)",
+                  "position": "62",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 39 (Nov. 28, 2022)",
+                  "position": "63",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 40 (Dec. 5, 2022)",
+                  "position": "64",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 41 (Dec. 12, 2022)",
+                  "position": "65",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 42 (Dec. 19, 2022)",
+                  "position": "66",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 43 (Dec. 26, 2022)",
+                  "position": "67",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 44 (Jan. 2, 2023)",
+                  "position": "68",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 45 (Jan. 16, 2023)",
+                  "position": "69",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 47 (Jan. 23, 2023)",
+                  "position": "70",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 48 (Jan. 30, 2023)",
+                  "position": "71",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 49 (Feb. 6, 2023)",
+                  "position": "72",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 99 No. 01 (Feb. 13, 2023 - Feb. 20, 2023)",
+                  "position": "73",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 99 No. 2 (Feb. 27, 2023)",
+                  "position": "74",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 99 No. 3 (Mar. 6, 2023)",
+                  "position": "75",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 99 No. 4 (Mar. 13, 2023)",
+                  "position": "76",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 99 No. 5 (Mar. 20, 2023)",
+                  "position": "77",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 99 No. 6 (Mar. 27, 2023)",
+                  "position": "78",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 99 No. 7 (Apr. 3, 2023)",
+                  "position": "79",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 99 No. 8 (Apr. 10, 2023)",
+                  "position": "80",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 99 No. 9 (Apr. 17, 2023)",
+                  "position": "81",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 99 No. 10 (Apr. 24, 2023)",
+                  "position": "82",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 99 No. 11 (May. 1, 2023)",
+                  "position": "83",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*DA+ (New Yorker)"
+                }
+              ],
+              "notes": [
+                "Room 108"
+              ],
+              "physicalLocation": [
+                "*DA+ (New Yorker)"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:makk3",
+                  "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                }
+              ],
+              "uri": "h1144777",
+              "shelfMark": [
+                "*DA+ (New Yorker)"
+              ]
+            },
+            {
+              "holdingStatement": [
+                "[Bound vols.] 1(1925)-June, Sept.1951-68:9(1992), 68:11(1992)-69:4(1993), 69:6(1993)-72:25(1996), 72:27(1996)-75:25(1999), 75:27(1999)-76:45(2001), 77:1(2001)-77:27(2001), 77:29(2001)-81:15(2005), 81:18(2005)-83:13(2007), 83:17(2007)-85:22(2009), 85:24(2009)-86:11(2010), 86:13(2010)-88:12(2012), 88:14(2012)-88:20(2012), 88:39(2012)-90:38(2014), 91:5(2015), 91:9(2015), 91:14(2015)-92:36(2016), 92:38(2016)-94(2018/19)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 95 No. 1 (Feb. 18, 2019)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 2 (Mar. 4, 2019)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 3 (Mar. 11, 2019)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 4 (Mar. 18, 2019)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 5 (Mar. 25, 2019)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 6 (Apr. 1, 2019)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 7 (Apr. 8, 2019)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 8 (Apr. 15, 2019)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 9 (Apr. 22, 2019)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 10 (Apr. 29, 2019)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 11 (May. 6, 2019)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 12 (May. 13, 2019)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 13 (May. 20, 2019)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 14 (May. 27, 2019)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 15 (Jun. 3, 2019)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 16 (Jun. 10, 2019)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 17 (Jun. 24, 2019)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 18 (Jul. 1, 2019)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 19 (Jul. 8, 2019)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 20 (Jul. 22, 2019)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 21 (Jul. 29, 2019)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 22 (Aug. 5, 2019)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 23 (Aug. 19, 2019)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 24 (Aug. 26, 2019)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 25 (Sep. 2, 2019)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 26 (Sep. 9, 2019)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 27 (Sep. 16, 2019)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 28 (Sep. 23, 2019)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 29 (Sep. 30, 2019)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 30 (Oct. 7, 2019)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 31 (Oct. 14, 2019)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 32 (Oct. 21, 2019)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 33 (Oct. 28, 2019)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 34 (Nov. 4, 2019)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 35 (Nov. 11, 2019)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 36 (Nov. 18, 2019)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 37 (Nov. 25, 2019)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 38 (Dec. 2, 2019)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 39 (Dec. 9, 2019)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 40 (Dec. 16, 2019)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 41 (Dec. 23, 2019)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 42 (Dec. 30, 2019)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 43 (Jan. 6, 2020)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 44 (Jan. 13, 2020)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 45 (Jan. 20, 2020)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 46 (Jan. 27, 2020)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 47 (Feb. 3, 2020)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 48 (Feb. 10, 2020)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 96 No. 1 (Feb. 17, 2020 - Feb. 24, 2020)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 2 (Mar. 2, 2020)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 3 (Mar. 9, 2020)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 4 (Mar. 16, 2020)",
+                  "position": "52",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 5 (Mar. 23, 2020)",
+                  "position": "53",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 6 (Mar. 30, 2020)",
+                  "position": "54",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 7 (Apr. 6, 2020)",
+                  "position": "55",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 8 (Apr. 13, 2020)",
+                  "position": "56",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 09 (Apr. 20, 2020)",
+                  "position": "57",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 10 (Apr. 27, 2020)",
+                  "position": "58",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 11 (May. 4, 2020)",
+                  "position": "59",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 12 (May. 11, 2020)",
+                  "position": "60",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 13 (May. 18, 2020)",
+                  "position": "61",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 14 (May. 23, 2020)",
+                  "position": "62",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 15 (Jun. 1, 2020)",
+                  "position": "63",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 16 (Jun. 8, 2020)",
+                  "position": "64",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 18 (Jun. 15, 2020)",
+                  "position": "65",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 96 No. 17 (Jun. 22, 2020)",
+                  "position": "66",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 18 (Jun. 29, 2020)",
+                  "position": "67",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 19 (Jul. 6, 2020 - Jul. 13, 2020)",
+                  "position": "68",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 20 (Jul. 20, 2020)",
+                  "position": "69",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 21 (Jul. 27, 2020)",
+                  "position": "70",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 22 (Aug. 3, 2020)",
+                  "position": "71",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 23 (Aug. 17, 2020)",
+                  "position": "72",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 24 (Aug. 24, 2020)",
+                  "position": "73",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 25 (Aug. 31, 2020)",
+                  "position": "74",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 26 (Sep. 7, 2020)",
+                  "position": "75",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 27 (Sep. 14, 2020)",
+                  "position": "76",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 28 (Sep. 21, 2020)",
+                  "position": "77",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 29 (Sep. 28, 2020)",
+                  "position": "78",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 30 (Oct. 5, 2020)",
+                  "position": "79",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 31 (Oct. 12, 2020)",
+                  "position": "80",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 32 (Oct. 19, 2020)",
+                  "position": "81",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 33 (Oct. 26, 2020)",
+                  "position": "82",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 34 (Nov. 2, 2020)",
+                  "position": "83",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 35 (Nov. 9, 2020)",
+                  "position": "84",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 36 (Nov. 16, 2020)",
+                  "position": "85",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 37 (Nov. 23, 2020)",
+                  "position": "86",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 38 (Nov. 30, 2020)",
+                  "position": "87",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 39 (Dec. 7, 2020)",
+                  "position": "88",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 40 (Dec. 14, 2020)",
+                  "position": "89",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 41 (Dec. 21, 2020)",
+                  "position": "90",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 42 (Dec. 28, 2020)",
+                  "position": "91",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 43 (Jan. 4, 2021)",
+                  "position": "92",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 44 (Jan. 18, 2021)",
+                  "position": "93",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 45 (Jan. 25, 2021)",
+                  "position": "94",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 46 (Feb. 1, 2021)",
+                  "position": "95",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 47 (Feb. 8, 2021)",
+                  "position": "96",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 1 (Feb. 15, 2021)",
+                  "position": "97",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 2 (Mar. 1, 2021)",
+                  "position": "98",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 3 (Mar. 8, 2021)",
+                  "position": "99",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 4 (Mar. 15, 2021)",
+                  "position": "100",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 5 (Mar. 22, 2021)",
+                  "position": "101",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 6 (Mar. 29, 2021)",
+                  "position": "102",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 7 (Apr. 5, 2021)",
+                  "position": "103",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 8 (Apr. 12, 2021)",
+                  "position": "104",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 9 (Apr. 19, 2021)",
+                  "position": "105",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 10 (Apr. 26, 2021 - May. 3, 2021)",
+                  "position": "106",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 11 (May. 10, 2021)",
+                  "position": "107",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 12 (May. 17, 2021)",
+                  "position": "108",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 13 (May. 24, 2021)",
+                  "position": "109",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 14 (May. 31, 2021)",
+                  "position": "110",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 15 (Jun. 7, 2021)",
+                  "position": "111",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 16 (Jun. 14, 2021)",
+                  "position": "112",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 17 (Jun. 21, 2021)",
+                  "position": "113",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 18 (Jun. 28, 2021)",
+                  "position": "114",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 19 (Jul. 5, 2021)",
+                  "position": "115",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 20 (Jul. 12, 2021)",
+                  "position": "116",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 21 (Jul. 26, 2021)",
+                  "position": "117",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 22 (Aug. 2, 2021)",
+                  "position": "118",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 23 (Aug. 9, 2021)",
+                  "position": "119",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 24 (Aug. 16, 2021)",
+                  "position": "120",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*DA+ (New Yorker)"
+                }
+              ],
+              "notes": [
+                "ROOM 108"
+              ],
+              "physicalLocation": [
+                "*DA+ (New Yorker)"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:makk3",
+                  "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                }
+              ],
+              "uri": "h1059671",
+              "shelfMark": [
+                "*DA+ (New Yorker)"
+              ]
+            }
+          ],
+          "updatedAt": 1679333246338,
+          "publicationStatement": [
+            "New York : F-R Pub. Corp., 1925-",
+            "[New York] : D. Carey",
+            "[New York] : Condé Nast Publications"
+          ],
+          "identifier": [
+            "urn:bnum:10833141",
+            "urn:issn:0028-792X",
+            "urn:lccn:   28005329",
+            "urn:oclc:1760231",
+            "urn:undefined:(OCoLC)1760231",
+            "urn:undefined:(OCoLC)228666271 (OCoLC)315923316 (OCoLC)813435753 (OCoLC)972367546 (OCoLC)973902298 (OCoLC)1032835230 (OCoLC)1038943160 (OCoLC)1041661831 (OCoLC)1054975031 (OCoLC)1058338019 (OCoLC)1065410087 (OCoLC)1078551167 (OCoLC)1081045337 (OCoLC)1082980679 (OCoLC)1114402509 (OCoLC)1134878896 (OCoLC)1134879337 (OCoLC)1144737766 (OCoLC)1167086187 (OCoLC)1294152325 (OCoLC)1302429095 (OCoLC)1319602865 (OCoLC)1322139476 (OCoLC)1332666305"
+          ],
+          "genreForm": [
+            "Electronic journals.",
+            "Collections.",
+            "Directories.",
+            "Periodicals."
+          ],
+          "numCheckinCardItems": [
+            203
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1925"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Literature -- Periodicals.",
+            "Intellectual life.",
+            "Literature.",
+            "Electronic journals.",
+            "New York (N.Y.) -- Intellectual life -- Directories.",
+            "New York (State) -- New York."
+          ],
+          "titleDisplay": [
+            "The New Yorker."
+          ],
+          "uri": "b10833141",
+          "lccClassification": [
+            "AP2 .N6763"
+          ],
+          "numItems": [
+            695
+          ],
+          "numAvailable": [
+            841
+          ],
+          "placeOfPublication": [
+            "New York",
+            "[New York]"
+          ],
+          "titleAlt": [
+            "New Yorker",
+            "The New Yorker"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "28-31 cm"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 563,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 886
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36060542",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 92 (July-Sept. 2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 92 (July-Sept. 2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433119872095"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 92 (July-Sept. 2016)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433119872095"
+                    ],
+                    "idBarcode": [
+                      "33433119872095"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 92,
+                        "lte": 92
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        92-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000092 (July-Sept. 2016)"
+                  },
+                  "sort": [
+                    "        92-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 883
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36060538",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 91 (Sept.-Oct. 2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 91 (Sept.-Oct. 2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433119872087"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 91 (Sept.-Oct. 2015)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433119872087"
+                    ],
+                    "idBarcode": [
+                      "33433119872087"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 91,
+                        "lte": 91
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2015",
+                        "lte": "2015"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        91-2015"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000091 (Sept.-Oct. 2015)"
+                  },
+                  "sort": [
+                    "        91-2015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 866
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878991",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Oct-Nov 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Oct-Nov 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099610952"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Oct-Nov 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099610952"
+                    ],
+                    "idBarcode": [
+                      "33433099610952"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Oct-Nov 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 865
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878983",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (June-July 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (June-July 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611083"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (June-July 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611083"
+                    ],
+                    "idBarcode": [
+                      "33433099611083"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (June-July 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 864
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878974",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Feb. 14-Mar. 28, 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Feb. 14-Mar. 28, 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611109"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Feb. 14-Mar. 28, 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611109"
+                    ],
+                    "idBarcode": [
+                      "33433099611109"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Feb. 14-Mar. 28, 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 863
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28879000",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Dec. 5, 2011-Feb. 6, 2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Dec. 5, 2011-Feb. 6, 2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099610945"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Dec. 5, 2011-Feb. 6, 2012)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099610945"
+                    ],
+                    "idBarcode": [
+                      "33433099610945"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Dec. 5, 2011-Feb. 6, 2012)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 862
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878989",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Aug-Sept 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Aug-Sept 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611075"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Aug-Sept 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611075"
+                    ],
+                    "idBarcode": [
+                      "33433099611075"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Aug-Sept 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 861
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878981",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 87 (Apr-May 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 87 (Apr-May 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611091"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 87 (Apr-May 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611091"
+                    ],
+                    "idBarcode": [
+                      "33433099611091"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 87,
+                        "lte": 87
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        87-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000087 (Apr-May 2011)"
+                  },
+                  "sort": [
+                    "        87-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 860
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28974701",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 inc. (May-July 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 inc. (May-July 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099612925"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 inc. (May-July 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099612925"
+                    ],
+                    "idBarcode": [
+                      "33433099612925"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 inc. (May-July 2010)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 859
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878958",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 (Oct-Nov 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 (Oct-Nov 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611125"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 (Oct-Nov 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611125"
+                    ],
+                    "idBarcode": [
+                      "33433099611125"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 (Oct-Nov 2010)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 858
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878948",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 (Feb. 15-Apr. 26, 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 (Feb. 15-Apr. 26, 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611141"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 (Feb. 15-Apr. 26, 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611141"
+                    ],
+                    "idBarcode": [
+                      "33433099611141"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 (Feb. 15-Apr. 26, 2010)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 857
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878970",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 (Dec. 6, 2010-Feb. 7, 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 (Dec. 6, 2010-Feb. 7, 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611117"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 (Dec. 6, 2010-Feb. 7, 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611117"
+                    ],
+                    "idBarcode": [
+                      "33433099611117"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 (Dec. 6, 2010-Feb. 7, 2011)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 856
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878953",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 86 (Aug-Sept 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 86 (Aug-Sept 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611133"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 86 (Aug-Sept 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611133"
+                    ],
+                    "idBarcode": [
+                      "33433099611133"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 86,
+                        "lte": 86
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        86-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000086 (Aug-Sept 2010)"
+                  },
+                  "sort": [
+                    "        86-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 855
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878932",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 85 (Oct-Nov 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 85 (Oct-Nov 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611166"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85 (Oct-Nov 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611166"
+                    ],
+                    "idBarcode": [
+                      "33433099611166"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000085 (Oct-Nov 2009)"
+                  },
+                  "sort": [
+                    "        85-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 854
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878920",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 85 (May-June 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 85 (May-June 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611182"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85 (May-June 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611182"
+                    ],
+                    "idBarcode": [
+                      "33433099611182"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000085 (May-June 2009)"
+                  },
+                  "sort": [
+                    "        85-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 853
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878911",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 85 (Feb. 9-Apr. 27, 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 85 (Feb. 9-Apr. 27, 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611190"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85 (Feb. 9-Apr. 27, 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611190"
+                    ],
+                    "idBarcode": [
+                      "33433099611190"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000085 (Feb. 9-Apr. 27, 2009)"
+                  },
+                  "sort": [
+                    "        85-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 852
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878925",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 85 (Aug. 10-Sept. 28, 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 85 (Aug. 10-Sept. 28, 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099611174"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85 (Aug. 10-Sept. 28, 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099611174"
+                    ],
+                    "idBarcode": [
+                      "33433099611174"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000085 (Aug. 10-Sept. 28, 2009)"
+                  },
+                  "sort": [
+                    "        85-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 851
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589223",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Oct-Nov 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Oct-Nov 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063992"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Oct-Nov 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063992"
+                    ],
+                    "idBarcode": [
+                      "33433085063992"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Oct-Nov 2008)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 850
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589214",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (June-July 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (June-July 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064008"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (June-July 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064008"
+                    ],
+                    "idBarcode": [
+                      "33433085064008"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (June-July 2008)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 849
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589272",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Feb. 11-Mar. 31 , 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Feb. 11-Mar. 31 , 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063950"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Feb. 11-Mar. 31 , 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063950"
+                    ],
+                    "idBarcode": [
+                      "33433085063950"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Feb. 11-Mar. 31 , 2008)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 848
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589242",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Dec 1, 2008-Feb 2, 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Dec 1, 2008-Feb 2, 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063976"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Dec 1, 2008-Feb 2, 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063976"
+                    ],
+                    "idBarcode": [
+                      "33433085063976"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Dec 1, 2008-Feb 2, 2009)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 847
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589287",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Aug-Sept 2008 & Suppl.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Aug-Sept 2008 & Suppl.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064172"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Aug-Sept 2008 & Suppl.)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064172"
+                    ],
+                    "idBarcode": [
+                      "33433085064172"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Aug-Sept 2008 & Suppl.)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 846
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589205",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 84 (Apr-May 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 84 (Apr-May 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064214"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84 (Apr-May 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064214"
+                    ],
+                    "idBarcode": [
+                      "33433085064214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000084 (Apr-May 2008)"
+                  },
+                  "sort": [
+                    "        84-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 845
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589229",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Oct-Nov 2007 & Suppl.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Oct-Nov 2007 & Suppl.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063984"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Oct-Nov 2007 & Suppl.)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063984"
+                    ],
+                    "idBarcode": [
+                      "33433085063984"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Oct-Nov 2007 & Suppl.)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 844
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589274",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (June 25-July 30, 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (June 25-July 30, 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063943"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (June 25-July 30, 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063943"
+                    ],
+                    "idBarcode": [
+                      "33433085063943"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (June 25-July 30, 2007)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 843
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589278",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Feb. 19-Mar. 26, 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Feb. 19-Mar. 26, 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064180"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Feb. 19-Mar. 26, 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064180"
+                    ],
+                    "idBarcode": [
+                      "33433085064180"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Feb. 19-Mar. 26, 2007)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 842
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589263",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Dec. 3, 2007-Feb. 4, 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Dec. 3, 2007-Feb. 4, 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064206"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Dec. 3, 2007-Feb. 4, 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064206"
+                    ],
+                    "idBarcode": [
+                      "33433085064206"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Dec. 3, 2007-Feb. 4, 2008)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 841
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589251",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Aug-Sept 2007 & Suppl.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Aug-Sept 2007 & Suppl.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085063968"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Aug-Sept 2007 & Suppl.)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085063968"
+                    ],
+                    "idBarcode": [
+                      "33433085063968"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Aug-Sept 2007 & Suppl.)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 840
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i25589269",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 83 (Apr. 2-May 21, 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 83 (Apr. 2-May 21, 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085064198"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 83 (Apr. 2-May 21, 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085064198"
+                    ],
+                    "idBarcode": [
+                      "33433085064198"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 83,
+                        "lte": 83
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        83-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000083 (Apr. 2-May 21, 2007)"
+                  },
+                  "sort": [
+                    "        83-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 839
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474922",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (Oct.-Nov. 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (Oct.-Nov. 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240575"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (Oct.-Nov. 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240575"
+                    ],
+                    "idBarcode": [
+                      "33433084240575"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (Oct.-Nov. 2006)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 838
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474920",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (May-June 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (May-June 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240559"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (May-June 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240559"
+                    ],
+                    "idBarcode": [
+                      "33433084240559"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (May-June 2006)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 837
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474921",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (July-Sept. & Suppl. 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (July-Sept. & Suppl. 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240567"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (July-Sept. & Suppl. 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240567"
+                    ],
+                    "idBarcode": [
+                      "33433084240567"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (July-Sept. & Suppl. 2006)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 836
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474919",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (Feb. 13-Apr. 24, 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (Feb. 13-Apr. 24, 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240542"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (Feb. 13-Apr. 24, 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240542"
+                    ],
+                    "idBarcode": [
+                      "33433084240542"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (Feb. 13-Apr. 24, 2006)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 835
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474923",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 82 (Dec. 4, 2006-Feb. 12, 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 82 (Dec. 4, 2006-Feb. 12, 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240583"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82 (Dec. 4, 2006-Feb. 12, 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240583"
+                    ],
+                    "idBarcode": [
+                      "33433084240583"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000082 (Dec. 4, 2006-Feb. 12, 2007)"
+                  },
+                  "sort": [
+                    "        82-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 834
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474917",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (Oct.-Nov. 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (Oct.-Nov. 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240526"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (Oct.-Nov. 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240526"
+                    ],
+                    "idBarcode": [
+                      "33433084240526"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (Oct.-Nov. 2005)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 833
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474916",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (June 27-Sept.26,2005;Suppl.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (June 27-Sept.26,2005;Suppl.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240518"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (June 27-Sept.26,2005;Suppl.)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240518"
+                    ],
+                    "idBarcode": [
+                      "33433084240518"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (June 27-Sept.26,2005;Suppl.)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 832
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474914",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (Feb. 14-Mar. 28, 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (Feb. 14-Mar. 28, 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240492"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (Feb. 14-Mar. 28, 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240492"
+                    ],
+                    "idBarcode": [
+                      "33433084240492"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (Feb. 14-Mar. 28, 2005)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 831
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474918",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (Dec. 5, 2005-Feb. 6, 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (Dec. 5, 2005-Feb. 6, 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240534"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (Dec. 5, 2005-Feb. 6, 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240534"
+                    ],
+                    "idBarcode": [
+                      "33433084240534"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (Dec. 5, 2005-Feb. 6, 2006)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 830
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474915",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 81 (Apr.-May 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 81 (Apr.-May 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240500"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 81 (Apr.-May 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240500"
+                    ],
+                    "idBarcode": [
+                      "33433084240500"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 81,
+                        "lte": 81
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        81-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000081 (Apr.-May 2005)"
+                  },
+                  "sort": [
+                    "        81-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 829
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474912",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (Oct.-Nov. 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (Oct.-Nov. 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240476"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (Oct.-Nov. 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240476"
+                    ],
+                    "idBarcode": [
+                      "33433084240476"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (Oct.-Nov. 2004)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 828
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474911",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (May-June 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (May-June 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240468"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (May-June 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240468"
+                    ],
+                    "idBarcode": [
+                      "33433084240468"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (May-June 2004)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 827
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474399",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (July-Sept 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (July-Sept 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078508037"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (July-Sept 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078508037"
+                    ],
+                    "idBarcode": [
+                      "33433078508037"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (July-Sept 2004)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 826
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474447",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (Feb. 16- Apr. 26 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (Feb. 16- Apr. 26 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433080028222"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (Feb. 16- Apr. 26 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433080028222"
+                    ],
+                    "idBarcode": [
+                      "33433080028222"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (Feb. 16- Apr. 26 2004)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 825
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474913",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 80 (Dec. 6, 2004-Feb. 7, 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 80 (Dec. 6, 2004-Feb. 7, 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240484"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 80 (Dec. 6, 2004-Feb. 7, 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240484"
+                    ],
+                    "idBarcode": [
+                      "33433084240484"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 80,
+                        "lte": 80
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        80-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000080 (Dec. 6, 2004-Feb. 7, 2005)"
+                  },
+                  "sort": [
+                    "        80-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 824
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474909",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Oct.-Nov. 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Oct.-Nov. 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240443"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Oct.-Nov. 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240443"
+                    ],
+                    "idBarcode": [
+                      "33433084240443"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Oct.-Nov. 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 823
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474907",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (June-July 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (June-July 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240427"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (June-July 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240427"
+                    ],
+                    "idBarcode": [
+                      "33433084240427"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (June-July 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 822
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474905",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Feb. 17-Mar. 31, 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Feb. 17-Mar. 31, 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240401"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Feb. 17-Mar. 31, 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240401"
+                    ],
+                    "idBarcode": [
+                      "33433084240401"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Feb. 17-Mar. 31, 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 821
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474910",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Dec. 1, 2003-Feb. 9, 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Dec. 1, 2003-Feb. 9, 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240450"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Dec. 1, 2003-Feb. 9, 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240450"
+                    ],
+                    "idBarcode": [
+                      "33433084240450"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Dec. 1, 2003-Feb. 9, 2004)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 820
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474908",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Aug-Sept. 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Aug-Sept. 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240435"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Aug-Sept. 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240435"
+                    ],
+                    "idBarcode": [
+                      "33433084240435"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Aug-Sept. 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 819
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474906",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 79 (Apr.-May 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 79 (Apr.-May 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240419"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 79 (Apr.-May 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240419"
+                    ],
+                    "idBarcode": [
+                      "33433084240419"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 79,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        79-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000079 (Apr.-May 2003)"
+                  },
+                  "sort": [
+                    "        79-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 818
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474903",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Oct.-Nov. 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Oct.-Nov. 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240385"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Oct.-Nov. 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240385"
+                    ],
+                    "idBarcode": [
+                      "33433084240385"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Oct.-Nov. 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 817
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474901",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (June-July 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (June-July 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240369"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (June-July 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240369"
+                    ],
+                    "idBarcode": [
+                      "33433084240369"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (June-July 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 816
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474899",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Feb. 18-Mar. 25, 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Feb. 18-Mar. 25, 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240344"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Feb. 18-Mar. 25, 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240344"
+                    ],
+                    "idBarcode": [
+                      "33433084240344"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Feb. 18-Mar. 25, 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 815
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474904",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Dec. 2, 2002-Feb. 10, 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Dec. 2, 2002-Feb. 10, 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240393"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Dec. 2, 2002-Feb. 10, 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240393"
+                    ],
+                    "idBarcode": [
+                      "33433084240393"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Dec. 2, 2002-Feb. 10, 2003)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 814
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474902",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Aug.-Sept. 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Aug.-Sept. 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240377"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Aug.-Sept. 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240377"
+                    ],
+                    "idBarcode": [
+                      "33433084240377"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Aug.-Sept. 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 813
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474900",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 78 (Apr.-May 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 78 (Apr.-May 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240351"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78 (Apr.-May 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240351"
+                    ],
+                    "idBarcode": [
+                      "33433084240351"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 78
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000078 (Apr.-May 2002)"
+                  },
+                  "sort": [
+                    "        78-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 812
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474897",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (Oct. -Nov. 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (Oct. -Nov. 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240328"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (Oct. -Nov. 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240328"
+                    ],
+                    "idBarcode": [
+                      "33433084240328"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (Oct. -Nov. 2001)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 811
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474446",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (May-July 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (May-July 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079991612"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (May-July 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433079991612"
+                    ],
+                    "idBarcode": [
+                      "33433079991612"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (May-July 2001)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 810
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474895",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (Feb. 19-Apr. 30, 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (Feb. 19-Apr. 30, 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240302"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (Feb. 19-Apr. 30, 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240302"
+                    ],
+                    "idBarcode": [
+                      "33433084240302"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (Feb. 19-Apr. 30, 2001)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 809
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474898",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (Dec. 3, 2001-Feb. 11, 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (Dec. 3, 2001-Feb. 11, 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240336"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (Dec. 3, 2001-Feb. 11, 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240336"
+                    ],
+                    "idBarcode": [
+                      "33433084240336"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (Dec. 3, 2001-Feb. 11, 2002)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 808
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474896",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 77 (Aug. 6-Sept. 17, 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 77 (Aug. 6-Sept. 17, 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240310"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 77 (Aug. 6-Sept. 17, 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240310"
+                    ],
+                    "idBarcode": [
+                      "33433084240310"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 77,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        77-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000077 (Aug. 6-Sept. 17, 2001)"
+                  },
+                  "sort": [
+                    "        77-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 807
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474893",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (Sept.-Oct. 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (Sept.-Oct. 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240286"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (Sept.-Oct. 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240286"
+                    ],
+                    "idBarcode": [
+                      "33433084240286"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (Sept.-Oct. 2000)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 806
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474894",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (Nov. 6, 2000-Feb. 5, 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (Nov. 6, 2000-Feb. 5, 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240294"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (Nov. 6, 2000-Feb. 5, 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240294"
+                    ],
+                    "idBarcode": [
+                      "33433084240294"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (Nov. 6, 2000-Feb. 5, 2001)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 805
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474402",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (July-Aug. 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (July-Aug. 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078639105"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (July-Aug. 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078639105"
+                    ],
+                    "idBarcode": [
+                      "33433078639105"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (July-Aug. 2000)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 804
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i40028166",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (Feb. 21 - Apr. 17, 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (Feb. 21 - Apr. 17, 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240278"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (Feb. 21 - Apr. 17, 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240278"
+                    ],
+                    "idBarcode": [
+                      "33433084240278"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (Feb. 21 - Apr. 17, 2000)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 803
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474434",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 76 (Apr 24-June 26 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 76 (Apr 24-June 26 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433080426707"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76 (Apr 24-June 26 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433080426707"
+                    ],
+                    "idBarcode": [
+                      "33433080426707"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 76
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000076 (Apr 24-June 26 2000)"
+                  },
+                  "sort": [
+                    "        76-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 802
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474887",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75(Feb.22-May 3, 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75(Feb.22-May 3, 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240211"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75(Feb.22-May 3, 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240211"
+                    ],
+                    "idBarcode": [
+                      "33433084240211"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075(Feb.22-May 3, 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 801
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474890",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (Sept.-Oct. 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (Sept.-Oct. 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240245"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (Sept.-Oct. 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240245"
+                    ],
+                    "idBarcode": [
+                      "33433084240245"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (Sept.-Oct. 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 800
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474891",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (Nov. 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (Nov. 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240252"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (Nov. 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240252"
+                    ],
+                    "idBarcode": [
+                      "33433084240252"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (Nov. 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 799
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474888",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (May 10-June 28, 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (May 10-June 28, 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240229"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (May 10-June 28, 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240229"
+                    ],
+                    "idBarcode": [
+                      "33433084240229"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (May 10-June 28, 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 798
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474889",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (July-Aug. 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (July-Aug. 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240237"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (July-Aug. 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240237"
+                    ],
+                    "idBarcode": [
+                      "33433084240237"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (July-Aug. 1999)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 797
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474892",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 75 (Dec. 6, 1999-Feb. 14, 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 75 (Dec. 6, 1999-Feb. 14, 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240260"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75 (Dec. 6, 1999-Feb. 14, 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240260"
+                    ],
+                    "idBarcode": [
+                      "33433084240260"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000075 (Dec. 6, 1999-Feb. 14, 2000)"
+                  },
+                  "sort": [
+                    "        75-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 796
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474886",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 74 (Sept. 7-Nov. 2, 1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 74 (Sept. 7-Nov. 2, 1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240203"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 74 (Sept. 7-Nov. 2, 1998)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240203"
+                    ],
+                    "idBarcode": [
+                      "33433084240203"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 74,
+                        "lte": 74
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1998",
+                        "lte": "1998"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        74-1998"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000074 (Sept. 7-Nov. 2, 1998)"
+                  },
+                  "sort": [
+                    "        74-1998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 795
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474403",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 74 (Nov. 9, 1998-Feb. 15, 1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 74 (Nov. 9, 1998-Feb. 15, 1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078660671"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 74 (Nov. 9, 1998-Feb. 15, 1999)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078660671"
+                    ],
+                    "idBarcode": [
+                      "33433078660671"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 74,
+                        "lte": 74
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1998",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        74-1998"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000074 (Nov. 9, 1998-Feb. 15, 1999)"
+                  },
+                  "sort": [
+                    "        74-1998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 794
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474885",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 74 (June- Aug. 1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 74 (June- Aug. 1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240195"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 74 (June- Aug. 1998)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240195"
+                    ],
+                    "idBarcode": [
+                      "33433084240195"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 74,
+                        "lte": 74
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1998",
+                        "lte": "1998"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        74-1998"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000074 (June- Aug. 1998)"
+                  },
+                  "sort": [
+                    "        74-1998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 793
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474453",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 74"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 74",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433080030616"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 74"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433080030616"
+                    ],
+                    "idBarcode": [
+                      "33433080030616"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 74,
+                        "lte": 74
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        74-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000074"
+                  },
+                  "sort": [
+                    "        74-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 792
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17142393",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 73 (Nov. 3, 1997-Feb. 9, 1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 73 (Nov. 3, 1997-Feb. 9, 1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078530031"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 73 (Nov. 3, 1997-Feb. 9, 1998)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078530031"
+                    ],
+                    "idBarcode": [
+                      "33433078530031"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 73,
+                        "lte": 73
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1997",
+                        "lte": "1998"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        73-1997"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000073 (Nov. 3, 1997-Feb. 9, 1998)"
+                  },
+                  "sort": [
+                    "        73-1997"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 791
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16700889",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 73 (May 12-July 28, 1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 73 (May 12-July 28, 1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433081121117"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 73 (May 12-July 28, 1997)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433081121117"
+                    ],
+                    "idBarcode": [
+                      "33433081121117"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 73,
+                        "lte": 73
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1997",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        73-1997"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000073 (May 12-July 28, 1997)"
+                  },
+                  "sort": [
+                    "        73-1997"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 790
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474429",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 73 (Feb 17-May 5 1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 73 (Feb 17-May 5 1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658105"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 73 (Feb 17-May 5 1997)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658105"
+                    ],
+                    "idBarcode": [
+                      "33433078658105"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 73,
+                        "lte": 73
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1997",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        73-1997"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000073 (Feb 17-May 5 1997)"
+                  },
+                  "sort": [
+                    "        73-1997"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 789
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474430",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 73 (Aug-Oct 1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 73 (Aug-Oct 1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658113"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 73 (Aug-Oct 1997)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658113"
+                    ],
+                    "idBarcode": [
+                      "33433078658113"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 73,
+                        "lte": 73
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1997",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        73-1997"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000073 (Aug-Oct 1997)"
+                  },
+                  "sort": [
+                    "        73-1997"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 788
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474427",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 72 (Oct 7-Nov 25 1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 72 (Oct 7-Nov 25 1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658089"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 72 (Oct 7-Nov 25 1996)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658089"
+                    ],
+                    "idBarcode": [
+                      "33433078658089"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 72,
+                        "lte": 72
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        72-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000072 (Oct 7-Nov 25 1996)"
+                  },
+                  "sort": [
+                    "        72-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 787
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474426",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 72 (July 8-Sept 30 1996 (inc))"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 72 (July 8-Sept 30 1996 (inc))",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658071"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 72 (July 8-Sept 30 1996 (inc))"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658071"
+                    ],
+                    "idBarcode": [
+                      "33433078658071"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 72,
+                        "lte": 72
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        72-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000072 (July 8-Sept 30 1996 (inc))"
+                  },
+                  "sort": [
+                    "        72-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 786
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474400",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 72 (Feb 19-Apr 22 1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 72 (Feb 19-Apr 22 1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078626128"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 72 (Feb 19-Apr 22 1996)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078626128"
+                    ],
+                    "idBarcode": [
+                      "33433078626128"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 72,
+                        "lte": 72
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        72-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000072 (Feb 19-Apr 22 1996)"
+                  },
+                  "sort": [
+                    "        72-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 785
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474428",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 72 (Dec 2 1996-Feb 10 1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 72 (Dec 2 1996-Feb 10 1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658097"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 72 (Dec 2 1996-Feb 10 1997)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658097"
+                    ],
+                    "idBarcode": [
+                      "33433078658097"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 72,
+                        "lte": 72
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        72-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000072 (Dec 2 1996-Feb 10 1997)"
+                  },
+                  "sort": [
+                    "        72-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 784
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474425",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 72 (Apr 29-July 1 1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 72 (Apr 29-July 1 1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658063"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 72 (Apr 29-July 1 1996)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658063"
+                    ],
+                    "idBarcode": [
+                      "33433078658063"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 72,
+                        "lte": 72
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        72-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000072 (Apr 29-July 1 1996)"
+                  },
+                  "sort": [
+                    "        72-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 783
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474423",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 71 (Oct-Nov 1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 71 (Oct-Nov 1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658048"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71 (Oct-Nov 1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658048"
+                    ],
+                    "idBarcode": [
+                      "33433078658048"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000071 (Oct-Nov 1995)"
+                  },
+                  "sort": [
+                    "        71-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 782
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474421",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 71 (June-July 1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 71 (June-July 1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658022"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71 (June-July 1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658022"
+                    ],
+                    "idBarcode": [
+                      "33433078658022"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000071 (June-July 1995)"
+                  },
+                  "sort": [
+                    "        71-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 781
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474883",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 71 (Feb. 20-Mar. 27, 1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 71 (Feb. 20-Mar. 27, 1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240179"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71 (Feb. 20-Mar. 27, 1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240179"
+                    ],
+                    "idBarcode": [
+                      "33433084240179"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000071 (Feb. 20-Mar. 27, 1995)"
+                  },
+                  "sort": [
+                    "        71-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 780
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474424",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 71 (Dec 4 1995-Feb 12 1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 71 (Dec 4 1995-Feb 12 1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658055"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71 (Dec 4 1995-Feb 12 1996)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658055"
+                    ],
+                    "idBarcode": [
+                      "33433078658055"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000071 (Dec 4 1995-Feb 12 1996)"
+                  },
+                  "sort": [
+                    "        71-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 779
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474422",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 71 (Aug-Sept 1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 71 (Aug-Sept 1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078658030"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71 (Aug-Sept 1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078658030"
+                    ],
+                    "idBarcode": [
+                      "33433078658030"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000071 (Aug-Sept 1995)"
+                  },
+                  "sort": [
+                    "        71-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 778
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474884",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 71 (Apr.-May 1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 71 (Apr.-May 1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240187"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71 (Apr.-May 1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240187"
+                    ],
+                    "idBarcode": [
+                      "33433084240187"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000071 (Apr.-May 1995)"
+                  },
+                  "sort": [
+                    "        71-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 773
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474882",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (Jan. 9-Feb. 13, 1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (Jan. 9-Feb. 13, 1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240161"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (Jan. 9-Feb. 13, 1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240161"
+                    ],
+                    "idBarcode": [
+                      "33433084240161"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (Jan. 9-Feb. 13, 1995)"
+                  },
+                  "sort": [
+                    "        70-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 777
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474879",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (Oct. 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (Oct. 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240138"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (Oct. 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240138"
+                    ],
+                    "idBarcode": [
+                      "33433084240138"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (Oct. 1994)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 776
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474880",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (Nov. 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (Nov. 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240146"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (Nov. 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240146"
+                    ],
+                    "idBarcode": [
+                      "33433084240146"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (Nov. 1994)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 775
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474876",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (May 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (May 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240104"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (May 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240104"
+                    ],
+                    "idBarcode": [
+                      "33433084240104"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (May 1994)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 774
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474877",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (June-July 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (June-July 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240112"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (June-July 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240112"
+                    ],
+                    "idBarcode": [
+                      "33433084240112"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (June-July 1994)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 772
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474875",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (Feb. 21-Mar. 28, 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (Feb. 21-Mar. 28, 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240096"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (Feb. 21-Mar. 28, 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240096"
+                    ],
+                    "idBarcode": [
+                      "33433084240096"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (Feb. 21-Mar. 28, 1994)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 771
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474881",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (Dec. 5, 1994-Jan. 2,1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (Dec. 5, 1994-Jan. 2,1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240153"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (Dec. 5, 1994-Jan. 2,1995)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240153"
+                    ],
+                    "idBarcode": [
+                      "33433084240153"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (Dec. 5, 1994-Jan. 2,1995)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 770
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474878",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 70 (Aug.-Sept. 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 70 (Aug.-Sept. 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240120"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 (Aug.-Sept. 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240120"
+                    ],
+                    "idBarcode": [
+                      "33433084240120"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000070 (Aug.-Sept. 1994)"
+                  },
+                  "sort": [
+                    "        70-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 764
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17474874",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 69 (Jan. 10-Feb. 14, 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 69 (Jan. 10-Feb. 14, 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084240088"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 69 (Jan. 10-Feb. 14, 1994)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084240088"
+                    ],
+                    "idBarcode": [
+                      "33433084240088"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 69,
+                        "lte": 69
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        69-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000069 (Jan. 10-Feb. 14, 1994)"
+                  },
+                  "sort": [
+                    "        69-1994"
+                  ]
+                }
+              ]
+            }
+          },
+          "allItems": {
+            "hits": {
+              "total": 898,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 897
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i37530724",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 94 (Oct.-Nov. 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 94 (Oct.-Nov. 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128201161"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 94 (Oct.-Nov. 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128201161"
+                    ],
+                    "idBarcode": [
+                      "33433128201161"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 94,
+                        "lte": 94
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        94-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000094 (Oct.-Nov. 2018)"
+                  }
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 896
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i37539307",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 94 (May-June 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 94 (May-June 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128201310"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 94 (May-June 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128201310"
+                    ],
+                    "idBarcode": [
+                      "33433128201310"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 94,
+                        "lte": 94
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        94-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000094 (May-June 2018)"
+                  }
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 895
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i37539308",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 94 (July-Sept. 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 94 (July-Sept. 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128201302"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 94 (July-Sept. 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128201302"
+                    ],
+                    "idBarcode": [
+                      "33433128201302"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 94,
+                        "lte": 94
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        94-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000094 (July-Sept. 2018)"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 898,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "loc:mal82||Schwarzman Building - Main Reading Room 315",
+            "doc_count": 563
+          },
+          {
+            "key": "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108",
+            "doc_count": 203
+          },
+          {
+            "key": "loc:rc2ma||Offsite",
+            "doc_count": 66
+          },
+          {
+            "key": "loc:rcma2||Offsite",
+            "doc_count": 66
+          }
+        ]
+      }
+    },
+    "item_format": {
+      "doc_count": 898,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 695
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 898,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 841
+          },
+          {
+            "key": "status:i||At bindery",
+            "doc_count": 48
+          },
+          {
+            "key": "status:na||Not Available (ReCAP)",
+            "doc_count": 9
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/query-07cbe6f69be2896897f94f95b4eb1e2a.json
+++ b/test/fixtures/query-07cbe6f69be2896897f94f95b4eb1e2a.json
@@ -1,0 +1,366 @@
+{
+  "took": 10,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.362451,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b11984689",
+        "_score": 14.362451,
+        "_source": {
+          "extent": [
+            "v. ill."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Established 1900.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Most issues lack subtitle.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "v. 42, no. 1-v. 62, no. 7; Jan. 1942-July 1962."
+          ],
+          "subjectLiteral_exploded": [
+            "Woodwork",
+            "Woodwork -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            19
+          ],
+          "publisherLiteral": [
+            "Southam-Maclean Publications [etc.]"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            19
+          ],
+          "createdYear": [
+            1942
+          ],
+          "dateEndString": [
+            "1962"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Canadian woodworker; millwork, furniture, plywood."
+          ],
+          "shelfMark": [
+            "VMA (Canadian woodworker)"
+          ],
+          "numItemVolumesParsed": [
+            19
+          ],
+          "createdString": [
+            "1942"
+          ],
+          "idLccn": [
+            "cn 76300447"
+          ],
+          "idIssn": [
+            "0316-9669"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1942
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "VMA (Canadian woodworker)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11984689"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0316-9669"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "cn 76300447"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG94-S11794"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1974025"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "RCON-STC"
+            }
+          ],
+          "idOclc": [
+            "NYPG94-S11794"
+          ],
+          "dateEndYear": [
+            1962
+          ],
+          "updatedAt": 1675262897750,
+          "publicationStatement": [
+            "Don Mills, Ont. [etc.] Southam-Maclean Publications [etc.]"
+          ],
+          "identifier": [
+            "urn:bnum:11984689",
+            "urn:issn:0316-9669",
+            "urn:lccn:cn 76300447",
+            "urn:oclc:NYPG94-S11794",
+            "urn:undefined:(WaOLN)nyp1974025",
+            "urn:undefined:RCON-STC"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1942"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Woodwork -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Canadian woodworker; millwork, furniture, plywood."
+          ],
+          "uri": "b11984689",
+          "numItems": [
+            19
+          ],
+          "numAvailable": [
+            19
+          ],
+          "placeOfPublication": [
+            "Don Mills, Ont. [etc.]"
+          ],
+          "titleAlt": [
+            "Canadian woodworker (1942)",
+            "Canadian woodworker and furniture manufacturer Jan.-Mar. 1942"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29976055",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "VMA (Canadian woodworker) v. 44 (1944)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "VMA (Canadian woodworker) v. 44 (1944)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433102812199"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 44 (1944)"
+                    ],
+                    "physicalLocation": [
+                      "VMA (Canadian woodworker)"
+                    ],
+                    "recapCustomerCode": [
+                      "JS"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433102812199"
+                    ],
+                    "idBarcode": [
+                      "33433102812199"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 44,
+                        "lte": 44
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1944",
+                        "lte": "1944"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        44-1944"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aVMA (Canadian woodworker) v. 000044 (1944)"
+                  },
+                  "sort": [
+                    "        44-1944"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 19,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "loc:rc2ma||Offsite",
+            "doc_count": 19
+          }
+        ]
+      }
+    },
+    "item_format": {
+      "doc_count": 19,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 19
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 19,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 19
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/query-095eb39aab6182ff4d12906a9d9e552e.json
+++ b/test/fixtures/query-095eb39aab6182ff4d12906a9d9e552e.json
@@ -1,0 +1,319 @@
+{
+  "took": 139,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 94.176,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b13565153",
+        "_score": 94.176,
+        "_source": {
+          "extent": [
+            "430 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on spine: Ladies companion to the flower garden.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Ladies' companion to the flower-garden (p. [97]-340), has half- title page.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Monthly calendar of work to be done in the flower-garden: p. [425]-430.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Gardening",
+            "Flower gardening"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "John Wiley"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1854
+          ],
+          "dateEndString": [
+            "1853"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Gardening for ladies : and, Companion to the flower-garden"
+          ],
+          "shelfMark": [
+            "VQG (Loudon, J. W. Gardening for ladies. 1854)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Loudon, Mrs. (Jane), 1807-1858."
+          ],
+          "createdString": [
+            "1854"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Downing, A. J. (Andrew Jackson), 1815-1852."
+          ],
+          "dateStartYear": [
+            1854
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "VQG (Loudon, J. W. Gardening for ladies. 1854)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13565153"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "31237346"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3539974"
+            }
+          ],
+          "idOclc": [
+            "31237346"
+          ],
+          "dateEndYear": [
+            1853
+          ],
+          "updatedAt": 1671727849446,
+          "publicationStatement": [
+            "New York : John Wiley, 1854, c1853."
+          ],
+          "identifier": [
+            "urn:bnum:13565153",
+            "urn:oclc:31237346",
+            "urn:undefined:(WaOLN)nyp3539974"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1854"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Gardening.",
+            "Flower gardening."
+          ],
+          "titleDisplay": [
+            "Gardening for ladies : and, Companion to the flower-garden / by Mrs. Loudon."
+          ],
+          "uri": "b13565153",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "titleAlt": [
+            "Companion to the flower-garden.",
+            "Ladies' companion to the flower garden."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i13565153-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://babel.hathitrust.org/cgi/pt?id=nyp.33433006564110",
+                        "label": "Full text available via HathiTrust"
+                      }
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "bi13565153-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10708577",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "VQG (Loudon, J. W. Gardening for ladies. 1854)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "VQG (Loudon, J. W. Gardening for ladies. 1854)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433006564110"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "VQG (Loudon, J. W. Gardening for ladies. 1854)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433006564110"
+                    ],
+                    "idBarcode": [
+                      "33433006564110"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aVQG (Loudon, J. W. Gardening for ladies. 1854)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-1053d284e7ff290044395682776f179d.json
+++ b/test/fixtures/query-1053d284e7ff290044395682776f179d.json
@@ -1,0 +1,1267 @@
+{
+  "took": 31,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.334448,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b14937001",
+        "_score": 14.334448,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "From 1807-June 1837 title reads: Morgenblatt für gebildete stände.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Kunst-blatt. Stuttgart, 1816-1849.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Includes the current supplements Literatur-blatt 1817-1849; Kunstblatt 1816-1849; Intelligenz-blatt 1817-1847.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "J. G. Cotta'sche buchhandlung."
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            4
+          ],
+          "dateEndString": [
+            "1"
+          ],
+          "createdYear": [
+            1855
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Morgenblatt für gebildete leser."
+          ],
+          "shelfMark": [
+            "*DF+ (Morgenblatt für gebildete Leser)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1855"
+          ],
+          "idLccn": [
+            "cau08001961"
+          ],
+          "numElectronicResources": [
+            88
+          ],
+          "dateStartYear": [
+            1855
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*DF+ (Morgenblatt für gebildete Leser)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14937001"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "cau08001961"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1608345"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "0494254"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)ret0001042"
+            }
+          ],
+          "idOclc": [
+            "1608345"
+          ],
+          "dateEndYear": [
+            1
+          ],
+          "updatedAt": 1671729582968,
+          "publicationStatement": [
+            "Stuttgart, Tübingen [etc.], J. G. Cotta'sche buchhandlung."
+          ],
+          "identifier": [
+            "urn:bnum:14937001",
+            "urn:lccn:cau08001961",
+            "urn:oclc:1608345",
+            "urn:undefined:0494254",
+            "urn:undefined:(WaOLN)ret0001042"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1855"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Morgenblatt für gebildete leser."
+          ],
+          "uri": "b14937001",
+          "numItems": [
+            4
+          ],
+          "numAvailable": [
+            4
+          ],
+          "placeOfPublication": [
+            "Stuttgart, Tübingen [etc.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i14937001-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899526k",
+                        "label": "Full text available via HathiTrust - jahrg.11:Jan.-June (1817)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899527i",
+                        "label": "Full text available via HathiTrust - jahrg.11:July-Dec. (1817)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899528g",
+                        "label": "Full text available via HathiTrust - jahrg.12:Jan.-June (1818)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899529e",
+                        "label": "Full text available via HathiTrust - jahrg.12:July-Dec. (1818)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899530t",
+                        "label": "Full text available via HathiTrust - jahrg.13:Jan.-June (1819)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899531r",
+                        "label": "Full text available via HathiTrust - jahrg.13:July-Dec. (1819)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899532p",
+                        "label": "Full text available via HathiTrust - jahrg.14:Jan.-June (1820)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899534l",
+                        "label": "Full text available via HathiTrust - jahrg.15:Jan.-June (1821)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899535j",
+                        "label": "Full text available via HathiTrust - jahrg.15:July-Dec. (1821)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899536h",
+                        "label": "Full text available via HathiTrust - jahrg.16:Jan.-June (1822)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899537f",
+                        "label": "Full text available via HathiTrust - jahrg.16:July-Dec. (1822)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899538d",
+                        "label": "Full text available via HathiTrust - jahrg.17:Jan.-June (1823)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899539b",
+                        "label": "Full text available via HathiTrust - jahrg.17:July-Dec. (1823)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899541o",
+                        "label": "Full text available via HathiTrust - jahrg.18:July-Dec. (1824)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899542m",
+                        "label": "Full text available via HathiTrust - jahrg.19:Jan.-June (1825)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899505s",
+                        "label": "Full text available via HathiTrust - jahrg.2:Jan.-June (1808)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899506q",
+                        "label": "Full text available via HathiTrust - jahrg.2:July-Dec. (1808)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899544i",
+                        "label": "Full text available via HathiTrust - jahrg.20:Jan.-June (1826)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899545g",
+                        "label": "Full text available via HathiTrust - jahrg.20:July-Dec. (1826)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899547c",
+                        "label": "Full text available via HathiTrust - jahrg.21:July-Dec. (1827)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899548a",
+                        "label": "Full text available via HathiTrust - jahrg.22 (1828)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899620s",
+                        "label": "Full text available via HathiTrust - jahrg.22:suppl.:art (1828)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899550n",
+                        "label": "Full text available via HathiTrust - jahrg.23:July-Dec. (1829)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899551l",
+                        "label": "Full text available via HathiTrust - jahrg.24:Jan.-June (1830)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899552j",
+                        "label": "Full text available via HathiTrust - jahrg.24:July-Dec. (1830)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899624k",
+                        "label": "Full text available via HathiTrust - jahrg.24:suppl.:lit. (1830)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899554f",
+                        "label": "Full text available via HathiTrust - jahrg.25:July-Dec. (1831)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899555d",
+                        "label": "Full text available via HathiTrust - jahrg.26:Jan.-June (1832)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899556b",
+                        "label": "Full text available via HathiTrust - jahrg.26:July-Dec. (1832)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995587",
+                        "label": "Full text available via HathiTrust - jahrg.28:Jan.-June (1834)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995595",
+                        "label": "Full text available via HathiTrust - jahrg.28:July-Dec. (1834)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899560k",
+                        "label": "Full text available via HathiTrust - jahrg.29:Jan.-June (1835)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899561i",
+                        "label": "Full text available via HathiTrust - jahrg.29:July-Dec. (1835)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899563e",
+                        "label": "Full text available via HathiTrust - jahrg.30:Oct.-Dec. (1836)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899641k",
+                        "label": "Full text available via HathiTrust - jahrg.32:suppl.:lit. (1838)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995668",
+                        "label": "Full text available via HathiTrust - jahrg.33 (1839)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899642i",
+                        "label": "Full text available via HathiTrust - jahrg.33:suppl.:art (1839)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899645c",
+                        "label": "Full text available via HathiTrust - jahrg.35:suppl.:art (1841)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899646a",
+                        "label": "Full text available via HathiTrust - jahrg.35:suppl.:lit. (1841)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995692",
+                        "label": "Full text available via HathiTrust - jahrg.36:Jan.-Apr. (1842)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899571f",
+                        "label": "Full text available via HathiTrust - jahrg.36:Sept.-Dec. (1842)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899572d",
+                        "label": "Full text available via HathiTrust - jahrg.37:Jan.-Apr. (1843)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899573b",
+                        "label": "Full text available via HathiTrust - jahrg.37:May-Aug. (1843)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995749",
+                        "label": "Full text available via HathiTrust - jahrg.37:Sept.-Dec. (1843)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951p01107664f",
+                        "label": "Full text available via HathiTrust - jahrg.38:Jan.-Apr. (1844)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995765",
+                        "label": "Full text available via HathiTrust - jahrg.38:May-Aug. (1844)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995781",
+                        "label": "Full text available via HathiTrust - jahrg.39:Jan.-June (1845)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899509k",
+                        "label": "Full text available via HathiTrust - jahrg.4:Jan.-June (1810)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899582a",
+                        "label": "Full text available via HathiTrust - jahrg.41:Jan.-June (1847)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995838",
+                        "label": "Full text available via HathiTrust - jahrg.41:July-Dec. (1847)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899589w",
+                        "label": "Full text available via HathiTrust - jahrg.44:July-Dec. (1850)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899590b",
+                        "label": "Full text available via HathiTrust - jahrg.45:Jan.-June (1851)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899599t",
+                        "label": "Full text available via HathiTrust - jahrg.49:July-Dec. (1855)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899512v",
+                        "label": "Full text available via HathiTrust - jahrg.5:July-Dec. (1811)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899600y",
+                        "label": "Full text available via HathiTrust - jahrg.50:Jan.-June (1856)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899601w",
+                        "label": "Full text available via HathiTrust - jahrg.50:July-Dec. (1856)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899602u",
+                        "label": "Full text available via HathiTrust - jahrg.51:Jan.-June (1857)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899603s",
+                        "label": "Full text available via HathiTrust - jahrg.51:July-Dec. (1857)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899605o",
+                        "label": "Full text available via HathiTrust - jahrg.52:July-Dec. (1858)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899606m",
+                        "label": "Full text available via HathiTrust - jahrg.53:Jan.-June (1859)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899607k",
+                        "label": "Full text available via HathiTrust - jahrg.53:July-Dec. (1859)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899608i",
+                        "label": "Full text available via HathiTrust - jahrg.54:Jan.-June (1860)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899609g",
+                        "label": "Full text available via HathiTrust - jahrg.54:July-Dec. (1860)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899610v",
+                        "label": "Full text available via HathiTrust - jahrg.55:Jan.-June (1861)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899611t",
+                        "label": "Full text available via HathiTrust - jahrg.55:July-Dec. (1861)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899612r",
+                        "label": "Full text available via HathiTrust - jahrg.56:Jan.-June (1862)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899613p",
+                        "label": "Full text available via HathiTrust - jahrg.56:July-Dec. (1862)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899614n",
+                        "label": "Full text available via HathiTrust - jahrg.57:Jan.-June (1863)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899615l",
+                        "label": "Full text available via HathiTrust - jahrg.57:July-Dec. (1863)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899616j",
+                        "label": "Full text available via HathiTrust - jahrg.58:Jan.-June (1864)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899617h",
+                        "label": "Full text available via HathiTrust - jahrg.58:July-Dec. (1864)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899619d",
+                        "label": "Full text available via HathiTrust - jahrg.59:July-Dec. (1865)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899513t",
+                        "label": "Full text available via HathiTrust - jahrg.6:Jan.-June (1812)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899514r",
+                        "label": "Full text available via HathiTrust - jahrg.6:July-Dec. (1812)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899516n",
+                        "label": "Full text available via HathiTrust - jahrg.7:July-Dec. (1813)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899521u",
+                        "label": "Full text available via HathiTrust - jahrg.9:Jan.-June (1815)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054677",
+                        "label": "Full text available via HathiTrust - vol.13, pt.2 (1819)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054701",
+                        "label": "Full text available via HathiTrust - vol.15, pt.1 (1821)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054743",
+                        "label": "Full text available via HathiTrust - vol.28, pt.1 (1834)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054768",
+                        "label": "Full text available via HathiTrust - vol.28, pt.2 (1834)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054776",
+                        "label": "Full text available via HathiTrust - vol.28, pt.3 (1834)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054800",
+                        "label": "Full text available via HathiTrust - vol.30, pt.1 (1836)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054818",
+                        "label": "Full text available via HathiTrust - vol.30, pt.2 (1836)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054826",
+                        "label": "Full text available via HathiTrust - vol.31, pt.1 (1837)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054834",
+                        "label": "Full text available via HathiTrust - vol.31, pt.2 (1837)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054842",
+                        "label": "Full text available via HathiTrust - vol.33, pt.1 (1839)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054859",
+                        "label": "Full text available via HathiTrust - vol.33, pt.2 (1839)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064488156",
+                        "label": "Full text available via HathiTrust - vol.40 (1846)"
+                      }
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "bi14937001-e"
+                  }
+                }
+              ]
+            }
+          },
+          "allItems": {
+            "hits": {
+              "total": 4,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i28309666",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 1933"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 1933",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088646033"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. Mar.-May 1933"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088646033"
+                    ],
+                    "idBarcode": [
+                      "33433088646033"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 001933"
+                  }
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i28309648",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433096425198"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 49 (1855)"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433096425198"
+                    ],
+                    "idBarcode": [
+                      "33433096425198"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)"
+                  }
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i28309668",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1861"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1861",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088646041"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 1861"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088646041"
+                    ],
+                    "idBarcode": [
+                      "33433088646041"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 001861"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 4,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28309666",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 1933"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 1933",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088646033"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. Mar.-May 1933"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088646033"
+                    ],
+                    "idBarcode": [
+                      "33433088646033"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 001933"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28309648",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433096425198"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 49 (1855)"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433096425198"
+                    ],
+                    "idBarcode": [
+                      "33433096425198"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28309668",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1861"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1861",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088646041"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 1861"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088646041"
+                    ],
+                    "idBarcode": [
+                      "33433088646041"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 001861"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28543800",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1860"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1860",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433097964930"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 1860"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433097964930"
+                    ],
+                    "idBarcode": [
+                      "33433097964930"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 001860"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 5,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "loc:rc2ma||Offsite",
+            "doc_count": 3
+          },
+          {
+            "key": "loc:mal92||Schwarzman Building M2 - General Research Room 315",
+            "doc_count": 1
+          }
+        ]
+      }
+    },
+    "item_format": {
+      "doc_count": 5,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 5
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 5,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 4
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/query-109d191a75e06b17a27be58bb877329a.json
+++ b/test/fixtures/query-109d191a75e06b17a27be58bb877329a.json
@@ -1,0 +1,13423 @@
+{
+  "took": 235,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1387261,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Stauffenburg"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Gmelin, Hermann, 1900-1958.",
+            "Baum, Richard.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGNYPG-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "idOclc": [
+            "NYPGNYPG-B"
+          ],
+          "updatedAt": 1678937667178,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:oclc:NYPGNYPG-B",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen"
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "3923721544"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000003",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. : col. ill. maps ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrides (Scotland)",
+            "Hebrides (Scotland) -- Pictorial works"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Constable"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1989
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Scottish islands"
+          ],
+          "shelfMark": [
+            "JFF 89-526"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Waite, Charlie."
+          ],
+          "createdString": [
+            "1989"
+          ],
+          "idLccn": [
+            "gb 89012970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1989
+          ],
+          "donor": [
+            "Gift of the Drue Heinz Book Fund for English Literature"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 89-526"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000003"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0094675708 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "gb 89012970"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGUKBPGP8917-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200002"
+            }
+          ],
+          "idOclc": [
+            "NYPGUKBPGP8917-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Constable, 1989."
+          ],
+          "identifier": [
+            "urn:bnum:10000003",
+            "urn:isbn:0094675708 :",
+            "urn:lccn:gb 89012970",
+            "urn:oclc:NYPGUKBPGP8917-B",
+            "urn:undefined:(WaOLN)nyp0200002"
+          ],
+          "idIsbn": [
+            "0094675708 "
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1989"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrides (Scotland) -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Scottish islands / Charlie Waite."
+          ],
+          "uri": "b10000003",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0094675708"
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000003"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 89-526"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 89-526",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050409147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 89-526"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050409147"
+                    ],
+                    "idBarcode": [
+                      "33433050409147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFF 89-000526"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000126",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "72 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ramana, Maharshi",
+            "Ramana, Maharshi -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Śrī Ramaṇāśrama"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrī Ramaṇa Maharshi : eka saṃkshipta jīvanī : sacitra."
+          ],
+          "shelfMark": [
+            "*OLY 82-4666"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 82-4666"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000126"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000074-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100074"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200125"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000074-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Tirūvaṇṇāmalai : Śrī Ramaṇāśrama, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000126",
+            "urn:oclc:NYPG001000074-B",
+            "urn:undefined:NNSZ00100074",
+            "urn:undefined:(WaOLN)nyp0200125"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ramana, Maharshi -- Biography."
+          ],
+          "titleDisplay": [
+            "Śrī Ramaṇa Maharshi : eka saṃkshipta jīvanī : sacitra."
+          ],
+          "uri": "b10000126",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirūvaṇṇāmalai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000126"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783800",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 82-4666"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 82-4666",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417551"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 82-4666"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417551"
+                    ],
+                    "idBarcode": [
+                      "33433060417551"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 82-004666"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000156",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "10, 9 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Additions and corrections in MS.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; introductory matter in Sanskrit or English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindu gods",
+            "Hindu hymns, Sanskrit"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Go. Venkaṭarāmaśāstri]"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṣṭakapañcakam = Ashtaka-panchakam ; Jaladhijānandalaharī = Jaladhijanandalahari"
+          ],
+          "shelfMark": [
+            "*OLY 83-4674"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75902648"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-4674"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000156"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902648"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000104-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100104"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200155"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000104-B"
+          ],
+          "uniformTitle": [
+            "Aṣṭakapañcaka"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "[S.l. : Go. Venkaṭarāmaśāstri], 1972."
+          ],
+          "identifier": [
+            "urn:bnum:10000156",
+            "urn:lccn:75902648",
+            "urn:oclc:NYPG001000104-B",
+            "urn:undefined:NNSZ00100104",
+            "urn:undefined:(WaOLN)nyp0200155"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindu gods.",
+            "Hindu hymns, Sanskrit."
+          ],
+          "titleDisplay": [
+            "Aṣṭakapañcakam = Ashtaka-panchakam ; Jaladhijānandalaharī = Jaladhijanandalahari / praṇetā Garikapāṭi Lakshmīkāntaḥ."
+          ],
+          "uri": "b10000156",
+          "lccClassification": [
+            "BL1216 .L34"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l."
+          ],
+          "titleAlt": [
+            "Aṣṭakapañcaka",
+            "Jaladhijānandalaharī."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000156"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783803",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-4674"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-4674",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060370396"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-4674"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060370396"
+                    ],
+                    "idBarcode": [
+                      "33433060370396"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-004674"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000165",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "47, 112 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vaishnavism",
+            "Vaishnavism -- Prayer books and devotions",
+            "Vaishnavism -- Prayer books and devotions -- Tamil"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Nārāyaṇacāmi Nāyaṭu"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Āḻv̲arkaḷ Tamiḻil akkārak kaṉikaḷ"
+          ],
+          "shelfMark": [
+            "*OLY 83-4895"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76901471"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Narayanaswami Naidu, Tiruchirrambalam Krishnaswamy, 1906-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-4895"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000165"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901471"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000113-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100113"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200164"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000113-B"
+          ],
+          "uniformTitle": [
+            "Nālāyirat tivviyap pirapantam. Selections."
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Kaṭalūr : Nārāyaṇacāmi Nāyaṭu, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000165",
+            "urn:lccn:76901471",
+            "urn:oclc:NYPG001000113-B",
+            "urn:undefined:NNSZ00100113",
+            "urn:undefined:(WaOLN)nyp0200164"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vaishnavism -- Prayer books and devotions -- Tamil."
+          ],
+          "titleDisplay": [
+            "Āḻv̲arkaḷ Tamiḻil akkārak kaṉikaḷ / [Tokuppāciriyar Ti. Ki. Nārāyaṇacāmi Nāyaṭu]."
+          ],
+          "uri": "b10000165",
+          "lccClassification": [
+            "BL1245.V3 N28 1975"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kaṭalūr"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000165"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783808",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-4895"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-4895",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060419649"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-4895"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060419649"
+                    ],
+                    "idBarcode": [
+                      "33433060419649"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-004895"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000177",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 4, 354 p. col. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [349]-354.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Rām Sanehīs"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Rāmasnehī Sāhitya Śodha Saṃsthāna"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rāmasnehī-sampradāya kī dārśanika prshṭhabhūmi."
+          ],
+          "shelfMark": [
+            "*OLY 84-85"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Pāṇḍeya, Śivāśaṅkara, 1935-"
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "74901467"
+          ],
+          "seriesStatement": [
+            "Rāmasnehī sāhitya śodha saṃsthāna, pushpa 1"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 84-85"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000177"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74901467"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000125-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100125"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200176"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000125-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Dillī, Rāmasnehī Sāhitya Śodha Saṃsthāna [1973]"
+          ],
+          "identifier": [
+            "urn:bnum:10000177",
+            "urn:lccn:74901467",
+            "urn:oclc:NYPG001000125-B",
+            "urn:undefined:NNSZ00100125",
+            "urn:undefined:(WaOLN)nyp0200176"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rām Sanehīs."
+          ],
+          "titleDisplay": [
+            "Rāmasnehī-sampradāya kī dārśanika prshṭhabhūmi. Lekhaka Śivāśaṅkara Pāṇḍeya."
+          ],
+          "uri": "b10000177",
+          "lccClassification": [
+            "BL1245.R35 P36"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dillī"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000177"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783812",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 84-85"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 84-85",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060419680"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 84-85"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060419680"
+                    ],
+                    "idBarcode": [
+                      "33433060419680"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 84-000085"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000195",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "116 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vālmīki"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Periyār Cuyamariyātaip Piracāra Niṟuvaṉa Veḷiyīṭu"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Irāmāyaṇap pāttiraṅkaḷ; ātāraṅkaḷil uḷḷapaṭi tokuttatu."
+          ],
+          "shelfMark": [
+            "*OLY 83-2592"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rāmacāmi, Ī. Ve., Tantai Periyār, 1878-1973."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "73903633"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-2592"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000195"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73903633"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000143-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100143"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200194"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000143-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Tirucci, Periyār Cuyamariyātaip Piracāra Niṟuvaṉa Veḷiyīṭu [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000195",
+            "urn:lccn:73903633",
+            "urn:oclc:NYPG001000143-B",
+            "urn:undefined:NNSZ00100143",
+            "urn:undefined:(WaOLN)nyp0200194"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vālmīki."
+          ],
+          "titleDisplay": [
+            "Irāmāyaṇap pāttiraṅkaḷ; ātāraṅkaḷil uḷḷapaṭi tokuttatu. [Eḻutiyavar] Periyār Ī. Ve. Rā."
+          ],
+          "uri": "b10000195",
+          "lccClassification": [
+            "PK3659 .R34 1972"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirucci"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000195"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783817",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-2592"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-2592",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060418526"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-2592"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060418526"
+                    ],
+                    "idBarcode": [
+                      "33433060418526"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-002592"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000203",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "201 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ramana, Maharshi"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Śivalāla Agravāla eṇḍa Kampanī"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ramaṇa Maharshi : evaṃ ātma-jñāna kā mārga. [́Hindi edition of Ramana Maharshi and the Path of Self-Knowledge by Arthur Osbourne]"
+          ],
+          "shelfMark": [
+            "*OLY 82-3981"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Vedālaṅkāra, Vedarāja."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Osbourne, Arthur."
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 82-3981"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000203"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000151-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100151"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200202"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000151-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Āgarā : Śivalāla Agravāla eṇḍa Kampanī, 1978."
+          ],
+          "identifier": [
+            "urn:bnum:10000203",
+            "urn:oclc:NYPG001000151-B",
+            "urn:undefined:NNSZ00100151",
+            "urn:undefined:(WaOLN)nyp0200202"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ramana, Maharshi."
+          ],
+          "titleDisplay": [
+            "Ramaṇa Maharshi : evaṃ ātma-jñāna kā mārga. [́Hindi edition of Ramana Maharshi and the Path of Self-Knowledge by Arthur Osbourne] / lekhaka Ārthara Āsaborna ; bhūmikā lekhaka Ḍā. Sarvapallī Rādhākṛshṇana ; anuvādaka Vedarāja Vedālankāra."
+          ],
+          "uri": "b10000203",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Āgarā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000203"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783820",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 82-3981"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 82-3981",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417486"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 82-3981"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417486"
+                    ],
+                    "idBarcode": [
+                      "33433060417486"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 82-003981"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000229",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "97, 5 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Running title: Silver jubilee souvenir '72",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Tamil or English.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Advertising matter included in paging.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindu devotional literature, Tamil",
+            "Vaishnavites",
+            "Vaishnavites -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "[Thirumazhisaiars' Association"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The Thirumazhisaiars' Association : (Mahisara Abhijana Sabha) silver jubilee souvenir, 1972."
+          ],
+          "shelfMark": [
+            "*OLY 84-1084"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "73902510"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Thirumazhisaiars' Association."
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 84-1084"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000229"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73902510"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000177-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100177"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200228"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000177-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Madras : [Thirumazhisaiars' Association, 1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000229",
+            "urn:lccn:73902510",
+            "urn:oclc:NYPG001000177-B",
+            "urn:undefined:NNSZ00100177",
+            "urn:undefined:(WaOLN)nyp0200228"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindu devotional literature, Tamil.",
+            "Vaishnavites -- Biography."
+          ],
+          "titleDisplay": [
+            "The Thirumazhisaiars' Association : (Mahisara Abhijana Sabha) silver jubilee souvenir, 1972."
+          ],
+          "uri": "b10000229",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Madras"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000229"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783829",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 84-1084"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 84-1084",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060419979"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 84-1084"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060419979"
+                    ],
+                    "idBarcode": [
+                      "33433060419979"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 84-001084"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000292",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "56 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit and English on opposite pages.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ramana, Maharshi"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sri Ramanasramam"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Revelation : Śrīramaṇahṛdayam. A Sanskrit Version of the Ulladu Narpadu of Bhagavan Sri Ramana with an English translation"
+          ],
+          "shelfMark": [
+            "*OLY 82-3739"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Sarma, K. Lakshmana."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 82-3739"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000292"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000245-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100245"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200291"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000245-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Tiruvannamalai : Sri Ramanasramam, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000292",
+            "urn:oclc:NYPG001000245-B",
+            "urn:undefined:NNSZ00100245",
+            "urn:undefined:(WaOLN)nyp0200291"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ramana, Maharshi."
+          ],
+          "titleDisplay": [
+            "Revelation : Śrīramaṇahṛdayam. A Sanskrit Version of the Ulladu Narpadu of Bhagavan Sri Ramana with an English translation / by K. Lakshmana Sarma, \"WHO.\""
+          ],
+          "uri": "b10000292",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tiruvannamalai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000292"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783845",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 82-3739"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 82-3739",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417452"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 82-3739"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417452"
+                    ],
+                    "idBarcode": [
+                      "33433060417452"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 82-003739"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000338",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "8, 323 p. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindu hymns"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Khemarāja Śrīkṛshṇadāsa"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1963
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bṛhatstotraratrākaraḥ, sacitraḥ; stotrasaṃkhyā 224."
+          ],
+          "shelfMark": [
+            "*OLY 82-3968"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1963"
+          ],
+          "idLccn": [
+            "sa 68013360"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1963
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 82-3968"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000338"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68013360"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000291-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100291"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200337"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000291-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Bambaī, Khemarāja Śrīkṛshṇadāsa, 1963."
+          ],
+          "identifier": [
+            "urn:bnum:10000338",
+            "urn:lccn:sa 68013360",
+            "urn:oclc:NYPG001000291-B",
+            "urn:undefined:NNSZ00100291",
+            "urn:undefined:(WaOLN)nyp0200337"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1963"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindu hymns."
+          ],
+          "titleDisplay": [
+            "Bṛhatstotraratrākaraḥ, sacitraḥ; stotrasaṃkhyā 224."
+          ],
+          "uri": "b10000338",
+          "lccClassification": [
+            "BL1226.3 .B7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bambaī"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000338"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783847",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 82-3968"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 82-3968",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417478"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 82-3968"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417478"
+                    ],
+                    "idBarcode": [
+                      "33433060417478"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 82-003968"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000344",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "194 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Persian or Arabic",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Translation of: Ṭibb al-Imām al-Ṣādiq.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jaʻfar al-Ṣādiq, 702?-765 or 6",
+            "Medicine, Medieval",
+            "Hygiene"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Bungāh-i Maṭbūʻātī-i ʻAṭāʼī"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1961
+          ],
+          "dateEndString": [
+            "1962"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ṭibb al-Ṣādiq, ṭibb va bihdāsht az naẓar-i Imām Jaʻfar Ṣādiq."
+          ],
+          "shelfMark": [
+            "*OGI 82-3991"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Khalīlī, Muḥammad."
+          ],
+          "createdString": [
+            "1961"
+          ],
+          "idLccn": [
+            "72274632"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Tihrānī, Nāṣir al-Dīn Ṣādiq."
+          ],
+          "dateStartYear": [
+            1961
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGI 82-3991"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000344"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72274632"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000297-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100297"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200343"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000297-B"
+          ],
+          "dateEndYear": [
+            1962
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Tihrān, Bungāh-i Maṭbūʻātī-i ʻAṭāʼī, 1339 [1961 or 1962]"
+          ],
+          "identifier": [
+            "urn:bnum:10000344",
+            "urn:lccn:72274632",
+            "urn:oclc:NYPG001000297-B",
+            "urn:undefined:NNSZ00100297",
+            "urn:undefined:(WaOLN)nyp0200343"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1961"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jaʻfar al-Ṣādiq, 702?-765 or 6.",
+            "Medicine, Medieval.",
+            "Hygiene."
+          ],
+          "titleDisplay": [
+            "Ṭibb al-Ṣādiq, ṭibb va bihdāsht az naẓar-i Imām Jaʻfar Ṣādiq. Taʼlīf-i Muḥammad Khalī̄li. Tarjumah va sharḥ az Naṣīr al-Dīn Ṣādiq Tihrānī."
+          ],
+          "uri": "b10000344",
+          "lccClassification": [
+            "BP193.16. K516 1961"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10000344"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858044",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OGI 82-3991"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGI 82-3991",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058031224"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGI 82-3991"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058031224"
+                    ],
+                    "idBarcode": [
+                      "33433058031224"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGI 82-003991"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000345",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "5, 247 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Persian or Arabic.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "ʻAlī al-Riḍāʼs Risālah dhahabīyah: p.191-220.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "ʻAlī al-Riḍā ibn Mūsá, -818 or 19",
+            "Medicine, Medieval",
+            "Hygiene"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muḥammad Rizā Lavāsānī"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1961
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ṭibb va bihdāsht az naẓar-i Imām ʻAlī ibn Mūsā al-Rizā"
+          ],
+          "shelfMark": [
+            "*OGI 82-3989"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Tihrānī, Nāṣir al-Dīn Ṣādiq."
+          ],
+          "createdString": [
+            "1961"
+          ],
+          "idLccn": [
+            "74214957"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "ʻAlī al-Riḍā ibn Mūsá, -818 or 19."
+          ],
+          "dateStartYear": [
+            1961
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGI 82-3989"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000345"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74214957"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000298-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100298"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200344"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000298-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Tihrān, Muḥammad Rizā Lavāsānī, 1340 [1961]"
+          ],
+          "identifier": [
+            "urn:bnum:10000345",
+            "urn:lccn:74214957",
+            "urn:oclc:NYPG001000298-B",
+            "urn:undefined:NNSZ00100298",
+            "urn:undefined:(WaOLN)nyp0200344"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1961"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "ʻAlī al-Riḍā ibn Mūsá, -818 or 19.",
+            "Medicine, Medieval.",
+            "Hygiene."
+          ],
+          "titleDisplay": [
+            "Ṭibb va bihdāsht az naẓar-i Imām ʻAlī ibn Mūsā al-Rizā, nivishtah-ʼi Naṣīr al-Dīn Mīr Ṣādiqī Tihrānī."
+          ],
+          "uri": "b10000345",
+          "lccClassification": [
+            "R141. T53"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000345"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858045",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OGI 82-3989"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGI 82-3989",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058030721"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGI 82-3989"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058030721"
+                    ],
+                    "idBarcode": [
+                      "33433058030721"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGI 82-003989"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000348",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[28], 573 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [7-10] (1st group)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Description and travel"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Mīrzā Ḥabīb Allāh"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1880"
+          ],
+          "createdYear": [
+            1879
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kitāb-i mustaṭāb-i ganj-i dānish"
+          ],
+          "shelfMark": [
+            "*ONA+ 82-2677"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Muʻtamid al-Sulṭān, Muḥammad Taqī khān Ḥakīm, mutakhalliṣ bih Ḥakīm."
+          ],
+          "createdString": [
+            "1879"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1879
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ONA+ 82-2677"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000348"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000301-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100301"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200347"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000301-B"
+          ],
+          "dateEndYear": [
+            1880
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Ṭihrān : Mīrzā Ḥabīb Allāh, 1305 [1879 or 1880]"
+          ],
+          "identifier": [
+            "urn:bnum:10000348",
+            "urn:oclc:NYPG001000301-B",
+            "urn:undefined:NNSZ00100301",
+            "urn:undefined:(WaOLN)nyp0200347"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1879"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Description and travel."
+          ],
+          "titleDisplay": [
+            "Kitāb-i mustaṭāb-i ganj-i dānish / az taʼlīfāt-i Muʻtamid al-Sulṭān Muḥammad Taqī Khān mutikhalliṣ bih Ḥakīm ; bi-saʻī va ihtimām-i Mullā Maḥmūd va Mullā Rizā Kitābfurūsh."
+          ],
+          "uri": "b10000348",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ṭihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Ganj-i dānish."
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          "b10000348"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783848",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*ONA+ 82-2677  "
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ONA+ 82-2677  ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059840763"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ONA+ 82-2677  "
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059840763"
+                    ],
+                    "idBarcode": [
+                      "33433059840763"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ONA+ 82-2677 "
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000379",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 v. in 1. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Persian or Arabic.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Shiites",
+            "Shiites -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Markazī"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1949
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Favāʼid al-Razavīyah : zindigānī-i ʻulamāʼī maẕ hab-i shīʻah"
+          ],
+          "shelfMark": [
+            "*OGI 83-4798"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Qummī, ʻAbbās ibn Muḥammad Riḍā, -1941."
+          ],
+          "createdString": [
+            "1949"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1949
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGI 83-4798"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000379"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000332-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100332"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200378"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000332-B"
+          ],
+          "updatedAt": 1676664769349,
+          "publicationStatement": [
+            "[Tihrān?] : Intishārāt-i Markazī, 1327 [1949]"
+          ],
+          "identifier": [
+            "urn:bnum:10000379",
+            "urn:oclc:NYPG001000332-B",
+            "urn:undefined:NNSZ00100332",
+            "urn:undefined:(WaOLN)nyp0200378"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1949"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Shiites -- Biography."
+          ],
+          "titleDisplay": [
+            "Favāʼid al-Razavīyah : zindigānī-i ʻulamāʼī maẕ hab-i shīʻah / taʼlīf-i Shaykh ʻAbbās Qummī."
+          ],
+          "uri": "b10000379",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Tihrān?]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000379"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858047",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OGI 83-4798"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGI 83-4798",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058030051"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGI 83-4798"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058030051"
+                    ],
+                    "idBarcode": [
+                      "33433058030051"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGI 83-004798"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000392",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "228 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Fasts and feasts",
+            "Fasts and feasts -- Hinduism",
+            "Hindu temples",
+            "Hindu temples -- Tamil Nadu"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Cāstā Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aimperu viḻākkaḷ."
+          ],
+          "shelfMark": [
+            "*OLY 84-1823"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Gopalakrishnan, Sattanathapuram Subramania, 1916-"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "74913252"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 84-1823"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000392"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74913252"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000346-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100346"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200391"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000346-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Tiruccentūr, Cāstā Patippakam [1970]"
+          ],
+          "identifier": [
+            "urn:bnum:10000392",
+            "urn:lccn:74913252",
+            "urn:oclc:NYPG001000346-B",
+            "urn:undefined:NNSZ00100346",
+            "urn:undefined:(WaOLN)nyp0200391"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Fasts and feasts -- Hinduism.",
+            "Hindu temples -- Tamil Nadu."
+          ],
+          "titleDisplay": [
+            "Aimperu viḻākkaḷ. Tokuppāciriyar Centil Tuṟavi."
+          ],
+          "uri": "b10000392",
+          "lccClassification": [
+            "BL1212 .G66"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tiruccentūr"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000392"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783870",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 84-1823"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 84-1823",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060420118"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 84-1823"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060420118"
+                    ],
+                    "idBarcode": [
+                      "33433060420118"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 84-001823"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000397",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "87 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Revision of a speech delivered at the 41st annual day celebration of the Saivasiddhanta Sabha, Tuticorin, 1924.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindu philosophy",
+            "Śaivism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Araci Puk Ṭippō"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Caivattiṉ camaracam."
+          ],
+          "shelfMark": [
+            "*OLY 84-1838"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "73913694"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Saivasiddhanta Sabha."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 84-1838"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000397"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73913694"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000351-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100351"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200396"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000351-B"
+          ],
+          "updatedAt": 1674870762646,
+          "publicationStatement": [
+            "Ceṉṉai, Araci Puk Ṭippō, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000397",
+            "urn:lccn:73913694",
+            "urn:oclc:NYPG001000351-B",
+            "urn:undefined:NNSZ00100351",
+            "urn:undefined:(WaOLN)nyp0200396"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindu philosophy.",
+            "Śaivism."
+          ],
+          "titleDisplay": [
+            "Caivattiṉ camaracam. Ākkiyōr Tiru. Vi. Kaliyāṇacuntaraṉār."
+          ],
+          "uri": "b10000397",
+          "lccClassification": [
+            "B131 .K343 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000397"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783872",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 84-1838"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 84-1838",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060420126"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 84-1838"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060420126"
+                    ],
+                    "idBarcode": [
+                      "33433060420126"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 84-001838"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000406",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "220 p. port."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Murugan (Hindu deity)",
+            "Murugan (Hindu deity) -- Poetry"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Acciṭṭōr Kāntitācaṉ Accakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ōtāḷar kuṟavañci; eṉum, Alakumalaikkuṟavañci."
+          ],
+          "shelfMark": [
+            "*OLY 84-1725"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ciṉṉattampi Nāvalar, active 18th century."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "74914694"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Paḻaṉiccāmip Pulavar, K."
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 84-1725"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000406"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74914694"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000360-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100360"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200405"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000360-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "[Kōvai, Acciṭṭōr Kāntitācaṉ Accakam, 1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000406",
+            "urn:lccn:74914694",
+            "urn:oclc:NYPG001000360-B",
+            "urn:undefined:NNSZ00100360",
+            "urn:undefined:(WaOLN)nyp0200405"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Murugan (Hindu deity) -- Poetry."
+          ],
+          "titleDisplay": [
+            "Ōtāḷar kuṟavañci; eṉum, Alakumalaikkuṟavañci. Patipp̲aciriyar Ka. Paḻaṉiccāmip Pulavar."
+          ],
+          "uri": "b10000406",
+          "lccClassification": [
+            "PL4758.9.C4985 O8"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Kōvai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000406"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783876",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 84-1725"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 84-1725",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060420076"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 84-1725"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060420076"
+                    ],
+                    "idBarcode": [
+                      "33433060420076"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 84-001725"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000413",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "100 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Karumari Amman (Hindu deity)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Cūppar Pavar Papḷikēṣaṉs"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tiruvēṟkāṭu Śrī Tēvi Karumārī Ammaṉ Catakam"
+          ],
+          "shelfMark": [
+            "*OLY 84-1817"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Śrī Tēvi Karumāri Tāsar."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "75914516"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 84-1817"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000413"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75914516"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000367-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100367"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200412"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000367-B"
+          ],
+          "updatedAt": 1674870762646,
+          "publicationStatement": [
+            "Ceṉṉai : Cūppar Pavar Papḷikēṣaṉs, [1970]"
+          ],
+          "identifier": [
+            "urn:bnum:10000413",
+            "urn:lccn:75914516",
+            "urn:oclc:NYPG001000367-B",
+            "urn:undefined:NNSZ00100367",
+            "urn:undefined:(WaOLN)nyp0200412"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Karumari Amman (Hindu deity)"
+          ],
+          "titleDisplay": [
+            "Tiruvēṟkāṭu Śrī Tēvi Karumārī Ammaṉ Catakam / iyaṟṟiyavar Śrī Tēvi Karumārī Tāsar."
+          ],
+          "uri": "b10000413",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10000413"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783880",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 84-1817"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 84-1817",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060420100"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 84-1817"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060420100"
+                    ],
+                    "idBarcode": [
+                      "33433060420100"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 84-001817"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000421",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 80 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nammāḻvār",
+            "Hindu philosophy",
+            "Vaishnavism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Araci Puk Ṭippō"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tamiḻnāṭum Nammāḻvārum."
+          ],
+          "shelfMark": [
+            "*OLY 84-1736"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "74913567"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 84-1736"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000421"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74913567"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000375-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100375"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200420"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000375-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Ceṉṉai, Araci Puk Ṭippō, 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000421",
+            "urn:lccn:74913567",
+            "urn:oclc:NYPG001000375-B",
+            "urn:undefined:NNSZ00100375",
+            "urn:undefined:(WaOLN)nyp0200420"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nammāḻvār.",
+            "Hindu philosophy.",
+            "Vaishnavism."
+          ],
+          "titleDisplay": [
+            "Tamiḻnāṭum Nammāḻvārum. Ākkiyōr Tiru. Vi. Kaliyāṇacuntaraṉār."
+          ],
+          "uri": "b10000421",
+          "lccClassification": [
+            "B131 .K346 1969"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000421"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783883",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 84-1736"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 84-1736",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060420092"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 84-1736"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060420092"
+                    ],
+                    "idBarcode": [
+                      "33433060420092"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 84-001736"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000424",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "7, 79 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1931 as an appendix to v.4 of Mīmāṃsādarśana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jaimini",
+            "Mimamsa"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ānandāśramasaṃsthā"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrīmajjaiminipraṇītamīmāṃsādarśaneʼṅgāṅgi-bhāvavimarśakaḥ \"Aṅgatvaniruktiḥ\" nāma prabandhaḥ"
+          ],
+          "shelfMark": [
+            "*OKM 97-3015"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Murārimiśra."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "76903136"
+          ],
+          "seriesStatement": [
+            "Ānandāśramasaṃskrtagranthāvaliḥ; granthāṇkaḥ 137"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ānandāśramasaṃsthā."
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKM 97-3015"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000424"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76903136"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000378-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100378"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200423"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000378-B"
+          ],
+          "uniformTitle": [
+            "Aṅgatvanirukti"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Puṇyākhyapattane : Ānandāśramasaṃsthā, 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000424",
+            "urn:lccn:76903136",
+            "urn:oclc:NYPG001000378-B",
+            "urn:undefined:NNSZ00100378",
+            "urn:undefined:(WaOLN)nyp0200423"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jaimini.",
+            "Mimamsa."
+          ],
+          "titleDisplay": [
+            "Śrīmajjaiminipraṇītamīmāṃsādarśaneʼṅgāṅgi-bhāvavimarśakaḥ \"Aṅgatvaniruktiḥ\" nāma prabandhaḥ / Śrīmanmurārimiśraviracitaḥ ; etatpustakaṃ Ānandāśramasthapaṇḍitaiḥ sampāditam."
+          ],
+          "uri": "b10000424",
+          "lccClassification": [
+            "B132.M5 M87"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Puṇyākhyapattane"
+          ],
+          "titleAlt": [
+            "Aṅgatvanirukti"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000424"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783885",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OKM 97-3015"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKM 97-3015",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058597968"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKM 97-3015"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058597968"
+                    ],
+                    "idBarcode": [
+                      "33433058597968"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKM 97-003015"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000461",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2v."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Caracuvatimāl] Nūlnilaiyak kaurava kāriyatarici S. Kōpālaiyaravarkaḷ"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1961
+          ],
+          "dateEndString": [
+            "1963"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ativīra Rāma Pāṇtiyar iyaṟṟiya Kūrma Purāṇa mūlam."
+          ],
+          "shelfMark": [
+            "*OKOK 81-2812"
+          ],
+          "numItemVolumesParsed": [
+            2
+          ],
+          "createdString": [
+            "1961"
+          ],
+          "idLccn": [
+            "sa 65009124"
+          ],
+          "seriesStatement": [
+            "Tañcai Caracuvati Māl. Veḷiyīṭu eṇ 91, 100"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ativira Rama Pandian, active 1562.",
+            "Govindaswami Pillai, R."
+          ],
+          "dateStartYear": [
+            1961
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKOK 81-2812"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000461"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 65009124"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000416-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100416"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200460"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000416-B"
+          ],
+          "uniformTitle": [
+            "Puranas. Kūrmapurāṇa. Tamil"
+          ],
+          "dateEndYear": [
+            1963
+          ],
+          "updatedAt": 1674870762646,
+          "publicationStatement": [
+            "[Tañcai, Caracuvatimāl] Nūlnilaiyak kaurava kāriyatarici S. Kōpālaiyaravarkaḷ, 1961-1963."
+          ],
+          "identifier": [
+            "urn:bnum:10000461",
+            "urn:lccn:sa 65009124",
+            "urn:oclc:NYPG001000416-B",
+            "urn:undefined:NNSZ00100416",
+            "urn:undefined:(WaOLN)nyp0200460"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1961"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Ativīra Rāma Pāṇtiyar iyaṟṟiya Kūrma Purāṇa mūlam. Pala piratikaḷaik konṭu paricōtittup patittavar Irāma. Kōvintacāmipiḷḷai."
+          ],
+          "uri": "b10000461",
+          "lccClassification": [
+            "PK3621 .K817"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Tañcai"
+          ],
+          "titleAlt": [
+            "Puranas. Kūrmapurāṇa.",
+            "Kūrma Purāṇa."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000461"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783891",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 81-2812 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 81-2812 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058648977"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 81-2812"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058648977"
+                    ],
+                    "idBarcode": [
+                      "33433058648977"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKOK 81-2812 v. 000002"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783890",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OKOK 81-2812 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOK 81-2812 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058648969"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 81-2812"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058648969"
+                    ],
+                    "idBarcode": [
+                      "33433058648969"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKOK 81-2812 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000468",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16, 312 p. port."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Banārasa Hindū Yūnivarsiṭī dvārā Pī-eca. Ḍī. kī upādhi ke lie svīkrta śodha-prabandha.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [282]-294.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ahiṃsā"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sohanalāla Jainadharma Pracāraka Samiti; prāpti-sthāna: Pārśvanātha Vidyāśrama Śodha Saṃsthāna, Vārāṇasī"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Jaina-dharma meṃ ahiṃsā."
+          ],
+          "shelfMark": [
+            "*OLX 83-155"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Sinha, Bashistha Narayan, 1935-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "73900921"
+          ],
+          "seriesStatement": [
+            "Pārśvanātha Vidyāśrama granthamālā, 17"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLX 83-155"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000468"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73900921"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000423-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100423"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200467"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000423-B"
+          ],
+          "updatedAt": 1674870767447,
+          "publicationStatement": [
+            "Amrtasara, Sohanalāla Jainadharma Pracāraka Samiti; prāpti-sthāna: Pārśvanātha Vidyāśrama Śodha Saṃsthāna, Vārāṇasī [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000468",
+            "urn:lccn:73900921",
+            "urn:oclc:NYPG001000423-B",
+            "urn:undefined:NNSZ00100423",
+            "urn:undefined:(WaOLN)nyp0200467"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ahiṃsā."
+          ],
+          "titleDisplay": [
+            "Jaina-dharma meṃ ahiṃsā. Lekhaka Baśishṭhanārāyaṇa Sinhā."
+          ],
+          "uri": "b10000468",
+          "lccClassification": [
+            "BL1375.A35 S56"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amrtasara"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000468"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783893",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLX 83-155"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLX 83-155",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060359332"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLX 83-155"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060359332"
+                    ],
+                    "idBarcode": [
+                      "33433060359332"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLX 83-000155"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000627",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "363, 53 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: The travels of Ibn Jubayr. Edited from a ms. in the University Library of Leyden by William Wright.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Original ed. issued as v. 5 of \"E.J.W. Gibb memorial\" series.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islamic Empire",
+            "Islamic Empire -- Description and travel"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "AMS Press"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            3
+          ],
+          "createdYear": [
+            1973
+          ],
+          "dateEndString": [
+            "1907"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Riḥlat Abī al-Husayn Muhammad ibn Ahmad ibn Jubayr al-Kinānī al-Andalusī al-Balinsī."
+          ],
+          "shelfMark": [
+            "*OAC (\"E. J. W. Gibb memorial\" series. v. 5)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ibn Jubayr, Muḥammad ibn Aḥmad, 1145-1217."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "77173005"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Wright, William, 1830-1889.",
+            "Goeje, M. J. de (Michael Jan), 1836-1909."
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OAC (\"E. J. W. Gibb memorial\" series. v. 5)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000627"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77173005"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002000036-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00200636"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200626"
+            }
+          ],
+          "idOclc": [
+            "NYPG002000036-B"
+          ],
+          "uniformTitle": [
+            "\"E.J.W. Gibb memorial\" series ; v.5."
+          ],
+          "dateEndYear": [
+            1907
+          ],
+          "updatedAt": 1674870762646,
+          "publicationStatement": [
+            "[New York, AMS Press, 1973] 1907."
+          ],
+          "identifier": [
+            "urn:bnum:10000627",
+            "urn:lccn:77173005",
+            "urn:oclc:NYPG002000036-B",
+            "urn:undefined:NNSZ00200636",
+            "urn:undefined:(WaOLN)nyp0200626"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islamic Empire -- Description and travel."
+          ],
+          "titleDisplay": [
+            "Riḥlat Abī al-Husayn Muhammad ibn Ahmad ibn Jubayr al-Kinānī al-Andalusī al-Balinsī."
+          ],
+          "uri": "b10000627",
+          "lccClassification": [
+            "DS36.6 .I26 1973"
+          ],
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "[New York"
+          ],
+          "titleAlt": [
+            "Travels of Ibn Jubayr."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000627"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000366",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFV 87-659"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFV 87-659",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014525079"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFV 87-659"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014525079"
+                    ],
+                    "idBarcode": [
+                      "33433014525079"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFV 87-000659"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000365",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OAC (\"E. J. W. Gibb memorial\" series. v. 5)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OAC (\"E. J. W. Gibb memorial\" series. v. 5)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433096515220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OAC (\"E. J. W. Gibb memorial\" series. v. 5)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433096515220"
+                    ],
+                    "idBarcode": [
+                      "33433096515220"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OAC (\"E. J. W. Gibb memorial\" series. v. 000005)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31207836",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:66",
+                        "label": "book, poor condition, non-MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:66||book, poor condition, non-MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OAC (\"E. J. W. Gibb memorial\" series. v. 5)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OAC (\"E. J. W. Gibb memorial\" series. v. 5)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433115326104"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OAC (\"E. J. W. Gibb memorial\" series. v. 5)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433115326104"
+                    ],
+                    "idBarcode": [
+                      "33433115326104"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OAC (\"E. J. W. Gibb memorial\" series. v. 000005)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000628",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "22, 484 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Historical dramas in Sanskrit literature.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Rājasthāna Viśvavidyālaya kī Pī.eca. Ḍī. kī upādhi ke lie svīkrta śodha prabandha.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliography and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Historical drama, Sanskrit",
+            "Historical drama, Sanskrit -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Devanāgara Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Saṃskrta ke aitihāsika nāṭaka : [...aitihāsika, sāhityika, evaṃ saṃskrtika anuśīlana]"
+          ],
+          "shelfMark": [
+            "*OKB 83.388"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Sharma, Shyama."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75900847"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKB 83.388"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000628"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75900847"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002000037-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00200637"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200627"
+            }
+          ],
+          "idOclc": [
+            "NYPG002000037-B"
+          ],
+          "updatedAt": 1674870772746,
+          "publicationStatement": [
+            "Jayapura : Devanāgara Prakāśana, [1974]"
+          ],
+          "identifier": [
+            "urn:bnum:10000628",
+            "urn:lccn:75900847",
+            "urn:oclc:NYPG002000037-B",
+            "urn:undefined:NNSZ00200637",
+            "urn:undefined:(WaOLN)nyp0200627"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Historical drama, Sanskrit -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Saṃskrta ke aitihāsika nāṭaka : [...aitihāsika, sāhityika, evaṃ saṃskrtika anuśīlana] / Śyāma Śarmā."
+          ],
+          "uri": "b10000628",
+          "lccClassification": [
+            "PK2932 .S5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Jayapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000628"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858062",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OKB 83.388"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKB 83.388",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058548284"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKB 83.388"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058548284"
+                    ],
+                    "idBarcode": [
+                      "33433058548284"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKB 83.000388"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000630",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 230 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Rāma (Hindu deity) in literature",
+            "Indic literature",
+            "Indic literature -- History and criticism",
+            "Bhakti in literature"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Hindī Vibhāga, Kalakattā Viśvavidyālaya ke lie Hindī Pustaka Ejensī"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rāmabhakti, paramparā aura sāhitya"
+          ],
+          "shelfMark": [
+            "*OLY 83-185"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Siṃha, Bhagavatī Prasāda."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75900873"
+          ],
+          "seriesStatement": [
+            "Śrīghanaśyāmadāsa Biṛalā Hindī vyākhyānamālā; 1972"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-185"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000630"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75900873"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002000039-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00200639"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200629"
+            }
+          ],
+          "idOclc": [
+            "NYPG002000039-B"
+          ],
+          "updatedAt": 1674870762646,
+          "publicationStatement": [
+            "Kalakattā : Hindī Vibhāga, Kalakattā Viśvavidyālaya ke lie Hindī Pustaka Ejensī, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000630",
+            "urn:lccn:75900873",
+            "urn:oclc:NYPG002000039-B",
+            "urn:undefined:NNSZ00200639",
+            "urn:undefined:(WaOLN)nyp0200629"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rāma (Hindu deity) in literature.",
+            "Indic literature -- History and criticism.",
+            "Bhakti in literature."
+          ],
+          "titleDisplay": [
+            "Rāmabhakti, paramparā aura sāhitya / vyākhyātā Bhagavatī Prasāda Siṃha."
+          ],
+          "uri": "b10000630",
+          "lccClassification": [
+            "PK2907.R25 S57"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kalakattā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000630"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783898",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-185"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-185",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417874"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-185"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417874"
+                    ],
+                    "idBarcode": [
+                      "33433060417874"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-000185"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000647",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "360 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Bhagavān Mahāvīra kī pacīsavīṃ nirvāṇa śatābdī ke upalaksha meṃ.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Mahāvīra"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Jaina Viśva Bhāratī Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śramaṇa Mahāvīra"
+          ],
+          "shelfMark": [
+            "*OLX 83-353"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Nathamal, Muni, 1920-"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75900818"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLX 83-353"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000647"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75900818"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002000056-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00200656"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200646"
+            }
+          ],
+          "idOclc": [
+            "NYPG002000056-B"
+          ],
+          "updatedAt": 1674870772746,
+          "publicationStatement": [
+            "Lāḍnūṃ : Jaina Viśva Bhāratī Prakāśana, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000647",
+            "urn:lccn:75900818",
+            "urn:oclc:NYPG002000056-B",
+            "urn:undefined:NNSZ00200656",
+            "urn:undefined:(WaOLN)nyp0200646"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Mahāvīra."
+          ],
+          "titleDisplay": [
+            "Śramaṇa Mahāvīra / Muni Nathamala; Sampādaka Muni Dulaharāja."
+          ],
+          "uri": "b10000647",
+          "lccClassification": [
+            "BL1371 .N36"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Lāḍnūṃ"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000647"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783899",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLX 83-353"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLX 83-353",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060359365"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLX 83-353"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060359365"
+                    ],
+                    "idBarcode": [
+                      "33433060359365"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLX 83-000353"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000654",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "200 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "English and Sanskrit; introd. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sokappadu, Ramanaidoo"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tapovanam Pub. House"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrī Viṣṇusahasranāmastotram. Sri Vishnu sahasranama stotram, with namavali."
+          ],
+          "shelfMark": [
+            "*OLY 83-374"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "sa 68001969"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Vimalananda, Swami."
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-374"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000654"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68001969"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002000063-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00200663"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200653"
+            }
+          ],
+          "idOclc": [
+            "NYPG002000063-B"
+          ],
+          "uniformTitle": [
+            "Viṣṇusahasranāma."
+          ],
+          "updatedAt": 1674870767447,
+          "publicationStatement": [
+            "Tirupparaitturai; Tapovanam Pub. House [1965]"
+          ],
+          "identifier": [
+            "urn:bnum:10000654",
+            "urn:lccn:sa 68001969",
+            "urn:oclc:NYPG002000063-B",
+            "urn:undefined:NNSZ00200663",
+            "urn:undefined:(WaOLN)nyp0200653"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sokappadu, Ramanaidoo."
+          ],
+          "titleDisplay": [
+            "Śrī Viṣṇusahasranāmastotram. Sri Vishnu sahasranama stotram, with namavali. Introd., English rendering and index by Swami Vimalananda."
+          ],
+          "uri": "b10000654",
+          "lccClassification": [
+            "BL1130.A353 V5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirupparaitturai;"
+          ],
+          "titleAlt": [
+            "Vishnu sahasranama stotram.",
+            "Viṣṇusahasranāmastotram."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000654"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783901",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-374"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-374",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417890"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-374"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417890"
+                    ],
+                    "idBarcode": [
+                      "33433060417890"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-000374"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000737",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "44, 56, 36 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Running title: Māmuṉivaṉ tivya sūkti sārārtta mālikai.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Each work has also separate t.p.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Sātāraṇa vaippacittirumūla malariṉ anupantam.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vaishnavism",
+            "Vaishnavism -- Poetry"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "kiṭaikkumiṭam Krantamālā Āpīs]"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vicatavākcikāmaṇikaḷāṉa Maṇavāḷamāmuṉikaḷ aruḷicceyta upatēcarattiṉamālai. Tiruvāymoḻi nūṟṟantāti. Ārttippirapantam."
+          ],
+          "shelfMark": [
+            "*OLY 83-2976"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Maṇavāḷa Māmuṉi, 1370-1444."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "73906525"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Maṇavāḷa Māmuṉi, 1370-1444.",
+            "Annangaracharya, Prativadi Bhayankara, Swami, 1891-"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-2976"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000737"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73906525"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002000146-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00200746"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200736"
+            }
+          ],
+          "idOclc": [
+            "NYPG002000146-B"
+          ],
+          "uniformTitle": [
+            "Upatēcarattiṉamālai"
+          ],
+          "updatedAt": 1674870779642,
+          "publicationStatement": [
+            "[Kāñcīpuram, kiṭaikkumiṭam Krantamālā Āpīs] 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000737",
+            "urn:lccn:73906525",
+            "urn:oclc:NYPG002000146-B",
+            "urn:undefined:NNSZ00200746",
+            "urn:undefined:(WaOLN)nyp0200736"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vaishnavism -- Poetry."
+          ],
+          "titleDisplay": [
+            "Vicatavākcikāmaṇikaḷāṉa Maṇavāḷamāmuṉikaḷ aruḷicceyta upatēcarattiṉamālai. Tiruvāymoḻi nūṟṟantāti. Ārttippirapantam. Aṇṇaṅkarācāryatāsaṉ iyaṟṟiya eḷiya teḷiya uraiyuṭaṉ kūṭiyavai."
+          ],
+          "uri": "b10000737",
+          "lccClassification": [
+            "PL4758.9.M242 U6"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Kāñcīpuram"
+          ],
+          "titleAlt": [
+            "Upatēcarattiṉamālai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000737"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783922",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-2976"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-2976",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060418666"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-2976"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060418666"
+                    ],
+                    "idBarcode": [
+                      "33433060418666"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-002976"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000739",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "968 p. col. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "On cover: Upaniṣad-bhāṣya, sānuvāda, khaṇḍa 3.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit; introductory matter in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Gītā Presa"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1967"
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Chāndogyopaniṣad."
+          ],
+          "shelfMark": [
+            "*OKLB 83-2978"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "idLccn": [
+            "sa 68015169"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Saṅkarācārya."
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKLB 83-2978"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000739"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68015169"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002000148-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00200748"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200738"
+            }
+          ],
+          "idOclc": [
+            "NYPG002000148-B"
+          ],
+          "uniformTitle": [
+            "Upanishads. Chāndogyopaniṣad."
+          ],
+          "dateEndYear": [
+            1967
+          ],
+          "updatedAt": 1674870777259,
+          "publicationStatement": [
+            "Gorakhapura, Gītā Presa [1966 or 7]"
+          ],
+          "identifier": [
+            "urn:bnum:10000739",
+            "urn:lccn:sa 68015169",
+            "urn:oclc:NYPG002000148-B",
+            "urn:undefined:NNSZ00200748",
+            "urn:undefined:(WaOLN)nyp0200738"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Chāndogyopaniṣad. sānuvāda Śaṅkarabhāṣyasahita."
+          ],
+          "uri": "b10000739",
+          "lccClassification": [
+            "PK3521 .C5 1966"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Gorakhapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000739"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783923",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OKLB 83-2978"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKLB 83-2978",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058574710"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKLB 83-2978"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058574710"
+                    ],
+                    "idBarcode": [
+                      "33433058574710"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKLB 83-002978"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000795",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "XV, 453 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Sanskrit or Tamil.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Vālmīki Rāmāyṇam\" (p. 389-453) comprises selected verses from the Valmīki Rāmāyaṇa.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kampar, active 9th century",
+            "Vālmīki"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Es. Sukumār; kiṭaikkumiṭam Pāri Nilaiyam, Ceṉṉai"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kāvya Rāmāyaṇam."
+          ],
+          "shelfMark": [
+            "*OLY 82-1781"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Srinivasan, K. S. (Karur Soundara), 1920-"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72904732"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 82-1781"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000795"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72904732"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002000204-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00200804"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200794"
+            }
+          ],
+          "idOclc": [
+            "NYPG002000204-B"
+          ],
+          "updatedAt": 1674870779642,
+          "publicationStatement": [
+            "[Putu Tilli, Es. Sukumār; kiṭaikkumiṭam Pāri Nilaiyam, Ceṉṉai, 1971]"
+          ],
+          "identifier": [
+            "urn:bnum:10000795",
+            "urn:lccn:72904732",
+            "urn:oclc:NYPG002000204-B",
+            "urn:undefined:NNSZ00200804",
+            "urn:undefined:(WaOLN)nyp0200794"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kampar, active 9th century.",
+            "Vālmīki."
+          ],
+          "titleDisplay": [
+            "Kāvya Rāmāyaṇam. [Eḻutiyavar] Kē. Es. Śrīṉivāsaṉ."
+          ],
+          "uri": "b10000795",
+          "lccClassification": [
+            "PL4758.9.K27 R35695"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Putu Tilli"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000795"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783961",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 82-1781"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 82-1781",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417288"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 82-1781"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417288"
+                    ],
+                    "idBarcode": [
+                      "33433060417288"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 82-001781"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000818",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "190 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 190.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Muḥammad, Prophet, -632"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Azhar, Majmaʻal-Buḥūth al-Islāmīyah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Rasūl, ṣallá Allāh ʻalayhi wa-sallam, lamḁhāt min ̥hayātih .... wa-nafaḥāt min  hadyih"
+          ],
+          "shelfMark": [
+            "*OGE 82-2828"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Maḥmūd, ʻAbd al-Ḥalīm."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "76960922"
+          ],
+          "seriesStatement": [
+            "Silsilat al-buḥūth al-Islāmīyah, al-kitāb 1"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGE 82-2828"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000818"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960922"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002000227-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00200827"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200817"
+            }
+          ],
+          "idOclc": [
+            "NYPG002000227-B"
+          ],
+          "updatedAt": 1674870777259,
+          "publicationStatement": [
+            "[al-Qāhirah] al-Azhar, Majmaʻal-Buḥūth al-Islāmīyah, 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000818",
+            "urn:lccn:76960922",
+            "urn:oclc:NYPG002000227-B",
+            "urn:undefined:NNSZ00200827",
+            "urn:undefined:(WaOLN)nyp0200817"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Muḥammad, Prophet, -632."
+          ],
+          "titleDisplay": [
+            "al-Rasūl, ṣallá Allāh ʻalayhi wa-sallam, lamḁhāt min ̥hayātih .... wa-nafaḥāt min  hadyih [taʻlīf] ʻAbd al-Ḥalīm Maḥmūd."
+          ],
+          "uri": "b10000818",
+          "lccClassification": [
+            "BP75.2 .M32"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[al-Qāhirah]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000818"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858070",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OGE 82-2828"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGE 82-2828",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057993358"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGE 82-2828"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057993358"
+                    ],
+                    "idBarcode": [
+                      "33433057993358"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGE 82-002828"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000912",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "245 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tulasīdāsa, 1532-1623"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Granthama"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tulasī kā mānasa."
+          ],
+          "shelfMark": [
+            "*OLY 83-31"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Sharma, Munshi Ram, 1901-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "72901165"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-31"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000912"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72901165"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002000322-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00200922"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200911"
+            }
+          ],
+          "idOclc": [
+            "NYPG002000322-B"
+          ],
+          "updatedAt": 1674870783590,
+          "publicationStatement": [
+            "Kānapura, Granthama [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000912",
+            "urn:lccn:72901165",
+            "urn:oclc:NYPG002000322-B",
+            "urn:undefined:NNSZ00200922",
+            "urn:undefined:(WaOLN)nyp0200911"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tulasīdāsa, 1532-1623."
+          ],
+          "titleDisplay": [
+            "Tulasī kā mānasa. [Lekhaka] Munśīrāma Śarmā."
+          ],
+          "uri": "b10000912",
+          "lccClassification": [
+            "PK2095.T8 R3394"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kānapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000912"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783983",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-31"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-31",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417726"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-31"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417726"
+                    ],
+                    "idBarcode": [
+                      "33433060417726"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-000031"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001029",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xivi, 400, 52 p., [14] leaves of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil, foreword in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cēsatri, Swami, 1870-1929",
+            "Hindus",
+            "Hindus -- Biography"
+          ],
+          "publisherLiteral": [
+            "Srī Satkuru Cēsātri Svāmikaḷ Matyasta Pracārasapā,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tiruvaṇṇāmalai Srī Cēṣātri Svāmikaḷ carittiram"
+          ],
+          "shelfMark": [
+            "*OLY 83-4924"
+          ],
+          "creatorLiteral": [
+            "Nārāyaṇa Cāstirikal, Kuḻumaṇi."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76902259"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-4924"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001029"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76902259"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201039"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201028"
+            }
+          ],
+          "updatedAt": 1636139596240,
+          "publicationStatement": [
+            "Kōyamputtūr : Srī Satkuru Cēsātri Svāmikaḷ Matyasta Pracārasapā, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10001029",
+            "urn:lccn:76902259",
+            "urn:undefined:NNSZ00201039",
+            "urn:undefined:(WaOLN)nyp0201028"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cēsatri, Swami, 1870-1929.",
+            "Hindus -- Biography."
+          ],
+          "titleDisplay": [
+            "Tiruvaṇṇāmalai Srī Cēṣātri Svāmikaḷ carittiram / eḻutiyatu Kuḻumaṇi Nārāyaṇa Cāstirikaḷ."
+          ],
+          "uri": "b10001029",
+          "lccClassification": [
+            "BL1175.C47 N37 1975"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kōyamputtūr :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10001029"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783994",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-4924"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-4924",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060419664"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-4924"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060419664"
+                    ],
+                    "idBarcode": [
+                      "33433060419664"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-004924"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001042",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "30, 122 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Tarkabhasha & Anekantavadanirasa of Mokshakaragupta and Jitaripad.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Running title: Bauddha-tarkabhāṣā.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit; introductory matter in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Buddhist logic"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Prācya Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mokṣākaraguptaviracitā Bauddha-tarkabhāṣā. Hindīanuvādapariśiṣṭadvayasaṃvalitā."
+          ],
+          "shelfMark": [
+            "*OLWF 83-4679"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Mokṣākara Gupta."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "71901168"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Jitāri, active 940-980.",
+            "Giri, Ragunath."
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLWF 83-4679"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001042"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "71901168"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002000452-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201052"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201041"
+            }
+          ],
+          "idOclc": [
+            "NYPG002000452-B"
+          ],
+          "updatedAt": 1673986529749,
+          "publicationStatement": [
+            "Vārāṇasī, Prācya Prakāśana [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10001042",
+            "urn:lccn:71901168",
+            "urn:oclc:NYPG002000452-B",
+            "urn:undefined:NNSZ00201052",
+            "urn:undefined:(WaOLN)nyp0201041"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Buddhist logic."
+          ],
+          "titleDisplay": [
+            "Mokṣākaraguptaviracitā Bauddha-tarkabhāṣā. Hindīanuvādapariśiṣṭadvayasaṃvalitā. Jitāripādaviracitaḥ Anekāntavādanirāsaḥ, Hindīanuvādasahitaḥ. Sampādakaḥ anuvādakaśca Raghunāthagiriḥ."
+          ],
+          "uri": "b10001042",
+          "lccClassification": [
+            "BC25 .M65"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasī"
+          ],
+          "titleAlt": [
+            "Bauddha-tarkabhāṣā.",
+            "Tarkabhasha.",
+            "Anekantavadanirasa."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10001042"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783998",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLWF 83-4679"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLWF 83-4679",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059862981"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLWF 83-4679"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059862981"
+                    ],
+                    "idBarcode": [
+                      "33433059862981"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLWF 83-004679"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001083",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "9, 142 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Text in Sanskrit; prefatory matter in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jaina logic"
+          ],
+          "publisherLiteral": [
+            "Bhāratīya Prācyatatva-Prakāśana Samiti ; prāptisthāna, Śā. Ramaṇala Vajecanda,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "1975"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vādasaṅgraha"
+          ],
+          "shelfMark": [
+            "*OLX 84-289"
+          ],
+          "creatorLiteral": [
+            "Yaśovijaya, 1624-1688."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "76902374"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLX 84-289"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001083"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76902374"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201094"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201082"
+            }
+          ],
+          "dateEndYear": [
+            1975
+          ],
+          "updatedAt": 1636143035644,
+          "publicationStatement": [
+            "Pindabāṛā : Bhāratīya Prācyatatva-Prakāśana Samiti ; Ȧhamadābāda : prāptisthāna, Śā. Ramaṇala Vajecanda, Vikrama Saṃ 2031 [1974 or 1975]"
+          ],
+          "identifier": [
+            "urn:bnum:10001083",
+            "urn:lccn:76902374",
+            "urn:undefined:NNSZ00201094",
+            "urn:undefined:(WaOLN)nyp0201082"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jaina logic."
+          ],
+          "titleDisplay": [
+            "Vādasaṅgraha / Yaśovijayopādhyāyaviracita."
+          ],
+          "uri": "b10001083",
+          "lccClassification": [
+            "BC25 .Y38"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Pindabāṛā : Ȧhamadābāda :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10001083"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLX 84-289"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLX 84-289",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060359589"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLX 84-289"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060359589"
+                    ],
+                    "idBarcode": [
+                      "33433060359589"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLX 84-000289"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001094",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 v. : ports. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Church history",
+            "Coptic church",
+            "Coptic church -- History"
+          ],
+          "publisherLiteral": [
+            "Maktabat al-Maḥabbah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Kharīdah al-nafīsah fī tārīkh al-kanīsah"
+          ],
+          "shelfMark": [
+            "*OCF 81-3103"
+          ],
+          "creatorLiteral": [
+            "Īsīdhūrūs, Bishop, 1867-1942."
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "contributorLiteral": [
+            "Arsānyūs al-Muḥarraqī."
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OCF 81-3103"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001094"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201106"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201093"
+            }
+          ],
+          "updatedAt": 1636072387033,
+          "publicationStatement": [
+            "[S.l.] : Maktabat al-Maḥabbah, 1964"
+          ],
+          "identifier": [
+            "urn:bnum:10001094",
+            "urn:undefined:NNSZ00201106",
+            "urn:undefined:(WaOLN)nyp0201093"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Church history.",
+            "Coptic church -- History."
+          ],
+          "titleDisplay": [
+            "al-Kharīdah al-nafīsah fī tārīkh al-kanīsah / qām bi-ṭabʻihi al-Qummuṣ ʻAṭā Allāh Arsānyūs al-Muḥarraqī ... ʻan al-nuskhah al-aṣlīyah lil-Usquf al-Anbā Īsīdhūrūs."
+          ],
+          "uri": "b10001094",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[S.l.] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10001094"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900431",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017339361"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017339361"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433017339361"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark": [
+                      "*OCF 81-3103"
+                    ],
+                    "shelfMark_sort": "a*OCF 81-003103"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900430",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017339353"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017339353"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433017339353"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark": [
+                      "*OCF 81-3103"
+                    ],
+                    "shelfMark_sort": "a*OCF 81-003103"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001112",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "80 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Muḥammad, Prophet, -632",
+            "Muḥammad, Prophet, -632 -- Prayers and devotions"
+          ],
+          "publisherLiteral": [
+            "Mukhtār Abū al-ʻAzāʼim,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Bashāʼir fī mawlid al-Mukhtār ..."
+          ],
+          "shelfMark": [
+            "*OGE 82-1575"
+          ],
+          "creatorLiteral": [
+            "Abū al-ʻAzāʼim, Muḥammad Māḍī."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "74960195"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGE 82-1575"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001112"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74960195"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201124"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201111"
+            }
+          ],
+          "updatedAt": 1636072366534,
+          "publicationStatement": [
+            "[al. Qāhirah] : Mukhtār Abū al-ʻAzāʼim, [1973]"
+          ],
+          "identifier": [
+            "urn:bnum:10001112",
+            "urn:lccn:74960195",
+            "urn:undefined:NNSZ00201124",
+            "urn:undefined:(WaOLN)nyp0201111"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Muḥammad, Prophet, -632 -- Prayers and devotions."
+          ],
+          "titleDisplay": [
+            "al-Bashāʼir fī mawlid al-Mukhtār ... / lil-sayyid Muḥammad Māḍī Abū al-ʻAzāʼim."
+          ],
+          "uri": "b10001112",
+          "lccClassification": [
+            "BP75.2 .A18"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[al. Qāhirah] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10001112"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858081",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057993127"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057993127"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433057993127"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark": [
+                      "*OGE 82-1575"
+                    ],
+                    "shelfMark_sort": "a*OGE 82-001575"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001164",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "36, 608, 40 p. port."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: The philosophy of oriental music, by Michael Allawerdi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Music, Oriental",
+            "Music, Oriental -- History and criticism"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1950
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Falsafat al-mūsīqá al-Sharqīyah fī asrār al-fann al-ʻArabī, kitāb yunaẓẓim ʻulūm al-mūsīqá wa-yadʻū ilá tawḥīd lughatihā ʻilmīyan"
+          ],
+          "shelfMark": [
+            "JME 82-175"
+          ],
+          "creatorLiteral": [
+            "Allawerdi, Michael."
+          ],
+          "createdString": [
+            "1950"
+          ],
+          "idLccn": [
+            "ne 66001433 /MN"
+          ],
+          "contributorLiteral": [
+            "Otto Kinkeldey Memorial Collection."
+          ],
+          "dateStartYear": [
+            1950
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JME 82-175"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001164"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ne 66001433 /MN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201177"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201163"
+            }
+          ],
+          "updatedAt": 1637345506387,
+          "publicationStatement": [
+            "Dimashq [1950]"
+          ],
+          "identifier": [
+            "urn:bnum:10001164",
+            "urn:lccn:ne 66001433 /MN",
+            "urn:undefined:NNSZ00201177",
+            "urn:undefined:(WaOLN)nyp0201163"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1950"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Music, Oriental -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Falsafat al-mūsīqá al-Sharqīyah fī asrār al-fann al-ʻArabī, kitāb yunaẓẓim ʻulūm al-mūsīqá wa-yadʻū ilá tawḥīd lughatihā ʻilmīyan [+aʼlīf] M. Allāh Wīrdī."
+          ],
+          "uri": "b10001164",
+          "lccClassification": [
+            "ML330. A44"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Dimashq"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Philosophy of oriental music."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10001164"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032678454"
+                    ],
+                    "shelfMark_sort": "aJME 82-000175",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10942096",
+                    "shelfMark": [
+                      "JME 82-175"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032678454"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433032678454"
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433098691227"
+                    ],
+                    "physicalLocation": [
+                      "*OG (Allawerdi. Falsafat al-mūsīqá al-Sharqīyah)"
+                    ],
+                    "shelfMark_sort": "a*OG (Allawerdi. Falsafat al-mūsīqá al-Sharqīyah)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i28274409",
+                    "shelfMark": [
+                      "*OG (Allawerdi. Falsafat al-mūsīqá al-Sharqīyah)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OG (Allawerdi. Falsafat al-mūsīqá al-Sharqīyah)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433098691227"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433098691227"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001190",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "320p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 313-320.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Chinese literature",
+            "Chinese literature -- Qing dynasty, 1644-1912",
+            "Chinese literature -- Qing dynasty, 1644-1912 -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Wen jin chu ban she,"
+          ],
+          "language": [
+            {
+              "id": "lang:chi",
+              "label": "Chinese"
+            }
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tʻung-Chʻeng pʻai wen hsueh shih"
+          ],
+          "shelfMark": [
+            "*OVK 82-796"
+          ],
+          "creatorLiteral": [
+            "Ye, Long."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76838266"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OVK 82-796"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001190"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76838266"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201203"
+            }
+          ],
+          "updatedAt": 1636140614104,
+          "publicationStatement": [
+            "[Taipei] : Wen jin chu ban she, Min'guo 64 [1975]"
+          ],
+          "identifier": [
+            "urn:bnum:10001190",
+            "urn:lccn:76838266",
+            "urn:undefined:NNSZ00201203"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Chinese literature -- Qing dynasty, 1644-1912 -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Tʻung-Chʻeng pʻai wen hsueh shih / Zhu zuo zhe Ye Long."
+          ],
+          "uri": "b10001190",
+          "lccClassification": [
+            "PL2297 .Y4"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Taipei] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10001190"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000788",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OVK 82-796"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OVK 82-796",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011952243"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OVK 82-796"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011952243"
+                    ],
+                    "idBarcode": [
+                      "33433011952243"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OVK 82-000796"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001233",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xviii, 269 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "In Malayalam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Classical Hindu text.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Krishna (Hindu deity)"
+          ],
+          "publisherLiteral": [
+            "Kēraḷa Sāhitya Akkādami ; vitaraṇaṃ, Nāṣanal Bukk Sṯāḷ,"
+          ],
+          "language": [
+            {
+              "id": "lang:mal",
+              "label": "Malayalam"
+            }
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bhāgavataṃ : Irupattināluvrttaṃ"
+          ],
+          "shelfMark": [
+            "*OLY 84-598"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "78900499"
+          ],
+          "contributorLiteral": [
+            "Krṣṇapiḷḷa, Es. En."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 84-598"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001233"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78900499"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201246"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201231"
+            }
+          ],
+          "uniformTitle": [
+            "Puranas. Bhāgavatapurāṇa. Malayalam."
+          ],
+          "updatedAt": 1636077703170,
+          "publicationStatement": [
+            "[Trśūr] : Kēraḷa Sāhitya Akkādami ; Kōṭṭayaṃ : vitaraṇaṃ, Nāṣanal Bukk Sṯāḷ, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10001233",
+            "urn:lccn:78900499",
+            "urn:undefined:NNSZ00201246",
+            "urn:undefined:(WaOLN)nyp0201231"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Krishna (Hindu deity)"
+          ],
+          "titleDisplay": [
+            "Bhāgavataṃ : Irupattināluvrttaṃ"
+          ],
+          "uri": "b10001233",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Trśūr] : Kōṭṭayaṃ :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10001233"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784029",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 84-598"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 84-598",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060419870"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 84-598"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060419870"
+                    ],
+                    "idBarcode": [
+                      "33433060419870"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 84-000598"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001239",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "679 p. : ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ramana, Maharshi"
+          ],
+          "publisherLiteral": [
+            "Śivalāla Agravāla eṇḍa Kampanī"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrī Ramaṇa Maharshi se bātacīta"
+          ],
+          "shelfMark": [
+            "*OLY 82-3982"
+          ],
+          "creatorLiteral": [
+            "Śarma, Dineśacandra."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "contributorLiteral": [
+            "Osbourne, Arthur."
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 82-3982"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001239"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201252"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201237"
+            }
+          ],
+          "updatedAt": 1653404628484,
+          "publicationStatement": [
+            "Āgarā : Śivalāla Agravāla eṇḍa Kampanī, 1979."
+          ],
+          "identifier": [
+            "urn:bnum:10001239",
+            "urn:undefined:NNSZ00201252",
+            "urn:undefined:(WaOLN)nyp0201237"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ramana, Maharshi."
+          ],
+          "titleDisplay": [
+            "Śrī Ramaṇa Maharshi se bātacīta / saṅgrahakartā Śrī Sunagala Esa. Veṅkaṭarāmaiyā ; bhūmikā-lekhaka Dā. Ṭī. Ema. Pī. Mahādevana ; prastāvanā lekhaka Mejara E. Ḍablyū. Caiḍavika ; anuvādaka Srī Dineśacandra Śarmā."
+          ],
+          "uri": "b10001239",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Āgarā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10001239"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 82-3982"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 82-3982",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417494"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 82-3982"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417494"
+                    ],
+                    "idBarcode": [
+                      "33433060417494"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 82-003982"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001240",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[8], 8, lxv, 888 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Introductory matter in English, Hindi, or Sanskrit; extant portion of the autocommentary, Bhāvadīpkā, in Sanskrit.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Title on spine: The Vedānta-kaumudī, with Bhāva-dīpika of Rāmādvayācārya, a critical edition.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Caption title: Śrī Rāmādvayācāryakrtā Vedāntakaumudī.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Advaita",
+            "Bādarāyaṇa"
+          ],
+          "publisherLiteral": [
+            "Kāśī Hindū Viśvavidyālaya Śodhaprakáśana,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vedāntakaumudī; Bhāvadīpikāsaṃvalitā."
+          ],
+          "shelfMark": [
+            "*OKN 84-1977"
+          ],
+          "creatorLiteral": [
+            "Rāmādvaya, active 14th century."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "74903417"
+          ],
+          "seriesStatement": [
+            "Kāśī Hindū Viśvavidyālaya Saṃskrtagranthamālā, puṣpa 9",
+            "Śodhaprakāśanayojanā"
+          ],
+          "contributorLiteral": [
+            "Caturvedī, Rādheśyāma, 1940-",
+            "Rāmādvaya, active 14th century."
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 84-1977"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001240"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903417"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201253"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201238"
+            }
+          ],
+          "uniformTitle": [
+            "Vedāntakaumudī. Hindi & Sanskrit."
+          ],
+          "updatedAt": 1641393543446,
+          "publicationStatement": [
+            "Vārāṇasī] Kāśī Hindū Viśvavidyālaya Śodhaprakáśana, 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10001240",
+            "urn:lccn:74903417",
+            "urn:undefined:NNSZ00201253",
+            "urn:undefined:(WaOLN)nyp0201238"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Advaita.",
+            "Bādarāyaṇa."
+          ],
+          "titleDisplay": [
+            "Vedāntakaumudī; Bhāvadīpikāsaṃvalitā. [Sampādaka, anuvādaka, tathā ṭippaṇīkāra] Rādheśyāma Caturvedī."
+          ],
+          "uri": "b10001240",
+          "lccClassification": [
+            "B132.A3 R2815"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasī]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Vedāntakaumudī."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10001240"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618418"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618418"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058618418"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark": [
+                      "*OKN 84-1977"
+                    ],
+                    "shelfMark_sort": "a*OKN 84-001977"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001310",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "44 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hinduism",
+            "Hinduism -- Controversial literature",
+            "Tamil (Indic people)",
+            "Tamil (Indic people) -- Religion",
+            "Tiruvaḷḷuvar"
+          ],
+          "publisherLiteral": [
+            "Tamiḻaṉ Nilaiyam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nāṉ Intu alla, eṉatu matam Tiruvaḷḷuvam."
+          ],
+          "shelfMark": [
+            "*OLY 83-1642"
+          ],
+          "creatorLiteral": [
+            "Kiruṣṇaṉ, P."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "73903976"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-1642"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001310"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73903976"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201324"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201308"
+            }
+          ],
+          "updatedAt": 1636119343632,
+          "publicationStatement": [
+            "Karūr, Tirucci Māvaṭṭam, Tamiḻaṉ Nilaiyam [1971]"
+          ],
+          "identifier": [
+            "urn:bnum:10001310",
+            "urn:lccn:73903976",
+            "urn:undefined:NNSZ00201324",
+            "urn:undefined:(WaOLN)nyp0201308"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hinduism -- Controversial literature.",
+            "Tamil (Indic people) -- Religion.",
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Nāṉ Intu alla, eṉatu matam Tiruvaḷḷuvam. [Eḻutiyavar]Pe. Kiruṣṇaṉ."
+          ],
+          "uri": "b10001310",
+          "lccClassification": [
+            "BL1211 .K57"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Karūr, Tirucci Māvaṭṭam,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10001310"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784058",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-1642"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-1642",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060418260"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-1642"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060418260"
+                    ],
+                    "idBarcode": [
+                      "33433060418260"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-001642"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001316",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxvi. 90 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Parvati (Hindu deity)",
+            "Parvati (Hindu deity) -- Poetry"
+          ],
+          "publisherLiteral": [
+            "Amuta Nilaiyam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Apirāmi antāti."
+          ],
+          "shelfMark": [
+            "*OLY 83-1631"
+          ],
+          "creatorLiteral": [
+            "Apirāmi Paṭṭar, active 18th century."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "77904332"
+          ],
+          "seriesStatement": [
+            "Amutam, 171"
+          ],
+          "contributorLiteral": [
+            "Jakannātaṉ, Ki. Vā., 1906-"
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-1631"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001316"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77904332"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201330"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201314"
+            }
+          ],
+          "updatedAt": 1641330883378,
+          "publicationStatement": [
+            "Ceṉṉai, Amuta Nilaiyam [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10001316",
+            "urn:lccn:77904332",
+            "urn:undefined:NNSZ00201330",
+            "urn:undefined:(WaOLN)nyp0201314"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Parvati (Hindu deity) -- Poetry."
+          ],
+          "titleDisplay": [
+            "Apirāmi antāti. Āciriyar Apirāmi Paṭṭar. Urai Āciriyar Ki. Vā. Jakannātaṉ."
+          ],
+          "uri": "b10001316",
+          "lccClassification": [
+            "PL4758.9.A6 A8 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10001316"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784062",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-1631"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-1631",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060418252"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-1631"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060418252"
+                    ],
+                    "idBarcode": [
+                      "33433060418252"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-001631"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001351",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "92 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Murugan (Hindu deity)",
+            "Murugan (Hindu deity) -- Poetry"
+          ],
+          "publisherLiteral": [
+            "Vācuki Patippakam] ; viṟpaṉai urimai, Pāri Nilaiyam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Paḻaṉiyāṉ kātal"
+          ],
+          "shelfMark": [
+            "*OLY 84-1362"
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "77910693"
+          ],
+          "seriesStatement": [
+            "Vācuki patippaka veḷiyīṭu 3"
+          ],
+          "contributorLiteral": [
+            "Kōvintacāmi, M."
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 84-1362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001351"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77910693"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201367"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201349"
+            }
+          ],
+          "updatedAt": 1636121455901,
+          "publicationStatement": [
+            "[Aṇṇāmalainakar : Vācuki Patippakam] ; Ceṉṉai : viṟpaṉai urimai, Pāri Nilaiyam, [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10001351",
+            "urn:lccn:77910693",
+            "urn:undefined:NNSZ00201367",
+            "urn:undefined:(WaOLN)nyp0201349"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Murugan (Hindu deity) -- Poetry."
+          ],
+          "titleDisplay": [
+            "Paḻaṉiyāṉ kātal / patippāciriyar Mu. Kōvintacāmi."
+          ],
+          "uri": "b10001351",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Aṇṇāmalainakar : Ceṉṉai :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10001351"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784068",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 84-1362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 84-1362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060419987"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 84-1362"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060419987"
+                    ],
+                    "idBarcode": [
+                      "33433060419987"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 84-001362"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001374",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "18, 316 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hinduism",
+            "Hinduism -- Rituals"
+          ],
+          "publisherLiteral": [
+            "[Director, Research Institute, Varanaseya Sanskrit Vishvavidyalaya]"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1963
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Saṃskāradīpakaḥ,"
+          ],
+          "shelfMark": [
+            "*OLY 83-204"
+          ],
+          "creatorLiteral": [
+            "Jhā, Harṣanātha, 1845-1896."
+          ],
+          "createdString": [
+            "1963"
+          ],
+          "idLccn": [
+            "sa 68001970"
+          ],
+          "seriesStatement": [
+            "Varanaseya Sanskrit Vishwavidyalaya. Research Institute. Gopīnāthakavirāja- granthamālā, 1"
+          ],
+          "contributorLiteral": [
+            "Jhā, Durgādhara, 1909-1987.",
+            "Khanaṇga, Rāmacandraśāstrī."
+          ],
+          "dateStartYear": [
+            1963
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-204"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001374"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68001970"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201390"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201372"
+            }
+          ],
+          "updatedAt": 1636128327571,
+          "publicationStatement": [
+            "Vārāṇasyām, [Director, Research Institute, Varanaseya Sanskrit Vishvavidyalaya] 1885 tame Śakābde [1963]"
+          ],
+          "identifier": [
+            "urn:bnum:10001374",
+            "urn:lccn:sa 68001970",
+            "urn:undefined:NNSZ00201390",
+            "urn:undefined:(WaOLN)nyp0201372"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1963"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hinduism -- Rituals."
+          ],
+          "titleDisplay": [
+            "Saṃskāradīpakaḥ, Mahāmahopādhyāyaśrī harṣanāthajhāviracitaḥ. Śrīrāmacandraśāstrikhanaṅgakrtaṭippaṇībhiḥ pariṣkrtaḥ. Sampādakaḥ Srīdurgādharajhā."
+          ],
+          "uri": "b10001374",
+          "lccClassification": [
+            "BL1226.2 .J46"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasyām,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10001374"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784073",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-204"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-204",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417882"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-204"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417882"
+                    ],
+                    "idBarcode": [
+                      "33433060417882"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-000204"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001378",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "7, 367 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Siva (Hindu deity)"
+          ],
+          "publisherLiteral": [
+            "Vācu Piracuram"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrī Liṅka purāṇam."
+          ],
+          "shelfMark": [
+            "*OLY 83-1666"
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "77904612"
+          ],
+          "contributorLiteral": [
+            "Ramanathan, S., 1931-"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-1666"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001378"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77904612"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201394"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201376"
+            }
+          ],
+          "uniformTitle": [
+            "Puranas. Liṅgapurāṇa. Tamil."
+          ],
+          "updatedAt": 1653404628484,
+          "publicationStatement": [
+            "Ceṉṉai, Vācu Piracuram [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10001378",
+            "urn:lccn:77904612",
+            "urn:undefined:NNSZ00201394",
+            "urn:undefined:(WaOLN)nyp0201376"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Siva (Hindu deity)"
+          ],
+          "titleDisplay": [
+            "Śrī Liṅka purāṇam. [Moḻipeyarppāciriyar] Kārttikēyaṉ."
+          ],
+          "uri": "b10001378",
+          "lccClassification": [
+            "BL1218 .P86"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10001378"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784074",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-1666"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-1666",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060418278"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-1666"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060418278"
+                    ],
+                    "idBarcode": [
+                      "33433060418278"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-001666"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001379",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "12, 197 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes the commentary Ālokaprakāśa, by C.K. Raman Nambia and others.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Naya"
+          ],
+          "publisherLiteral": [
+            "[Director, Research Institute, Varanaseya Sanskrit Vishvavidyalaya; Prāptisthānam: Prakāśanavibhāgaḥ, Vārāṇaseyasaṃskṛta viśvavidyālayaḥ]"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʻNa caʼ ratnamālikā; Svopajñanūtanālokaṭīkāsamvalitā"
+          ],
+          "shelfMark": [
+            "*OKM 83-1701"
+          ],
+          "creatorLiteral": [
+            "Sarmā, Sāstṛ."
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "sa 68010892"
+          ],
+          "seriesStatement": [
+            "Saravati Bhavana granthamala, 93"
+          ],
+          "contributorLiteral": [
+            "Raman Nambiar, C. K."
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKM 83-1701"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001379"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68010892"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201395"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201377"
+            }
+          ],
+          "updatedAt": 1653404628484,
+          "publicationStatement": [
+            "Vārāṇasyām [Director, Research Institute, Varanaseya Sanskrit Vishvavidyalaya; Prāptisthānam: Prakāśanavibhāgaḥ, Vārāṇaseyasaṃskṛta viśvavidyālayaḥ] 1887 tame śakābde [1965]"
+          ],
+          "identifier": [
+            "urn:bnum:10001379",
+            "urn:lccn:sa 68010892",
+            "urn:undefined:NNSZ00201395",
+            "urn:undefined:(WaOLN)nyp0201377"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Naya."
+          ],
+          "titleDisplay": [
+            "ʻNa caʼ ratnamālikā; Svopajñanūtanālokaṭīkāsamvalitā, Śrīśāstṛśarmaṇā viracitā granthakāraśiṣyaiḥ saṃkalitayā ālokaprakāśaṭippaṇyopab̄rhita ca."
+          ],
+          "uri": "b10001379",
+          "lccClassification": [
+            "B132.N8 S2"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasyām"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10001379"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784075",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058602826"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058602826"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433058602826"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark": [
+                      "*OKM 83-1701"
+                    ],
+                    "shelfMark_sort": "a*OKM 83-001701"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001388",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "36 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Originally broadcast over All India Radio, Madras.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Without the music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Songs, Tamil",
+            "Songs, Tamil -- Texts",
+            "Parvati (Hindu deity)",
+            "Parvati (Hindu deity) -- Songs and music"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrī Tēvi Mahātmiyam; kīrttaṉaikaḷ."
+          ],
+          "shelfMark": [
+            "*OLY 83-1674"
+          ],
+          "creatorLiteral": [
+            "Thiagarajan, K. C."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "70903904"
+          ],
+          "contributorLiteral": [
+            "All India Radio."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-1674"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001388"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "70903904"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201404"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201386"
+            }
+          ],
+          "updatedAt": 1653404628484,
+          "publicationStatement": [
+            "[Ceṉṉai, 1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10001388",
+            "urn:lccn:70903904",
+            "urn:undefined:NNSZ00201404",
+            "urn:undefined:(WaOLN)nyp0201386"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Songs, Tamil -- Texts.",
+            "Parvati (Hindu deity) -- Songs and music."
+          ],
+          "titleDisplay": [
+            "Śrī Tēvi Mahātmiyam; kīrttaṉaikaḷ. Ākkiyōṉ Kē. Si. Tiyākarājaṉ."
+          ],
+          "uri": "b10001388",
+          "lccClassification": [
+            "M1808.T53 S7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10001388"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784080",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-1674"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-1674",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060418286"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-1674"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060418286"
+                    ],
+                    "idBarcode": [
+                      "33433060418286"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-001674"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-109e5949184ed4c9a759adee9011a617.json
+++ b/test/fixtures/query-109e5949184ed4c9a759adee9011a617.json
@@ -1,0 +1,918 @@
+{
+  "took": 147,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.903906,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.903906,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-162ff7c4bd1c5369230bc5ae37426355.json
+++ b/test/fixtures/query-162ff7c4bd1c5369230bc5ae37426355.json
@@ -1,0 +1,27 @@
+{
+  "took": 13,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 0,
+    "hits": []
+  },
+  "aggregations": {
+    "statuses": {
+      "doc_count": 19,
+      "nonrecap_statuses": {
+        "doc_count": 0,
+        "nonrecap_status_buckets": {
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+          "buckets": []
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/query-19c0e61554957fe6e96acd883be4d994.json
+++ b/test/fixtures/query-19c0e61554957fe6e96acd883be4d994.json
@@ -1,0 +1,14078 @@
+{
+  "took": 1897,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 17464952,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Stauffenburg"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Gmelin, Hermann, 1900-1958.",
+            "Baum, Richard.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGNYPG-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "idOclc": [
+            "NYPGNYPG-B"
+          ],
+          "updatedAt": 1678937667178,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:oclc:NYPGNYPG-B",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen"
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "3923721544"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000003",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. : col. ill. maps ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrides (Scotland)",
+            "Hebrides (Scotland) -- Pictorial works"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Constable"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1989
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Scottish islands"
+          ],
+          "shelfMark": [
+            "JFF 89-526"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Waite, Charlie."
+          ],
+          "createdString": [
+            "1989"
+          ],
+          "idLccn": [
+            "gb 89012970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1989
+          ],
+          "donor": [
+            "Gift of the Drue Heinz Book Fund for English Literature"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 89-526"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000003"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0094675708 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "gb 89012970"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGUKBPGP8917-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200002"
+            }
+          ],
+          "idOclc": [
+            "NYPGUKBPGP8917-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Constable, 1989."
+          ],
+          "identifier": [
+            "urn:bnum:10000003",
+            "urn:isbn:0094675708 :",
+            "urn:lccn:gb 89012970",
+            "urn:oclc:NYPGUKBPGP8917-B",
+            "urn:undefined:(WaOLN)nyp0200002"
+          ],
+          "idIsbn": [
+            "0094675708 "
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1989"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrides (Scotland) -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Scottish islands / Charlie Waite."
+          ],
+          "uri": "b10000003",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0094675708"
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000003"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 89-526"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 89-526",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050409147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 89-526"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050409147"
+                    ],
+                    "idBarcode": [
+                      "33433050409147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFF 89-000526"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000004",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "23, 216 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1956.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mutaṟkuṟaḷ uvamai."
+          ],
+          "shelfMark": [
+            "*OLB 84-1934"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kothandapani Pillai, K., 1896-"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "74915265"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1247"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1934"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000004"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74915265"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200003"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tirunelvēli, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1965."
+          ],
+          "identifier": [
+            "urn:bnum:10000004",
+            "urn:lccn:74915265",
+            "urn:oclc:NYPG001000001-B",
+            "urn:undefined:NNSZ00100001",
+            "urn:undefined:(WaOLN)nyp0200003"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Mutaṟkuṟaḷ uvamai. Āciriyar Ku. Kōtaṇṭapāṇi Piḷḷai."
+          ],
+          "uri": "b10000004",
+          "lccClassification": [
+            "PL4758.9.T5 K6 1965"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirunelvēli"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000004"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783781",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1934",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1934"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301556"
+                    ],
+                    "idBarcode": [
+                      "33433061301556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001934"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000005",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (43 p.) + 1 part (12 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Acc. arr. for piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Soch. 22\"--Caption.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: 11049.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Concertos (Violin)",
+            "Concertos (Violin) -- Solo with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muzyka"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom"
+          ],
+          "shelfMark": [
+            "JMF 83-336"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Wieniawski, Henri, 1835-1880."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-336"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000005"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "11049. Muzyka"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100551"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200004"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-C"
+          ],
+          "uniformTitle": [
+            "Concertos, violin, orchestra, no. 2, op. 22, D minor; arranged"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Moskva : Muzyka, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000005",
+            "urn:oclc:NYPG001000001-C",
+            "urn:undefined:11049. Muzyka",
+            "urn:undefined:NNSZ00100551",
+            "urn:undefined:(WaOLN)nyp0200004"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Concertos (Violin) -- Solo with piano."
+          ],
+          "titleDisplay": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom / G. Ven︠i︡avskiĭ ; klavir."
+          ],
+          "uri": "b10000005",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Moskva"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Concertos, no. 2, op. 22"
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10000005"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942022",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-336"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-336",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032711909"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-336"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032711909"
+                    ],
+                    "idBarcode": [
+                      "33433032711909"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000336"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000006",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "227 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of The reconstruction of religious thought in Islam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām"
+          ],
+          "shelfMark": [
+            "*OGC 84-1984"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Iqbal, Muhammad, Sir, 1877-1938."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75962707"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Maḥmūd, ʻAbbās."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1984"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000006"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75962707"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100002"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200005"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "al-Qāhirah, Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000006",
+            "urn:lccn:75962707",
+            "urn:oclc:NYPG001000002-B",
+            "urn:undefined:NNSZ00100002",
+            "urn:undefined:(WaOLN)nyp0200005"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām, taʼlif Muhammad Iqbāl. Tarjamat ʻAbbās Maḥmūd. Rājaʻa muqaddimatahu wa-al-faṣl al-awwal minhu ʻAbd al-ʻAzīz al-Maraghī, wa-rājaʻa baqīyat al-Kitāb Mahdī ʻAllām."
+          ],
+          "uri": "b10000006",
+          "lccClassification": [
+            "BP161 .I712 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000006"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691665"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1984"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691665"
+                    ],
+                    "idBarcode": [
+                      "33433022691665"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001984"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 7:35.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: Z.8917.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Guitar music",
+            "Guitar",
+            "Guitar -- Studies and exercises"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Editio Musica"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Due studi per chitarra"
+          ],
+          "shelfMark": [
+            "JMG 83-276"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Patachich, Iván."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000007"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Z.8917. Editio Musica"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100552"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200006"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-C"
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Budapest : Editio Musica, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000007",
+            "urn:oclc:NYPG001000002-C",
+            "urn:undefined:Z.8917. Editio Musica",
+            "urn:undefined:NNSZ00100552",
+            "urn:undefined:(WaOLN)nyp0200006"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Guitar music.",
+            "Guitar -- Studies and exercises."
+          ],
+          "titleDisplay": [
+            "Due studi per chitarra / Patachich Iván."
+          ],
+          "uri": "b10000007",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Budapest"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies"
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000007"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942023",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-276"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-276",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883591"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-276"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883591"
+                    ],
+                    "idBarcode": [
+                      "33433032883591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000276"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000008",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "351 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Parimaḷam Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṇṇāviṉ ciṟukataikaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1986"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Annadurai, C. N., 1909-1969."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913998"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1986"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000008"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913998"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100003"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200007"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Parimaḷam Patippakam [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000008",
+            "urn:lccn:72913998",
+            "urn:oclc:NYPG001000003-B",
+            "urn:undefined:NNSZ00100003",
+            "urn:undefined:(WaOLN)nyp0200007"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Aṇṇāviṉ ciṟukataikaḷ. [Eḻutiyavar] Ci. Eṉ. Aṇṇāturai."
+          ],
+          "uri": "b10000008",
+          "lccClassification": [
+            "PL4758.9.A5 A84"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000008"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783782",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1986",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301689"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1986"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301689"
+                    ],
+                    "idBarcode": [
+                      "33433061301689"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001986"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000009",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "30 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Edition Peters Nr. 5489.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: E.P. 13028.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Edition Peters ; C.F. Peters"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Miniaturen II : 13 kleine Klavierstücke"
+          ],
+          "shelfMark": [
+            "JMG 83-278"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Golle, Jürgen, 1942-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-278"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000009"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters Nr. 5489 Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "E.P. 13028. Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200008"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-C"
+          ],
+          "uniformTitle": [
+            "Miniaturen, no. 2"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Leipzig : Edition Peters ; New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000009",
+            "urn:oclc:NYPG001000003-C",
+            "urn:undefined:Edition Peters Nr. 5489 Edition Peters",
+            "urn:undefined:E.P. 13028. Edition Peters",
+            "urn:undefined:NNSZ00100553",
+            "urn:undefined:(WaOLN)nyp0200008"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Miniaturen II : 13 kleine Klavierstücke / Jürgen Golle."
+          ],
+          "uri": "b10000009",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig : New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen, no. 2"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000009"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942024",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-278"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-278",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883617"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-278"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883617"
+                    ],
+                    "idBarcode": [
+                      "33433032883617"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000278"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000010",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "110 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cēkkiḻār, active 12th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaikkaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1938"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Irācamāṇikkaṉār, Mā., 1907-1967."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913466"
+          ],
+          "seriesStatement": [
+            "Corṇammāḷ corpoḻivu varicai, 6"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1938"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100004"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200009"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Aṇṇāmalainakar, Aṇṇāmalaip Palkalaikkaḻakam, 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000010",
+            "urn:lccn:72913466",
+            "urn:oclc:NYPG001000004-B",
+            "urn:undefined:NNSZ00100004",
+            "urn:undefined:(WaOLN)nyp0200009"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cēkkiḻār, active 12th century."
+          ],
+          "titleDisplay": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ. [Āṟṟiyavar] Mā. Irācamāṇikkaṉār."
+          ],
+          "uri": "b10000010",
+          "lccClassification": [
+            "PL4758.9.C385 Z8"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Aṇṇāmalainakar"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000010"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783783",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1938",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301598"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1938"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301598"
+                    ],
+                    "idBarcode": [
+                      "33433061301598"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001938"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "46 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)",
+            "Easter music (Organ)",
+            "Passion music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Boeijenga"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1982"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Passie en pasen : suite voor orgel, opus 50"
+          ],
+          "shelfMark": [
+            "JMG 83-279"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Berg, Jan J. van den."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-279"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000011"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200010"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-C"
+          ],
+          "dateEndYear": [
+            1982
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Sneek [Netherlands] : Boeijenga, [between 1976 and 1982]."
+          ],
+          "identifier": [
+            "urn:bnum:10000011",
+            "urn:oclc:NYPG001000004-C",
+            "urn:undefined:(WaOLN)nyp0200010"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)",
+            "Easter music (Organ)",
+            "Passion music."
+          ],
+          "titleDisplay": [
+            "Passie en pasen : suite voor orgel, opus 50 / door Jan J. van den Berg."
+          ],
+          "uri": "b10000011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Sneek [Netherlands]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Passie. I. Psalm 22. II. Leer mij O Heer. III. \"Mijn Verlosser hangt aan 't kruis.\" IV. \"O hoofd vol bloed en wonden.\" V. \"O kostbaar kruis.\" VI. \"Jezus, leven van mijn leven\" -- Pasen. VII. Toccata over \"Christus is opgestanden.\" VIII. Canon: \"Jesus unser Trost und Leben.\" IX. Trio: Ik zeg het allen dat Hij leeft.\" X. Trio: \"Staakt Uw rouwen Magdalene.\" XI. Postludium over \"Jesus leeft en wij met Hem\" (met \"Christus onze Heer verrees\" als tegenstem)."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000011"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942025",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-279"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-279",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883625"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-279"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883625"
+                    ],
+                    "idBarcode": [
+                      "33433032883625"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000279"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "223 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p.221.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Thaqāfah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi"
+          ],
+          "shelfMark": [
+            "*OFS 84-1997"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ḥāwī, Īlīyā Salīm."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 84-1997"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200011"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Thaqāfah, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000012",
+            "urn:oclc:NYPG001000005-B",
+            "urn:undefined:NNSZ00100005",
+            "urn:undefined:(WaOLN)nyp0200011"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "titleDisplay": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi / bi-qalam Īlīyā Ḥāwī."
+          ],
+          "uri": "b10000012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000012"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000003",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 84-1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514719"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 84-1997"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514719"
+                    ],
+                    "idBarcode": [
+                      "33433014514719"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFS 84-001997"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000013",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "32 p. of music : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Popular music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Arr. for piano with chord symbols; superlinear German words.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Popular music -- Germany (East)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Harth Musik Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "shelfMark": [
+            "JMF 83-366"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-366"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000013"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100555"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200012"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Leipzig : Harth Musik Verlag, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000013",
+            "urn:oclc:NYPG001000005-C",
+            "urn:undefined:NNSZ00100555",
+            "urn:undefined:(WaOLN)nyp0200012"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Popular music -- Germany (East)"
+          ],
+          "titleDisplay": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "uri": "b10000013",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Disko Treff eins."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000013"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942026",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-366"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-366",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032712204"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-366"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032712204"
+                    ],
+                    "idBarcode": [
+                      "33433032712204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000366"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000014",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "520 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on cover: Islamic unity or the Mutual approach among Muslim sects.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Panislamism",
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muʼassasat al-Aʻlamī lil-Maṭbūʻāt"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah"
+          ],
+          "shelfMark": [
+            "*OGC 84-1996"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Shīrāzī, ʻAbd al-Karīm Bī Āzār."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1996"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000014"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100006"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200013"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Muʼassasat al-Aʻlamī lil-Maṭbūʻāt, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000014",
+            "urn:oclc:NYPG001000006-B",
+            "urn:undefined:NNSZ00100006",
+            "urn:undefined:(WaOLN)nyp0200013"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Panislamism.",
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah / Jamʻ wa-tartīb ʻAbd al-Karīm Bī Āzār al-Shīrāzī."
+          ],
+          "uri": "b10000014",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Islamic unity."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000014"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691780"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1996"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691780"
+                    ],
+                    "idBarcode": [
+                      "33433022691780"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001996"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000015",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "25 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For organ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"A McAfee Music Publication.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: DM 220.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Belwin-Mills"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Suite no. 1 : 1977"
+          ],
+          "shelfMark": [
+            "JNG 83-102"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hampton, Calvin."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNG 83-102"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000015"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "DM 220. Belwin-Mills"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100556"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200014"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-C"
+          ],
+          "uniformTitle": [
+            "Suite, organ, no. 1"
+          ],
+          "updatedAt": 1678726416948,
+          "publicationStatement": [
+            "Melville, NY : Belwin-Mills, [1980?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000015",
+            "urn:oclc:NYPG001000006-C",
+            "urn:undefined:DM 220. Belwin-Mills",
+            "urn:undefined:NNSZ00100556",
+            "urn:undefined:(WaOLN)nyp0200014"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)"
+          ],
+          "titleDisplay": [
+            "Suite no. 1 : 1977 / Calvin Hampton."
+          ],
+          "uri": "b10000015",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Melville, NY"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Suite, no. 1"
+          ],
+          "tableOfContents": [
+            "Fanfares -- Antiphon -- Toccata."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000015"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000016",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "111 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuṟuntokai"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Manṅkaḷa Nūlakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nalla Kuṟuntokaiyil nāṉilam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1937"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Cellappaṉ, Cilampoli, 1929-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "74913402"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1937"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000016"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74913402"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200015"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Ceṉṉai, Manṅkaḷa Nūlakam, 1959 [i.e. 1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000016",
+            "urn:lccn:74913402",
+            "urn:oclc:NYPG001000007-B",
+            "urn:undefined:NNSZ00100007",
+            "urn:undefined:(WaOLN)nyp0200015"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuṟuntokai."
+          ],
+          "titleDisplay": [
+            "Nalla Kuṟuntokaiyil nāṉilam. [Eḻutiyavar] Cu. Cellappaṉ."
+          ],
+          "uri": "b10000016",
+          "lccClassification": [
+            "PL4758.9.K794 Z6 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000016"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783785",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1937",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301580"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1937"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301580"
+                    ],
+                    "idBarcode": [
+                      "33433061301580"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001937"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000017",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (17 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For baritone and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Words printed also as text.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 3:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Corbière, Tristan, 1845-1875",
+            "Corbière, Tristan, 1845-1875 -- Musical settings",
+            "Songs (Medium voice) with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lettre du Mexique : pour baryton et piano, 1942"
+          ],
+          "shelfMark": [
+            "JMG 83-395"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Escher, Rudolf."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Corbière, Tristan, 1845-1875."
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000017"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100557"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200016"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000017",
+            "urn:oclc:NYPG001000007-C",
+            "urn:undefined:NNSZ00100557",
+            "urn:undefined:(WaOLN)nyp0200016"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Corbière, Tristan, 1845-1875 -- Musical settings.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "Lettre du Mexique : pour baryton et piano, 1942 / Rudolf Escher ; poème de Tristan Corbière."
+          ],
+          "uri": "b10000017",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000017"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-395"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-395",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032735007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-395"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032735007"
+                    ],
+                    "idBarcode": [
+                      "33433032735007"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000395"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "68 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Lebanon"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Ṭalīʻah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā"
+          ],
+          "shelfMark": [
+            "*OFX 84-1995"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Bashshūr, Najlāʼ Naṣīr."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "78970449"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1995"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000018"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78970449"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100008"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200017"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Ṭalīʻah, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000018",
+            "urn:lccn:78970449",
+            "urn:oclc:NYPG001000008-B",
+            "urn:undefined:NNSZ00100008",
+            "urn:undefined:(WaOLN)nyp0200017"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Lebanon."
+          ],
+          "titleDisplay": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā / Najlāʼ Naṣīr Bashshūr."
+          ],
+          "uri": "b10000018",
+          "lccClassification": [
+            "HQ1728 .B37"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000018"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000004",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1995"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031718"
+                    ],
+                    "idBarcode": [
+                      "33433002031718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001995"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000019",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: M 18.487.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Waltzes (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zwölf Walzer und ein Epilog : für Klavier"
+          ],
+          "shelfMark": [
+            "JMG 83-111"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Benary, Peter."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-111"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000019"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Möseler M 18.487."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200018"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-C"
+          ],
+          "uniformTitle": [
+            "Walzer und ein Epilog"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000019",
+            "urn:oclc:NYPG001000008-C",
+            "urn:undefined:Möseler M 18.487.",
+            "urn:undefined:NNSZ00100558",
+            "urn:undefined:(WaOLN)nyp0200018"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Waltzes (Piano)"
+          ],
+          "titleDisplay": [
+            "Zwölf Walzer und ein Epilog : für Klavier / Peter Benary."
+          ],
+          "uri": "b10000019",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Walzer und ein Epilog",
+            "Walzer und ein Epilog."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000019"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942028",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-111"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-111",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-111"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845053"
+                    ],
+                    "idBarcode": [
+                      "33433032845053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000111"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000020",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 172, 320 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tolkāppiyar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaik Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tolkāppiyam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1936"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "creatorLiteral": [
+            "Veḷḷaivāraṇaṉ, Ka."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "74914844"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1936"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000020"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74914844"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200019"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "[Aṇṇāmalainakar] Aṇṇāmalaip Palkalaik Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000020",
+            "urn:lccn:74914844",
+            "urn:oclc:NYPG001000009-B",
+            "urn:undefined:NNSZ00100009",
+            "urn:undefined:(WaOLN)nyp0200019"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tolkāppiyar."
+          ],
+          "titleDisplay": [
+            "Tolkāppiyam. [Eḻutiyavar] Ka. Veḷḷaivāraṇaṉ."
+          ],
+          "uri": "b10000020",
+          "lccClassification": [
+            "PL4754.T583 V4 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Aṇṇāmalainakar]"
+          ],
+          "titleAlt": [
+            "Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Tolkāppiyam.--Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000020"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783786",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1936 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1936 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301572"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1936"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301572"
+                    ],
+                    "idBarcode": [
+                      "33433061301572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-1936 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000021",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (51 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: NM 384.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Verlag Neue Musik"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aurora : sinfonischer Prolog : Partitur"
+          ],
+          "shelfMark": [
+            "JMG 83-113"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Weitzendorf, Heinz."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-113"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000021"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NM 384. Verlag Neue Musik"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100559"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200020"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-C"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Berlin : Verlag Neue Musik, c1978."
+          ],
+          "identifier": [
+            "urn:bnum:10000021",
+            "urn:oclc:NYPG001000009-C",
+            "urn:undefined:NM 384. Verlag Neue Musik",
+            "urn:undefined:NNSZ00100559",
+            "urn:undefined:(WaOLN)nyp0200020"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "Aurora : sinfonischer Prolog : Partitur / Heinz Weitzendorf."
+          ],
+          "uri": "b10000021",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Berlin"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000021"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942029",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-113"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-113",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845079"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-113"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845079"
+                    ],
+                    "idBarcode": [
+                      "33433032845079"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000113"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000022",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "19, 493 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1942.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Grammar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1935"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Puttamittiraṉār, active 11th century."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "73913714"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1388"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Peruntēvaṉār, active 11th century.",
+            "Kōvintarāja Mutaliyār, Kā. Ra., 1874-1952."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1935"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73913714"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100010"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200021"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000022",
+            "urn:lccn:73913714",
+            "urn:oclc:NYPG001000010-B",
+            "urn:undefined:NNSZ00100010",
+            "urn:undefined:(WaOLN)nyp0200021"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ. Patippāciriyar Kā. Ra. Kōvintarāca Mutaliyār."
+          ],
+          "uri": "b10000022",
+          "lccClassification": [
+            "PL4754 .P8 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "titleAlt": [
+            "Viracōḻiyam."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000022"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783787",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1935",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301564"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1935"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301564"
+                    ],
+                    "idBarcode": [
+                      "33433061301564"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001935"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000023",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (18 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For band or wind ensemble.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Based on the composer's Veni creator spiritus.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: KC913.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Band music",
+            "Band music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Shawnee Press"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Musica sacra"
+          ],
+          "shelfMark": [
+            "JMF 83-38"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Zaninelli, Luigi."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-38"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000023"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "KC913 Shawnee Press"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100560"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200022"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-C"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Delaware Water Gap, Pa. : Shawnee Press, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000023",
+            "urn:oclc:NYPG001000010-C",
+            "urn:undefined:KC913 Shawnee Press",
+            "urn:undefined:NNSZ00100560",
+            "urn:undefined:(WaOLN)nyp0200022"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Band music -- Scores."
+          ],
+          "titleDisplay": [
+            "Musica sacra / Luigi Zaninelli."
+          ],
+          "uri": "b10000023",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Delaware Water Gap, Pa."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10000023"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942030",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-38"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-38",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709028"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-38"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709028"
+                    ],
+                    "idBarcode": [
+                      "33433032709028"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000038"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000024",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bahrain",
+            "Bahrain -- History",
+            "Bahrain -- History -- 20th century",
+            "Bahrain -- Economic conditions",
+            "Bahrain -- Social conditions"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār Ibn Khaldūn"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī"
+          ],
+          "shelfMark": [
+            "*OFK 84-1944"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rumayḥī, Muḥammad Ghānim."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "79971032"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFK 84-1944"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000024"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79971032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200023"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[Bayrūt] : Dār Ibn Khaldūn, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000024",
+            "urn:lccn:79971032",
+            "urn:oclc:NYPG001000011-B",
+            "urn:undefined:NNSZ00100011",
+            "urn:undefined:(WaOLN)nyp0200023"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bahrain -- History -- 20th century.",
+            "Bahrain -- Economic conditions.",
+            "Bahrain -- Social conditions."
+          ],
+          "titleDisplay": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī / Muḥammad al-Rumayḥī."
+          ],
+          "uri": "b10000024",
+          "lccClassification": [
+            "DS247.B28 R85"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000024"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000005",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK 84-1944",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005548676"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK 84-1944"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005548676"
+                    ],
+                    "idBarcode": [
+                      "33433005548676"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFK 84-001944"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000025",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei Sonatinen für Klavier"
+          ],
+          "shelfMark": [
+            "JMF 83-107"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stockmeier, Wolfgang."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 179"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-107"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000025"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100561"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200024"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-C"
+          ],
+          "uniformTitle": [
+            "Sonatinas, piano"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000025",
+            "urn:oclc:NYPG001000011-C",
+            "urn:undefined:NNSZ00100561",
+            "urn:undefined:(WaOLN)nyp0200024"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Drei Sonatinen für Klavier / Wolfgang Stockmeier."
+          ],
+          "uri": "b10000025",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatinas"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000025"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-107"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-107",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709697"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-107"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709697"
+                    ],
+                    "idBarcode": [
+                      "33433032709697"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000107"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000026",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "222 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 217-220.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Syria"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975"
+          ],
+          "shelfMark": [
+            "*OFX 84-1953"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Razzāz, Nabīlah."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76960987"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1953"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000026"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960987"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200025"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Dimashq : Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000026",
+            "urn:lccn:76960987",
+            "urn:oclc:NYPG001000012-B",
+            "urn:undefined:NNSZ00100012",
+            "urn:undefined:(WaOLN)nyp0200025"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Syria."
+          ],
+          "titleDisplay": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975 / Nabīlah al-Razzāz."
+          ],
+          "uri": "b10000026",
+          "lccClassification": [
+            "HQ402 .R39"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10000026"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000006",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1953",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031700"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1953"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031700"
+                    ],
+                    "idBarcode": [
+                      "33433002031700"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001953"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000027",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Violin)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei kleine Sonaten : für Violine solo"
+          ],
+          "shelfMark": [
+            "JMF 83-95"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Köhler, Friedemann."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 172"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-95"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000027"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100562"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200026"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-C"
+          ],
+          "uniformTitle": [
+            "Kleine Sonaten, violin"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler Verlag, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000027",
+            "urn:oclc:NYPG001000012-C",
+            "urn:undefined:NNSZ00100562",
+            "urn:undefined:(WaOLN)nyp0200026"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Violin)"
+          ],
+          "titleDisplay": [
+            "Drei kleine Sonaten : für Violine solo / Friedemann Köhler."
+          ],
+          "uri": "b10000027",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Kleine Sonaten"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000027"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-95"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-95",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-95"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709572"
+                    ],
+                    "idBarcode": [
+                      "33433032709572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000095"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000028",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "9, 3, 3, 324 p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Prastuta śodha-prabandha Rājasthāna Viśvavidyālaya, Jayapura kī Pī-eca.Ḍī-upāthi ke nimitta viśvavidyālaya anudāna āyoga kī risarca phailośipa ke antargata likhā gayā thā.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [321]-324.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sūryamalla Miśraṇa, 1815-1868"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Rājasthāna Sāhitya Akādamī (Saṅgama)"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vaṃśabhāskara : eka adhyayana"
+          ],
+          "shelfMark": [
+            "*OKTM 84-1945"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Khāna, Ālama Śāha, 1936-2003."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75903689"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000028"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75903689"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200027"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Udayapura : Rājasthāna Sāhitya Akādamī (Saṅgama), 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000028",
+            "urn:lccn:75903689",
+            "urn:oclc:NYPG001000013-B",
+            "urn:undefined:NNSZ00100013",
+            "urn:undefined:(WaOLN)nyp0200027"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sūryamalla Miśraṇa, 1815-1868."
+          ],
+          "titleDisplay": [
+            "Vaṃśabhāskara : eka adhyayana / lekhaka Ālamaśāha Khāna."
+          ],
+          "uri": "b10000028",
+          "lccClassification": [
+            "PK2708.9.S9 V334"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Udayapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000028"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-1945",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011094210"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-1945"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011094210"
+                    ],
+                    "idBarcode": [
+                      "33433011094210"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-001945"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000029",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Wilhelm Hansen edition no. 4372.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: 29589.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Organ music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "W. Hansen ; Distribution, Magnamusic-Baton"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cruor : for organ solo, 1977"
+          ],
+          "shelfMark": [
+            "JMF 83-93"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lorentzen, Bent."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82771131"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-93"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000029"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82771131"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Wilhelm Hansen edition no. 4372."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "29589."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100563"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200028"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Copenhagen ; New York : W. Hansen ; [s.l.] : Distribution, Magnamusic-Baton, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000029",
+            "urn:lccn:82771131",
+            "urn:oclc:NYPG001000013-C",
+            "urn:undefined:Wilhelm Hansen edition no. 4372.",
+            "urn:undefined:29589.",
+            "urn:undefined:NNSZ00100563",
+            "urn:undefined:(WaOLN)nyp0200028"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Organ music."
+          ],
+          "titleDisplay": [
+            "Cruor : for organ solo, 1977 / B. Lorentzen."
+          ],
+          "uri": "b10000029",
+          "lccClassification": [
+            "M11 .L"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Copenhagen ; New York : [s.l.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000029"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942034",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-93"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-93",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-93"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709556"
+                    ],
+                    "idBarcode": [
+                      "33433032709556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000093"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000030",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21, 264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Āryasamāja-śatābdī-saṃskaraṇam.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Authorship uncertain. Attributed variously to Āpiśali, Pānini and Śākaṭāyana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit: introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Suffixes and prefixes"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; prāptisthānam, Rāmalāla Kapūra Ṭrasṭa"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Uṇādi-koṣaḥ"
+          ],
+          "shelfMark": [
+            "*OKA 84-1931"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902275"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Āpiśali.",
+            "Pāṇini.",
+            "Śākatāyana.",
+            "Dayananda Sarasvati, Swami, 1824-1883.",
+            "Yudhiṣṭhira Mīmāṃsaka, 1909-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKA 84-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000030"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902275"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200029"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-B"
+          ],
+          "uniformTitle": [
+            "Uṇādisūtra."
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Karanāla : Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; Bahālagaḍha, Harayāṇa : prāptisthānam, Rāmalāla Kapūra Ṭrasṭa, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000030",
+            "urn:lccn:75902275",
+            "urn:oclc:NYPG001000014-B",
+            "urn:undefined:NNSZ00100014",
+            "urn:undefined:(WaOLN)nyp0200029"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Suffixes and prefixes."
+          ],
+          "titleDisplay": [
+            "Uṇādi-koṣaḥ / Dayānanda Sarasvatī Svāminā viracitayā Vaidika-laukika-koṣābhidhayā vyākhyayā sahitaḥ vividhābhi-ṣṭippaṇībhiḥ sūcībhiśca saṃyutaḥ ; sampādakaḥ Yudhiṣṭhiro Mīmāṃsakaḥ."
+          ],
+          "uri": "b10000030",
+          "lccClassification": [
+            "PK551 .U73"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Karanāla : Bahālagaḍha, Harayāṇa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000030"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000007",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKA 84-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012968222"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKA 84-1931"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012968222"
+                    ],
+                    "idBarcode": [
+                      "33433012968222"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKA 84-001931"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000031",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "W. Müller"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Neun Miniaturen : für Klavier : op. 52"
+          ],
+          "shelfMark": [
+            "JMG 83-17"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Petersen, Wilhelm, 1890-1957."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-17"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000031"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "W. Müller WM 1713 SM."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200030"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-C"
+          ],
+          "uniformTitle": [
+            "Miniaturen"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Heidelberg : W. Müller, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000031",
+            "urn:oclc:NYPG001000014-C",
+            "urn:undefined:W. Müller WM 1713 SM.",
+            "urn:undefined:NNSZ00100564",
+            "urn:undefined:(WaOLN)nyp0200030"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Neun Miniaturen : für Klavier : op. 52 / Wilhelm Petersen."
+          ],
+          "uri": "b10000031",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Heidelberg"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen",
+            "Miniaturen."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000031"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942035",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-17"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-17",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841631"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841631"
+                    ],
+                    "idBarcode": [
+                      "33433032841631"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000017"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000032",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14, 405, 7 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jahrom (Iran : Province)",
+            "Jahrom (Iran : Province) -- Biography",
+            "Khafr (Iran)",
+            "Khafr (Iran) -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kitābfurūshī-i Khayyām"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr"
+          ],
+          "shelfMark": [
+            "*OMP 84-2007"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ishrāq, Muḥammad Karīm."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2007"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200031"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tihrān : Kitābfurūshī-i Khayyām, 1351 [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000032",
+            "urn:oclc:NYPG001000015-B",
+            "urn:undefined:NNSZ00100015",
+            "urn:undefined:(WaOLN)nyp0200031"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jahrom (Iran : Province) -- Biography.",
+            "Khafr (Iran) -- Biography."
+          ],
+          "titleDisplay": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr / taʼlīf-i Muḥammad Karīm Ishrāq."
+          ],
+          "uri": "b10000032",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm"
+          ]
+        },
+        "sort": [
+          "b10000032"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2007",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173012"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2007"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173012"
+                    ],
+                    "idBarcode": [
+                      "33433013173012"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002007"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000033",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (20 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For voice and organ.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sacred songs (Medium voice) with organ",
+            "Psalms (Music)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Agápe"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Psalm settings"
+          ],
+          "shelfMark": [
+            "JMG 83-59"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Nelhybel, Vaclav."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-59"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000033"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100565"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200032"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Carol Stream, Ill. : Agápe, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000033",
+            "urn:oclc:NYPG001000015-C",
+            "urn:undefined:NNSZ00100565",
+            "urn:undefined:(WaOLN)nyp0200032"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sacred songs (Medium voice) with organ.",
+            "Psalms (Music)"
+          ],
+          "titleDisplay": [
+            "Psalm settings / Vaclav Nelhybel."
+          ],
+          "uri": "b10000033",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Carol Stream, Ill."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Hear me when I call -- Be not far from me -- Hear my voice -- The Lord is my rock."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000033"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942037",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-59",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-59"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942036",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-59",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842035"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-59"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842035"
+                    ],
+                    "idBarcode": [
+                      "33433032842035"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "366 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Brhatkathāślokasaṁgrahaḥ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Colophon: Iti Śrībhaṭṭabudhasvāminā krte ślokasaṁgrahe Brhatkathāyāṁ--",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Text in Sanskrit; apparatus in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Prithivi Prakashan"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brhatkathāślokasaṁgraha : a study"
+          ],
+          "shelfMark": [
+            "*OKR 84-2006"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Budhasvāmin."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903273"
+          ],
+          "seriesStatement": [
+            "Indian civilization series ; no. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Guṇāḍhya.",
+            "Agrawala, Vasudeva Sharana.",
+            "Agrawala, Prithvi Kumar."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKR 84-2006"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000034"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903273"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100016"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200033"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Varanasi : Prithivi Prakashan, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000034",
+            "urn:lccn:74903273",
+            "urn:oclc:NYPG001000016-B",
+            "urn:undefined:NNSZ00100016",
+            "urn:undefined:(WaOLN)nyp0200033"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Brhatkathāślokasaṁgraha : a study / by V.S. Agrawala ; with Sanskrit text, edited by P.K. Agrawala."
+          ],
+          "uri": "b10000034",
+          "lccClassification": [
+            "PK3794.B84 B7 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Varanasi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000034"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKR 84-2006",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011528696"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKR 84-2006"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011528696"
+                    ],
+                    "idBarcode": [
+                      "33433011528696"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKR 84-002006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000035",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "22 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Suite.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 12:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Serenade voor piano : 1980"
+          ],
+          "shelfMark": [
+            "JMG 83-6"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kasbergen, Marinus, 1936-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000035"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100566"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200034"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-C"
+          ],
+          "uniformTitle": [
+            "Serenade, piano"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000035",
+            "urn:oclc:NYPG001000016-C",
+            "urn:undefined:NNSZ00100566",
+            "urn:undefined:(WaOLN)nyp0200034"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Piano)"
+          ],
+          "titleDisplay": [
+            "Serenade voor piano : 1980 / Marinus Kasbergen."
+          ],
+          "uri": "b10000035",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Serenade"
+          ],
+          "tableOfContents": [
+            "Varianten -- Nocturne -- Toccata I -- Intermezzo -- Toccata II."
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000035"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942038",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841490"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-6"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841490"
+                    ],
+                    "idBarcode": [
+                      "33433032841490"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-6",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-6"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000036",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "viii, 38 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; prefatory matter in Sanskrit or Telegu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nārāyaṇatīrtha, 17th cent",
+            "Nārāyaṇatīrtha, 17th cent -- In literature"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic]"
+          ],
+          "shelfMark": [
+            "*OKB 84-1928"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75902755"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKB 84-1928"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000036"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902755"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200035"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[s.1. : s.n.], 1972"
+          ],
+          "identifier": [
+            "urn:bnum:10000036",
+            "urn:lccn:75902755",
+            "urn:oclc:NYPG001000017-B",
+            "urn:undefined:NNSZ00100017",
+            "urn:undefined:(WaOLN)nyp0200035"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nārāyaṇatīrtha, 17th cent -- In literature."
+          ],
+          "titleDisplay": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic] / praṇetā Garikapāṭi Lakṣmīkāntaḥ."
+          ],
+          "uri": "b10000036",
+          "lccClassification": [
+            "PK3799.L28 S68"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[s.1."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000036"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKB 84-1928"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKB 84-1928",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058548433"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKB 84-1928"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058548433"
+                    ],
+                    "idBarcode": [
+                      "33433058548433"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKB 84-001928"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000037",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13a p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 15:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Guitar)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Eight studies for guitar : in form of a suite : 1979"
+          ],
+          "shelfMark": [
+            "JMG 83-5"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hekster, Walter."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000037"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100567"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200036"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-C"
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000037",
+            "urn:oclc:NYPG001000017-C",
+            "urn:undefined:NNSZ00100567",
+            "urn:undefined:(WaOLN)nyp0200036"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Guitar)"
+          ],
+          "titleDisplay": [
+            "Eight studies for guitar : in form of a suite : 1979 / Walter Hekster."
+          ],
+          "uri": "b10000037",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies"
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000037"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841482"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-5"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841482"
+                    ],
+                    "idBarcode": [
+                      "33433032841482"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000005"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000038",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 160 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit, with verse and prose translations in Hindi; prefatory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit poetry",
+            "Sanskrit poetry -- Himachal Pradesh"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Himācala Kalā-Saṃskrti-Bhāṣā Akādamī"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana"
+          ],
+          "shelfMark": [
+            "*OKP 84-1932"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900772"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Prarthi, Lall Chand, 1916-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 84-1932"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000038"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900772"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200037"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Śimalā : Himācala Kalā-Saṃskrti-Bhāṣā Akādamī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000038",
+            "urn:lccn:76900772",
+            "urn:oclc:NYPG001000018-B",
+            "urn:undefined:NNSZ00100018",
+            "urn:undefined:(WaOLN)nyp0200037"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit poetry -- Himachal Pradesh."
+          ],
+          "titleDisplay": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana / mukhya sampādaka Lāla Canda Prārthī ; sampādaka maṇḍala, Manasā Rāma Śarmā 'Arūṇa'...[et al.]."
+          ],
+          "uri": "b10000038",
+          "lccClassification": [
+            "PK3800.H52 R7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Śimalā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000038"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783788",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 84-1932",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 84-1932"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153572"
+                    ],
+                    "idBarcode": [
+                      "33433058153572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKP 84-001932"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000039",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "49 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "C.F. Peters"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Five sonatas for pianoforte"
+          ],
+          "shelfMark": [
+            "JMG 83-66"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hässler, Johann Wilhelm, 1747-1822."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Oberdoerffer, Fritz."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000039"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters no. 66799. C.F. Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100568"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200038"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-C"
+          ],
+          "uniformTitle": [
+            "Sonatas, piano. Selections"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000039",
+            "urn:oclc:NYPG001000018-C",
+            "urn:undefined:Edition Peters no. 66799. C.F. Peters",
+            "urn:undefined:NNSZ00100568",
+            "urn:undefined:(WaOLN)nyp0200038"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Five sonatas for pianoforte / Johann Wilhelm Hässler ; edited by Fritz Oberdoerffer."
+          ],
+          "uri": "b10000039",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatas"
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000039"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842100"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-66"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842100"
+                    ],
+                    "idBarcode": [
+                      "33433032842100"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000066"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000040",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "146 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār."
+          ],
+          "shelfMark": [
+            "*OLB 84-1947"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Pulavar Arasu, 1900-"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "78913375"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 672"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1947"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000040"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78913375"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200039"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000040",
+            "urn:lccn:78913375",
+            "urn:oclc:NYPG001000019-B",
+            "urn:undefined:NNSZ00100019",
+            "urn:undefined:(WaOLN)nyp0200039"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953."
+          ],
+          "titleDisplay": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār. Āciriyar Pulavar Aracu."
+          ],
+          "uri": "b10000040",
+          "lccClassification": [
+            "PL4758.9.K223 Z83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000040"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783789",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1947",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301622"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1947"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301622"
+                    ],
+                    "idBarcode": [
+                      "33433061301622"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001947"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000041",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (23 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 5 clarinets.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Woodwind quintets (Clarinets (5))",
+            "Woodwind quintets (Clarinets (5)) -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Primavera"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Encounter"
+          ],
+          "shelfMark": [
+            "JMF 83-66"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Usher, Julia."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "81770739"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000041"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770739"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100569"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200040"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Primavera, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000041",
+            "urn:lccn:81770739",
+            "urn:oclc:NYPG001000019-C",
+            "urn:undefined:NNSZ00100569",
+            "urn:undefined:(WaOLN)nyp0200040"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Woodwind quintets (Clarinets (5)) -- Scores."
+          ],
+          "titleDisplay": [
+            "Encounter / Julia Usher."
+          ],
+          "uri": "b10000041",
+          "lccClassification": [
+            "M557.2.U8 E5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Greeting -- Circular argument -- Escape."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000041"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709291"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-66"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709291"
+                    ],
+                    "idBarcode": [
+                      "33433032709291"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000066"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000042",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 108 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit: pref. in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Advaita",
+            "Vedanta"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Devabhāṣā Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "dateEndString": [
+            "1972"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita."
+          ],
+          "shelfMark": [
+            "*OKN 84-1926"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902870"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Brahmashram, Śwami, 1915-"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 84-1926"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000042"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902870"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100020"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200041"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-B"
+          ],
+          "uniformTitle": [
+            "Mahābhārata. Sanatsugātīya."
+          ],
+          "dateEndYear": [
+            1972
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Prayāga, Devabhāṣā Prakāśana, Samvat 2028, i.e. 1971 or 2]"
+          ],
+          "identifier": [
+            "urn:bnum:10000042",
+            "urn:lccn:72902870",
+            "urn:oclc:NYPG001000020-B",
+            "urn:undefined:NNSZ00100020",
+            "urn:undefined:(WaOLN)nyp0200041"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Advaita.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita. Vyākhyātā Svāmī Brahmāśrama."
+          ],
+          "uri": "b10000042",
+          "lccClassification": [
+            "B132.V3 M264"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Prayāga"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000042"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783790",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 84-1926"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 84-1926",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618392"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKN 84-1926"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618392"
+                    ],
+                    "idBarcode": [
+                      "33433058618392"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 84-001926"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (28 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 2 flutes, 2 oboes, 2 clarinets, 2 horns, and 2 bassoons.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 5:00-6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: D.15 579.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Wind ensembles",
+            "Wind ensembles -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Verlag Doblinger"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Capriccio : für 10 Blasinstrumente"
+          ],
+          "shelfMark": [
+            "JMC 83-9"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Eröd, Iván."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Doblingers Studienpartituren ; Stp. 410"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMC 83-9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000043"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Stp. 410 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "D.15 579 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100570"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200042"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Wien : Verlag Doblinger, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000043",
+            "urn:oclc:NYPG001000020-C",
+            "urn:undefined:Stp. 410 Verlag Doblinger",
+            "urn:undefined:D.15 579 Verlag Doblinger",
+            "urn:undefined:NNSZ00100570",
+            "urn:undefined:(WaOLN)nyp0200042"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Wind ensembles -- Scores."
+          ],
+          "titleDisplay": [
+            "Capriccio : für 10 Blasinstrumente / Iván Eröd."
+          ],
+          "uri": "b10000043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wien"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000043"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMC 83-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMC 83-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004744128"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMC 83-9"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004744128"
+                    ],
+                    "idBarcode": [
+                      "33433004744128"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMC 83-000009"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000044",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[99] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Biographies of Khri-chen Byaṅ-chub-chos-ʼphel and Śel-dkar Bla-ma Saṅs-rgyas-bstan-ʼphel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from prints from blocks from Lhasa and Śel-dkar Dgaʼ-ldan-legs-bśad-gliṅ.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884",
+            "Lamas",
+            "Lamas -- Tibet",
+            "Lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ngawang Sopa"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2361"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rgal-dbaṅ Chos-rje Blo-bzaṅ-ʼphrin-las-rnam-rgyal, active 1840-1860."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77901316"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ngag-dbang-blo-bzang-rgya-mtsho, Dalai Lama V, 1617-1682."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2361"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000044"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77901316"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000021-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100021"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200043"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000021-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "New Delhi : Ngawang Sopa, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000044",
+            "urn:lccn:77901316",
+            "urn:oclc:NYPG001000021-B",
+            "urn:undefined:NNSZ00100021",
+            "urn:undefined:(WaOLN)nyp0200043"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838.",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884.",
+            "Lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel / by Dar-han Mkhan-sprul Blo-bzaṅ-ʼphrin-las-rnam-rgyal. Bkaʼ-gdams bstan-paʼi mdzod-ʼdzin Rje-btsun Bla-ma Saṅs-rgyas-bstan-ʼphel dpal-bzaṅ-poʼi rnam par thar pa dad ldan yid kyi dgaʼ ston : the biography of Saṅs-rgyas-bstan-ʼphel of Śel-dkar / by Śel-dkar Bkaʼ-ʼgyur Bla-ma Ṅag-dbaṅ-blo-bzaṅ-bstan-ʼdzin-tshul-khrims-rgyal-mtshan."
+          ],
+          "uri": "b10000044",
+          "lccClassification": [
+            "BQ942.Y367 R47 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000044"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000011",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2361",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080645"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080645"
+                    ],
+                    "idBarcode": [
+                      "33433015080645"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002361"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000045",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "12 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Violin music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sole selling agents, Or-Tav"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Thoughts & feelings : for violin solo"
+          ],
+          "shelfMark": [
+            "JMG 82-688"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stutschewsky, Joachim, 1891-1982."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "80770813"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 82-688"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000045"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80770813"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000021-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100571"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200044"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000021-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tel-Aviv : Sole selling agents, Or-Tav, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000045",
+            "urn:lccn:80770813",
+            "urn:oclc:NYPG001000021-C",
+            "urn:undefined:NNSZ00100571",
+            "urn:undefined:(WaOLN)nyp0200044"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Violin music."
+          ],
+          "titleDisplay": [
+            "Thoughts & feelings : for violin solo / Joachim Stutschewsky."
+          ],
+          "uri": "b10000045",
+          "lccClassification": [
+            "M42 .S"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tel-Aviv"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000045"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942043",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 82-688"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 82-688",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032707568"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 82-688"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032707568"
+                    ],
+                    "idBarcode": [
+                      "33433032707568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 82-000688"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000046",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[83] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Kye rdor rnam bśad.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from tracing and manuscripts from the library of Mkhan-po Rin-chen by Trayang and Jamyang Samten.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456",
+            "Tripiṭaka.",
+            "Tripiṭaka. -- Commentaries",
+            "Sa-skya-pa lamas",
+            "Sa-skya-pa lamas -- Tibet",
+            "Sa-skya-pa lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Trayang and Jamyang Samten"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2362"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Tshe-dbaṅ-rdo-rje-rig-ʼdzin, Prince of Sde-dge."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77900893"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sangs-rgyas-phun-tshogs, Ngor-chen, 1649-1705."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000046"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77900893"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000022-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100022"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200045"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000022-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "New Delhi : Trayang and Jamyang Samten, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000046",
+            "urn:lccn:77900893",
+            "urn:oclc:NYPG001000022-B",
+            "urn:undefined:NNSZ00100022",
+            "urn:undefined:(WaOLN)nyp0200045"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456.",
+            "Tripiṭaka. -- Commentaries.",
+            "Sa-skya-pa lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra / by Sde-dge Yab-chen Tshe-dbaṅ-rdo-rje-rig-ʼdzin alias Byams-pa-kun-dgaʼ-bstan-paʼi-rgyal-mtshan. Rgyal ba Rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas : the life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po / by Ṅor-chen Saṅs-rgyas-phun-tshogs."
+          ],
+          "uri": "b10000046",
+          "lccClassification": [
+            "BG974.0727 T75"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "titleAlt": [
+            "Rgyal ba rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas.",
+            "Detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra.",
+            "Life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000046"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080413"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080413"
+                    ],
+                    "idBarcode": [
+                      "33433015080413"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002362"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000047",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (30 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"This work was written between 14 March and 1 May, 1979\"--verso t.p.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 15 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vocalises (High voice) with instrumental ensemble",
+            "Vocalises (High voice) with instrumental ensemble -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello"
+          ],
+          "shelfMark": [
+            "JMG 83-79"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "81770634"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-79"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000047"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770634"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000022-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100572"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200046"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000022-C"
+          ],
+          "uniformTitle": [
+            "Vocalise, soprano, instrumental ensemble, op. 38"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London, England (Arlington Park House, London W4) : Redcliffe Edition, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000047",
+            "urn:lccn:81770634",
+            "urn:oclc:NYPG001000022-C",
+            "urn:undefined:NNSZ00100572",
+            "urn:undefined:(WaOLN)nyp0200046"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vocalises (High voice) with instrumental ensemble -- Scores."
+          ],
+          "titleDisplay": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello / Francis Routh."
+          ],
+          "uri": "b10000047",
+          "lccClassification": [
+            "M1613.3 .R8 op.38"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London, England (Arlington Park House, London W4)"
+          ],
+          "titleAlt": [
+            "Vocalise, op. 38"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "38 cm."
+          ]
+        },
+        "sort": [
+          "b10000047"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942044",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-79"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-79",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842233"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-79"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842233"
+                    ],
+                    "idBarcode": [
+                      "33433032842233"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000079"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000048",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[150] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a MS. preserved at Pha-lo-ldiṅ Monastery in Bhutan.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Buddhism",
+            "Buddhism -- Rituals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kunzang Topgey"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2382"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901012"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2382"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000048"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000023-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100023"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200047"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000023-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Thimphu : Kunzang Topgey, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000048",
+            "urn:lccn:76901012",
+            "urn:oclc:NYPG001000023-B",
+            "urn:undefined:NNSZ00100023",
+            "urn:undefined:(WaOLN)nyp0200047"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Buddhism -- Rituals."
+          ],
+          "titleDisplay": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "uri": "b10000048",
+          "lccClassification": [
+            "BQ7695 .B55"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Thimphu"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 38 cm."
+          ]
+        },
+        "sort": [
+          "b10000048"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2382",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080439"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080439"
+                    ],
+                    "idBarcode": [
+                      "33433015080439"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002382"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000049",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (105 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 25 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Symphony, op. 26 : full score"
+          ],
+          "shelfMark": [
+            "JMG 83-80"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "81770641"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-80"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000049"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770641"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000023-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100573"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200048"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000023-C"
+          ],
+          "uniformTitle": [
+            "Symphony, op. 26"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "London (Arlington Park House, London W4 4HD) : Redcliffe Edition, c1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000049",
+            "urn:lccn:81770641",
+            "urn:oclc:NYPG001000023-C",
+            "urn:undefined:NNSZ00100573",
+            "urn:undefined:(WaOLN)nyp0200048"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "Symphony, op. 26 : full score / Francis Routh."
+          ],
+          "uri": "b10000049",
+          "lccClassification": [
+            "M1001 .R8615 op.26"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London (Arlington Park House, London W4 4HD)"
+          ],
+          "titleAlt": [
+            "Symphony, op. 26"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000049"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942045",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-80"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-80",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842241"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-80"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842241"
+                    ],
+                    "idBarcode": [
+                      "33433032842241"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000080"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000050",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[188] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a print from the early 16th century western Tibetan blocks by Urgyan Dorje.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?",
+            "Bkaʼ-brgyud-pa lamas",
+            "Bkaʼ-brgyud-pa lamas -- Tibet",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography",
+            "Spiritual life",
+            "Spiritual life -- Buddhism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Urgyan Dorje"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2381"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901747"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2381"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000050"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901747"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000024-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100024"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200049"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000024-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "New Delhi : Urgyan Dorje, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000050",
+            "urn:lccn:76901747",
+            "urn:oclc:NYPG001000024-B",
+            "urn:undefined:NNSZ00100024",
+            "urn:undefined:(WaOLN)nyp0200049"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography.",
+            "Spiritual life -- Buddhism."
+          ],
+          "titleDisplay": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "uri": "b10000050",
+          "lccClassification": [
+            "BQ942.A187 A35 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000050"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2381",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080421"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080421"
+                    ],
+                    "idBarcode": [
+                      "33433015080421"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002381"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000051",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "score (64 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Samfundet til udgivelse af dansk musik"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972"
+          ],
+          "shelfMark": [
+            "JMG 83-75"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Christiansen, Henning."
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "idLccn": [
+            "78770955"
+          ],
+          "seriesStatement": [
+            "[Publikation] - Samfundet til udgivelse af dansk musik : 3. serie, nr. 264"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-75"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000051"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78770955"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000024-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100574"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200050"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000024-C"
+          ],
+          "uniformTitle": [
+            "Symphony, no. 2, op. 69c",
+            "Samfundet til udgivelse af dansk musik (Series) ; 3. ser., nr. 264."
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "København : Samfundet til udgivelse af dansk musik, 1977."
+          ],
+          "identifier": [
+            "urn:bnum:10000051",
+            "urn:lccn:78770955",
+            "urn:oclc:NYPG001000024-C",
+            "urn:undefined:NNSZ00100574",
+            "urn:undefined:(WaOLN)nyp0200050"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972 / Henning Christiansen."
+          ],
+          "uri": "b10000051",
+          "lccClassification": [
+            "M1001 .C533 op.69c"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "København"
+          ],
+          "titleAlt": [
+            "Symphony, no. 2, op. 69c",
+            "Den forsvundne."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "37 cm."
+          ]
+        },
+        "sort": [
+          "b10000051"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942046",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-75"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-75",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842191"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-75"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842191"
+                    ],
+                    "idBarcode": [
+                      "33433032842191"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000075"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-1f829724950a064befff498b93a305d3.json
+++ b/test/fixtures/query-1f829724950a064befff498b93a305d3.json
@@ -1,0 +1,918 @@
+{
+  "took": 85,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.902664,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.902664,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-29a4e82c299ca63a19ef61cf8beb423d.json
+++ b/test/fixtures/query-29a4e82c299ca63a19ef61cf8beb423d.json
@@ -1,0 +1,1267 @@
+{
+  "took": 23,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.333013,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b14937001",
+        "_score": 14.333013,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "From 1807-June 1837 title reads: Morgenblatt für gebildete stände.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Kunst-blatt. Stuttgart, 1816-1849.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Includes the current supplements Literatur-blatt 1817-1849; Kunstblatt 1816-1849; Intelligenz-blatt 1817-1847.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "J. G. Cotta'sche buchhandlung."
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            4
+          ],
+          "dateEndString": [
+            "1"
+          ],
+          "createdYear": [
+            1855
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Morgenblatt für gebildete leser."
+          ],
+          "shelfMark": [
+            "*DF+ (Morgenblatt für gebildete Leser)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1855"
+          ],
+          "idLccn": [
+            "cau08001961"
+          ],
+          "numElectronicResources": [
+            88
+          ],
+          "dateStartYear": [
+            1855
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*DF+ (Morgenblatt für gebildete Leser)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14937001"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "cau08001961"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1608345"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "0494254"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)ret0001042"
+            }
+          ],
+          "idOclc": [
+            "1608345"
+          ],
+          "dateEndYear": [
+            1
+          ],
+          "updatedAt": 1671729582968,
+          "publicationStatement": [
+            "Stuttgart, Tübingen [etc.], J. G. Cotta'sche buchhandlung."
+          ],
+          "identifier": [
+            "urn:bnum:14937001",
+            "urn:lccn:cau08001961",
+            "urn:oclc:1608345",
+            "urn:undefined:0494254",
+            "urn:undefined:(WaOLN)ret0001042"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1855"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Morgenblatt für gebildete leser."
+          ],
+          "uri": "b14937001",
+          "numItems": [
+            4
+          ],
+          "numAvailable": [
+            4
+          ],
+          "placeOfPublication": [
+            "Stuttgart, Tübingen [etc.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i14937001-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899526k",
+                        "label": "Full text available via HathiTrust - jahrg.11:Jan.-June (1817)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899527i",
+                        "label": "Full text available via HathiTrust - jahrg.11:July-Dec. (1817)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899528g",
+                        "label": "Full text available via HathiTrust - jahrg.12:Jan.-June (1818)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899529e",
+                        "label": "Full text available via HathiTrust - jahrg.12:July-Dec. (1818)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899530t",
+                        "label": "Full text available via HathiTrust - jahrg.13:Jan.-June (1819)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899531r",
+                        "label": "Full text available via HathiTrust - jahrg.13:July-Dec. (1819)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899532p",
+                        "label": "Full text available via HathiTrust - jahrg.14:Jan.-June (1820)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899534l",
+                        "label": "Full text available via HathiTrust - jahrg.15:Jan.-June (1821)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899535j",
+                        "label": "Full text available via HathiTrust - jahrg.15:July-Dec. (1821)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899536h",
+                        "label": "Full text available via HathiTrust - jahrg.16:Jan.-June (1822)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899537f",
+                        "label": "Full text available via HathiTrust - jahrg.16:July-Dec. (1822)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899538d",
+                        "label": "Full text available via HathiTrust - jahrg.17:Jan.-June (1823)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899539b",
+                        "label": "Full text available via HathiTrust - jahrg.17:July-Dec. (1823)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899541o",
+                        "label": "Full text available via HathiTrust - jahrg.18:July-Dec. (1824)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899542m",
+                        "label": "Full text available via HathiTrust - jahrg.19:Jan.-June (1825)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899505s",
+                        "label": "Full text available via HathiTrust - jahrg.2:Jan.-June (1808)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899506q",
+                        "label": "Full text available via HathiTrust - jahrg.2:July-Dec. (1808)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899544i",
+                        "label": "Full text available via HathiTrust - jahrg.20:Jan.-June (1826)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899545g",
+                        "label": "Full text available via HathiTrust - jahrg.20:July-Dec. (1826)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899547c",
+                        "label": "Full text available via HathiTrust - jahrg.21:July-Dec. (1827)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899548a",
+                        "label": "Full text available via HathiTrust - jahrg.22 (1828)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899620s",
+                        "label": "Full text available via HathiTrust - jahrg.22:suppl.:art (1828)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899550n",
+                        "label": "Full text available via HathiTrust - jahrg.23:July-Dec. (1829)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899551l",
+                        "label": "Full text available via HathiTrust - jahrg.24:Jan.-June (1830)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899552j",
+                        "label": "Full text available via HathiTrust - jahrg.24:July-Dec. (1830)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899624k",
+                        "label": "Full text available via HathiTrust - jahrg.24:suppl.:lit. (1830)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899554f",
+                        "label": "Full text available via HathiTrust - jahrg.25:July-Dec. (1831)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899555d",
+                        "label": "Full text available via HathiTrust - jahrg.26:Jan.-June (1832)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899556b",
+                        "label": "Full text available via HathiTrust - jahrg.26:July-Dec. (1832)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995587",
+                        "label": "Full text available via HathiTrust - jahrg.28:Jan.-June (1834)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995595",
+                        "label": "Full text available via HathiTrust - jahrg.28:July-Dec. (1834)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899560k",
+                        "label": "Full text available via HathiTrust - jahrg.29:Jan.-June (1835)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899561i",
+                        "label": "Full text available via HathiTrust - jahrg.29:July-Dec. (1835)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899563e",
+                        "label": "Full text available via HathiTrust - jahrg.30:Oct.-Dec. (1836)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899641k",
+                        "label": "Full text available via HathiTrust - jahrg.32:suppl.:lit. (1838)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995668",
+                        "label": "Full text available via HathiTrust - jahrg.33 (1839)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899642i",
+                        "label": "Full text available via HathiTrust - jahrg.33:suppl.:art (1839)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899645c",
+                        "label": "Full text available via HathiTrust - jahrg.35:suppl.:art (1841)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899646a",
+                        "label": "Full text available via HathiTrust - jahrg.35:suppl.:lit. (1841)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995692",
+                        "label": "Full text available via HathiTrust - jahrg.36:Jan.-Apr. (1842)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899571f",
+                        "label": "Full text available via HathiTrust - jahrg.36:Sept.-Dec. (1842)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899572d",
+                        "label": "Full text available via HathiTrust - jahrg.37:Jan.-Apr. (1843)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899573b",
+                        "label": "Full text available via HathiTrust - jahrg.37:May-Aug. (1843)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995749",
+                        "label": "Full text available via HathiTrust - jahrg.37:Sept.-Dec. (1843)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951p01107664f",
+                        "label": "Full text available via HathiTrust - jahrg.38:Jan.-Apr. (1844)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995765",
+                        "label": "Full text available via HathiTrust - jahrg.38:May-Aug. (1844)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995781",
+                        "label": "Full text available via HathiTrust - jahrg.39:Jan.-June (1845)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899509k",
+                        "label": "Full text available via HathiTrust - jahrg.4:Jan.-June (1810)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899582a",
+                        "label": "Full text available via HathiTrust - jahrg.41:Jan.-June (1847)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995838",
+                        "label": "Full text available via HathiTrust - jahrg.41:July-Dec. (1847)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899589w",
+                        "label": "Full text available via HathiTrust - jahrg.44:July-Dec. (1850)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899590b",
+                        "label": "Full text available via HathiTrust - jahrg.45:Jan.-June (1851)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899599t",
+                        "label": "Full text available via HathiTrust - jahrg.49:July-Dec. (1855)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899512v",
+                        "label": "Full text available via HathiTrust - jahrg.5:July-Dec. (1811)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899600y",
+                        "label": "Full text available via HathiTrust - jahrg.50:Jan.-June (1856)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899601w",
+                        "label": "Full text available via HathiTrust - jahrg.50:July-Dec. (1856)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899602u",
+                        "label": "Full text available via HathiTrust - jahrg.51:Jan.-June (1857)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899603s",
+                        "label": "Full text available via HathiTrust - jahrg.51:July-Dec. (1857)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899605o",
+                        "label": "Full text available via HathiTrust - jahrg.52:July-Dec. (1858)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899606m",
+                        "label": "Full text available via HathiTrust - jahrg.53:Jan.-June (1859)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899607k",
+                        "label": "Full text available via HathiTrust - jahrg.53:July-Dec. (1859)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899608i",
+                        "label": "Full text available via HathiTrust - jahrg.54:Jan.-June (1860)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899609g",
+                        "label": "Full text available via HathiTrust - jahrg.54:July-Dec. (1860)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899610v",
+                        "label": "Full text available via HathiTrust - jahrg.55:Jan.-June (1861)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899611t",
+                        "label": "Full text available via HathiTrust - jahrg.55:July-Dec. (1861)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899612r",
+                        "label": "Full text available via HathiTrust - jahrg.56:Jan.-June (1862)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899613p",
+                        "label": "Full text available via HathiTrust - jahrg.56:July-Dec. (1862)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899614n",
+                        "label": "Full text available via HathiTrust - jahrg.57:Jan.-June (1863)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899615l",
+                        "label": "Full text available via HathiTrust - jahrg.57:July-Dec. (1863)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899616j",
+                        "label": "Full text available via HathiTrust - jahrg.58:Jan.-June (1864)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899617h",
+                        "label": "Full text available via HathiTrust - jahrg.58:July-Dec. (1864)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899619d",
+                        "label": "Full text available via HathiTrust - jahrg.59:July-Dec. (1865)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899513t",
+                        "label": "Full text available via HathiTrust - jahrg.6:Jan.-June (1812)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899514r",
+                        "label": "Full text available via HathiTrust - jahrg.6:July-Dec. (1812)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899516n",
+                        "label": "Full text available via HathiTrust - jahrg.7:July-Dec. (1813)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899521u",
+                        "label": "Full text available via HathiTrust - jahrg.9:Jan.-June (1815)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054677",
+                        "label": "Full text available via HathiTrust - vol.13, pt.2 (1819)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054701",
+                        "label": "Full text available via HathiTrust - vol.15, pt.1 (1821)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054743",
+                        "label": "Full text available via HathiTrust - vol.28, pt.1 (1834)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054768",
+                        "label": "Full text available via HathiTrust - vol.28, pt.2 (1834)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054776",
+                        "label": "Full text available via HathiTrust - vol.28, pt.3 (1834)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054800",
+                        "label": "Full text available via HathiTrust - vol.30, pt.1 (1836)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054818",
+                        "label": "Full text available via HathiTrust - vol.30, pt.2 (1836)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054826",
+                        "label": "Full text available via HathiTrust - vol.31, pt.1 (1837)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054834",
+                        "label": "Full text available via HathiTrust - vol.31, pt.2 (1837)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054842",
+                        "label": "Full text available via HathiTrust - vol.33, pt.1 (1839)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054859",
+                        "label": "Full text available via HathiTrust - vol.33, pt.2 (1839)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064488156",
+                        "label": "Full text available via HathiTrust - vol.40 (1846)"
+                      }
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "bi14937001-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 4,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28309666",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 1933"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 1933",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088646033"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. Mar.-May 1933"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088646033"
+                    ],
+                    "idBarcode": [
+                      "33433088646033"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 001933"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28309648",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433096425198"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 49 (1855)"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433096425198"
+                    ],
+                    "idBarcode": [
+                      "33433096425198"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28309668",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1861"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1861",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088646041"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 1861"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088646041"
+                    ],
+                    "idBarcode": [
+                      "33433088646041"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 001861"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28543800",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1860"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1860",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433097964930"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 1860"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433097964930"
+                    ],
+                    "idBarcode": [
+                      "33433097964930"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 001860"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          },
+          "allItems": {
+            "hits": {
+              "total": 4,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i28309666",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 1933"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 1933",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088646033"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. Mar.-May 1933"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088646033"
+                    ],
+                    "idBarcode": [
+                      "33433088646033"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 001933"
+                  }
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i28309648",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433096425198"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 49 (1855)"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433096425198"
+                    ],
+                    "idBarcode": [
+                      "33433096425198"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)"
+                  }
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i28309668",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1861"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1861",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088646041"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 1861"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088646041"
+                    ],
+                    "idBarcode": [
+                      "33433088646041"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 001861"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 5,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "loc:rc2ma||Offsite",
+            "doc_count": 3
+          },
+          {
+            "key": "loc:mal92||Schwarzman Building M2 - General Research Room 315",
+            "doc_count": 1
+          }
+        ]
+      }
+    },
+    "item_format": {
+      "doc_count": 5,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 5
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 5,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 4
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/query-2c8ba81e7a1f7033a1c448407ebd69df.json
+++ b/test/fixtures/query-2c8ba81e7a1f7033a1c448407ebd69df.json
@@ -1,0 +1,918 @@
+{
+  "took": 84,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 29.90047,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 29.90047,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-38a1ff4bb6a8f66bd5910f715bff0353.json
+++ b/test/fixtures/query-38a1ff4bb6a8f66bd5910f715bff0353.json
@@ -1,0 +1,918 @@
+{
+  "took": 954,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.903906,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.903906,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-42320466c1ce6e4a03da3e23de43281c.json
+++ b/test/fixtures/query-42320466c1ce6e4a03da3e23de43281c.json
@@ -1,0 +1,12947 @@
+{
+  "took": 849,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1993921,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000061",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 ms. score (10 p.) + 1 ms. part (3 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holographs (?) signed, in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For violin and piano; part incomplete.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Title varies: Hungarian song and dance.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "On t.p.: Given to H H Huss by Maud Powell.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Huss, Henry Holden, 1862-1953",
+            "Huss, Henry Holden, 1862-1953 -- Manuscripts",
+            "Violin and piano music",
+            "Violin and piano music -- Scores and parts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1888
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Hungarian melody and dance"
+          ],
+          "shelfMark": [
+            "JPB 83-155 no. 189"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Matus."
+          ],
+          "createdString": [
+            "1888"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Huss, Henry Holden, 1862-1953.",
+            "Powell, Maud, 1867-1920."
+          ],
+          "dateStartYear": [
+            1888
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 83-155 no. 189"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000061"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000029-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100579"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200060"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000029-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "1888."
+          ],
+          "identifier": [
+            "urn:bnum:10000061",
+            "urn:oclc:NYPG001000029-C",
+            "urn:undefined:NNSZ00100579",
+            "urn:undefined:(WaOLN)nyp0200060"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1888"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Huss, Henry Holden, 1862-1953 -- Manuscripts.",
+            "Violin and piano music -- Scores and parts."
+          ],
+          "titleDisplay": [
+            "Hungarian melody and dance / Matus ; arranged by H.H.H. Mazurka caprice / Henry Holden Huss."
+          ],
+          "uri": "b10000061",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Hungarian song and dance.",
+            "Mazurka caprice."
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000061"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746396",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:8",
+                        "label": "manuscript music"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:8||manuscript music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym38||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JPB 83-155 no. 189"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 83-155 no. 189",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433116929518"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 83-155 no. 189"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433116929518"
+                    ],
+                    "idBarcode": [
+                      "33433116929518"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJPB 83-155 no. 000189"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000063",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 ms. score (2 leaves) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ms. (in ink) in the hand of Henry Holden Huss.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For one or more voices and piano.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Huss, Henry Holden, 1862-1953",
+            "Huss, Henry Holden, 1862-1953 -- Manuscripts",
+            "Songs (Medium voice) with piano",
+            "Choruses, Secular (Mixed voices, 2 parts) with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1953"
+          ],
+          "createdYear": [
+            1862
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "For it's free : our native land"
+          ],
+          "shelfMark": [
+            "JPB 83-155 no. 190  "
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Proctor, David."
+          ],
+          "createdString": [
+            "1862"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Huss, Henry Holden, 1862-1953."
+          ],
+          "dateStartYear": [
+            1862
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 83-155 no. 190  "
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000063"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000030-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100580"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200062"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000030-C"
+          ],
+          "dateEndYear": [
+            1953
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[19--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000063",
+            "urn:oclc:NYPG001000030-C",
+            "urn:undefined:NNSZ00100580",
+            "urn:undefined:(WaOLN)nyp0200062"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1862"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Huss, Henry Holden, 1862-1953 -- Manuscripts.",
+            "Songs (Medium voice) with piano.",
+            "Choruses, Secular (Mixed voices, 2 parts) with piano."
+          ],
+          "titleDisplay": [
+            "For it's free : our native land / music by David Proctor ; author anon."
+          ],
+          "uri": "b10000063",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000063"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746397",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:8",
+                        "label": "manuscript music"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:8||manuscript music"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym38||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JPB 83-155 no. 190"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 83-155 no. 190",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433116929526"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 83-155 no. 190"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433116929526"
+                    ],
+                    "idBarcode": [
+                      "33433116929526"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJPB 83-155 no. 000190"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000071",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 ms. score ([3] p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holograph signed, in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For voice and piano.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Gilbert, Henry F. B. 1868-1928",
+            "Gilbert, Henry F. B. 1868-1928 -- Manuscripts",
+            "Riley, James Whitcomb, 1849-1916",
+            "Riley, James Whitcomb, 1849-1916 -- Musical settings",
+            "Songs (Medium voice) with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1928"
+          ],
+          "createdYear": [
+            1868
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The treasure of the wise man"
+          ],
+          "shelfMark": [
+            "JPB 83-480"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Gilbert, Henry F. B. (Henry Franklin Belknap), 1868-1928."
+          ],
+          "createdString": [
+            "1868"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Riley, James Whitcomb, 1849-1916."
+          ],
+          "dateStartYear": [
+            1868
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 83-480"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000071"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000034-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100584"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200070"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000034-C"
+          ],
+          "dateEndYear": [
+            1928
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "[19--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000071",
+            "urn:oclc:NYPG001000034-C",
+            "urn:undefined:NNSZ00100584",
+            "urn:undefined:(WaOLN)nyp0200070"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1868"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Gilbert, Henry F. B. 1868-1928 -- Manuscripts.",
+            "Riley, James Whitcomb, 1849-1916 -- Musical settings.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "The treasure of the wise man / [words by] James Whitcomb Riley ; [music by] Henry F. Gilbert."
+          ],
+          "uri": "b10000071",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000071"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746401",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym38||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JPB 83-480"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 83-480",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 83-480"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJPB 83-000480"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000077",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 ms. score ([3] p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holograph signed, in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For voice and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At end: Komponirt im September 1892 ; revidirt & ballindet [?] im Mai 1894.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Published in: Sechs Lieder für tiefe Stimme mit Pianofortebegleitung, op. 2, no. 1. Leipzig, New York : Breitkopf & Härtel, c1900.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Paper extremely brittle and badly torn.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Goldmark, Rubin, 1872-1936",
+            "Goldmark, Rubin, 1872-1936 -- Manuscripts",
+            "Songs (Low voice) with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1894
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Blaublümlein : rheinisches Volkslied"
+          ],
+          "shelfMark": [
+            "JPB 83-483"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Goldmark, Rubin, 1872-1936."
+          ],
+          "createdString": [
+            "1894"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1894
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 83-483"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000077"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000037-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100587"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200076"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000037-C"
+          ],
+          "uniformTitle": [
+            "Lieder, op. 2. Blaublümlein"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "1894 May."
+          ],
+          "identifier": [
+            "urn:bnum:10000077",
+            "urn:oclc:NYPG001000037-C",
+            "urn:undefined:NNSZ00100587",
+            "urn:undefined:(WaOLN)nyp0200076"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1894"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Goldmark, Rubin, 1872-1936 -- Manuscripts.",
+            "Songs (Low voice) with piano."
+          ],
+          "titleDisplay": [
+            "Blaublümlein : rheinisches Volkslied / Rubin Goldmark."
+          ],
+          "uri": "b10000077",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Lieder, op. 2. Blaublümlein"
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          "b10000077"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746404",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym38||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JPB 83-483"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 83-483",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 83-483"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJPB 83-000483"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000079",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 ms. score ([3] p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holograph, in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "For voice and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "English and German words.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Goldmark, Rubin, 1872-1936",
+            "Goldmark, Rubin, 1872-1936 -- Manuscripts",
+            "Songs (Medium voice) with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1936"
+          ],
+          "createdYear": [
+            1872
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The forest has its birds of song"
+          ],
+          "shelfMark": [
+            "JPB 83-484"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Goldmark, Rubin, 1872-1936."
+          ],
+          "createdString": [
+            "1872"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1872
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 83-484"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000079"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000038-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100588"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200078"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000038-C"
+          ],
+          "dateEndYear": [
+            1936
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[18--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000079",
+            "urn:oclc:NYPG001000038-C",
+            "urn:undefined:NNSZ00100588",
+            "urn:undefined:(WaOLN)nyp0200078"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1872"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Goldmark, Rubin, 1872-1936 -- Manuscripts.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "The forest has its birds of song / [Rubin Goldmark]."
+          ],
+          "uri": "b10000079",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          "b10000079"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746405",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym38||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JPB 83-484"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 83-484",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 83-484"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJPB 83-000484"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000084",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 ms. score ([2] leaves) ; 1 ms. part ([1] leaf) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Holograph, in ink.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Published in: A group of songs, op. 1-2. Boston: Boston Music Co., c1896.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Accompanied by text (holograph, 2 leaves, 26 cm.) dated June 27th, 1889.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Gow, George Coleman, 1860-1938",
+            "Gow, George Coleman, 1860-1938 -- Manuscripts",
+            "Songs (Medium voice) with instrumental ensemble",
+            "Songs (Medium voice) with instrumental ensemble -- Scores and parts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1890
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Slumber song : violin, voice, and pianoforte"
+          ],
+          "shelfMark": [
+            "JPB 83-488"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Gow, George Coleman, 1860-1938."
+          ],
+          "createdString": [
+            "1890"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1890
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JPB 83-488"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000084"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000041-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100591"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200083"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000041-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "1890 Mar. 10."
+          ],
+          "identifier": [
+            "urn:bnum:10000084",
+            "urn:oclc:NYPG001000041-C",
+            "urn:undefined:NNSZ00100591",
+            "urn:undefined:(WaOLN)nyp0200083"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1890"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Gow, George Coleman, 1860-1938 -- Manuscripts.",
+            "Songs (Medium voice) with instrumental ensemble -- Scores and parts."
+          ],
+          "titleDisplay": [
+            "Slumber song : violin, voice, and pianoforte / by G. C. Gow."
+          ],
+          "uri": "b10000084",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 cm. + 27 cm."
+          ]
+        },
+        "sort": [
+          "b10000084"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746408",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym38",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym38||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JPB 83-488"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JPB 83-488",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JPB 83-488"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJPB 83-000488"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000284",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "20, 429 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reprint of the 1826 ed., published by Dar al-Inṭibāʻ-i Dār al-Salṭanah, Tabrīz.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- History",
+            "Iran -- History -- Qajar dynasty, 1794-1925",
+            "Iran -- Foreign relations",
+            "Iran -- Foreign relations -- Russia",
+            "Russia",
+            "Russia -- Foreign relations",
+            "Russia -- Foreign relations -- Iran"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Ibn Sīnā"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "dateEndString": [
+            "1826"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Maʼā̲sir-i sulṭānīyah, tārīkh-i janǵhā-yi Īrān va Rūs."
+          ],
+          "shelfMark": [
+            "*OMZ 82-4274"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Maftūn Dunbulī, ʻAbd al-Razzāq, 1762 or 3-1827 or 8."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "74216823"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ṣadrī Afshār, Ghulām Ḥusayn."
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 82-4274"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000284"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74216823"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000237-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100237"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200283"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000237-B"
+          ],
+          "dateEndYear": [
+            1826
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "[Tihrān] Intishārāt-i Ibn Sīnā, 1351 [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000284",
+            "urn:lccn:74216823",
+            "urn:oclc:NYPG001000237-B",
+            "urn:undefined:NNSZ00100237",
+            "urn:undefined:(WaOLN)nyp0200283"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- History -- Qajar dynasty, 1794-1925.",
+            "Iran -- Foreign relations -- Russia.",
+            "Russia -- Foreign relations -- Iran."
+          ],
+          "titleDisplay": [
+            "Maʼā̲sir-i sulṭānīyah, tārīkh-i janǵhā-yi Īrān va Rūs. A̲sar-i ʻAbd al-Razzāq Maftūn Dunbulī. Bā muqaddamah va fihristhā bi-ihtimām-i Ghulām Ḥusayn Ṣadrī Afshār."
+          ],
+          "uri": "b10000284",
+          "lccClassification": [
+            "DS302 .M33 1972"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Tihrān]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000284"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942064",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMZ 82-4274"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMZ 82-4274",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539161"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 82-4274"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539161"
+                    ],
+                    "idBarcode": [
+                      "33433014539161"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMZ 82-004274"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000348",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[28], 573 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [7-10] (1st group)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Description and travel"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Mīrzā Ḥabīb Allāh"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1880"
+          ],
+          "createdYear": [
+            1879
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kitāb-i mustaṭāb-i ganj-i dānish"
+          ],
+          "shelfMark": [
+            "*ONA+ 82-2677"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Muʻtamid al-Sulṭān, Muḥammad Taqī khān Ḥakīm, mutakhalliṣ bih Ḥakīm."
+          ],
+          "createdString": [
+            "1879"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1879
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ONA+ 82-2677"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000348"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000301-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100301"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200347"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000301-B"
+          ],
+          "dateEndYear": [
+            1880
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Ṭihrān : Mīrzā Ḥabīb Allāh, 1305 [1879 or 1880]"
+          ],
+          "identifier": [
+            "urn:bnum:10000348",
+            "urn:oclc:NYPG001000301-B",
+            "urn:undefined:NNSZ00100301",
+            "urn:undefined:(WaOLN)nyp0200347"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1879"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Description and travel."
+          ],
+          "titleDisplay": [
+            "Kitāb-i mustaṭāb-i ganj-i dānish / az taʼlīfāt-i Muʻtamid al-Sulṭān Muḥammad Taqī Khān mutikhalliṣ bih Ḥakīm ; bi-saʻī va ihtimām-i Mullā Maḥmūd va Mullā Rizā Kitābfurūsh."
+          ],
+          "uri": "b10000348",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ṭihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Ganj-i dānish."
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          "b10000348"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783848",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*ONA+ 82-2677  "
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ONA+ 82-2677  ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059840763"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ONA+ 82-2677  "
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059840763"
+                    ],
+                    "idBarcode": [
+                      "33433059840763"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ONA+ 82-2677 "
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000546",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Trük. K. Mattiesen"
+          ],
+          "language": [
+            {
+              "id": "lang:est",
+              "label": "Estonian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1891
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Üks öö tissa jöe peal"
+          ],
+          "shelfMark": [
+            "*Z-3414 no. 9"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "1891"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1891
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3414 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000546"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000503-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100503"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200545"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000503-B"
+          ],
+          "updatedAt": 1676922086720,
+          "publicationStatement": [
+            "Tartus : Trük. K. Mattiesen, 1891."
+          ],
+          "identifier": [
+            "urn:bnum:10000546",
+            "urn:oclc:NYPG001000503-B",
+            "urn:undefined:NNSZ00100503",
+            "urn:undefined:(WaOLN)nyp0200545"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1891"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Üks öö tissa jöe peal [microform]."
+          ],
+          "uri": "b10000546",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tartus"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "sort": [
+          "b10000546"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30112243",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*Z-3414 no. 1-16"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*Z-3414 no. 1-16",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107825220"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-16"
+                    ],
+                    "physicalLocation": [
+                      "*Z-3414"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107825220"
+                    ],
+                    "idBarcode": [
+                      "33433107825220"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 16
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*Z-3414 no. 000001-16"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000547",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "31 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Trük. L. Weyde"
+          ],
+          "language": [
+            {
+              "id": "lang:est",
+              "label": "Estonian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1874
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kirjakandja tuike üks rutuline rööwlide käest päästaw sönum."
+          ],
+          "shelfMark": [
+            "*Z-3414 no. 6"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "1874"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1874
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3414 no. 6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000547"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000504-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100504"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200546"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000504-B"
+          ],
+          "updatedAt": 1676922086720,
+          "publicationStatement": [
+            "Riigas : Trük. L. Weyde, 1874."
+          ],
+          "identifier": [
+            "urn:bnum:10000547",
+            "urn:oclc:NYPG001000504-B",
+            "urn:undefined:NNSZ00100504",
+            "urn:undefined:(WaOLN)nyp0200546"
+          ],
+          "genreForm": [
+            "Estonian fiction."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1874"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Kirjakandja tuike [microform] : üks rutuline rööwlide käest päästaw sönum."
+          ],
+          "uri": "b10000547",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Riigas"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "sort": [
+          "b10000547"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30112243",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*Z-3414 no. 1-16"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*Z-3414 no. 1-16",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107825220"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-16"
+                    ],
+                    "physicalLocation": [
+                      "*Z-3414"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107825220"
+                    ],
+                    "idBarcode": [
+                      "33433107825220"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 16
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*Z-3414 no. 000001-16"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000548",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "89 p. : ill., port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "United States Lawn Tennis Association",
+            "Tennis",
+            "Tennis -- Rules"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wright & Ditson"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1889
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Official lawn tennis rules as adopted by the United States National Lawn Tennis Association, containing also the constitution and by-laws, list of officers and clubs in the association, cases and decisions, rules for umpires, and the Bagnal wild system of drawing, by James Dwight ..."
+          ],
+          "shelfMark": [
+            "*Z-3414 no. 4"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "1889"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "United States Lawn Tennis Association."
+          ],
+          "dateStartYear": [
+            1889
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3414 no. 4"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000548"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000505-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100505"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200547"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000505-B"
+          ],
+          "updatedAt": 1676922086720,
+          "publicationStatement": [
+            "Boston, Mass. : Wright & Ditson, 1889."
+          ],
+          "identifier": [
+            "urn:bnum:10000548",
+            "urn:oclc:NYPG001000505-B",
+            "urn:undefined:NNSZ00100505",
+            "urn:undefined:(WaOLN)nyp0200547"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1889"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "United States Lawn Tennis Association.",
+            "Tennis -- Rules."
+          ],
+          "titleDisplay": [
+            "Official lawn tennis rules [microform] : as adopted by the United States National Lawn Tennis Association, containing also the constitution and by-laws, list of officers and clubs in the association, cases and decisions, rules for umpires, and the Bagnal wild system of drawing, by James Dwight ..."
+          ],
+          "uri": "b10000548",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Boston, Mass."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "sort": [
+          "b10000548"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30112243",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*Z-3414 no. 1-16"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*Z-3414 no. 1-16",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107825220"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-16"
+                    ],
+                    "physicalLocation": [
+                      "*Z-3414"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107825220"
+                    ],
+                    "idBarcode": [
+                      "33433107825220"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 16
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*Z-3414 no. 000001-16"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000574",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xii, 56 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "J. Maisonneuve"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1891
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Les hymnes rohitas Livre XIII de l'Atharva-Véda"
+          ],
+          "shelfMark": [
+            "*ZO-180 no. 10"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1891"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Henry, Victor, 1850-1907."
+          ],
+          "dateStartYear": [
+            1891
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-180 no. 10"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000574"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000531-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100531"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200573"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000531-B"
+          ],
+          "uniformTitle": [
+            "Vedas. Atharvaveda. French. Selections."
+          ],
+          "updatedAt": 1674870762646,
+          "publicationStatement": [
+            "Paris, J. Maisonneuve, 1891."
+          ],
+          "identifier": [
+            "urn:bnum:10000574",
+            "urn:oclc:NYPG001000531-B",
+            "urn:undefined:NNSZ00100531",
+            "urn:undefined:(WaOLN)nyp0200573"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1891"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Les hymnes rohitas [microform] Livre XIII de l'Atharva-Véda, traduit et commenté par Victor Henry."
+          ],
+          "uri": "b10000574",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "8̕."
+          ]
+        },
+        "sort": [
+          "b10000574"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30080033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-180 11 misc oriental titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-180 11 misc oriental titles",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673077"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "11 misc oriental titles"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-180"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673077"
+                    ],
+                    "idBarcode": [
+                      "33433105673077"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZO-180 11 misc oriental titles"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000575",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "23 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sloman, Jane, 1824-",
+            "Pianists",
+            "Pianists -- England",
+            "Pianists -- England -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dutton and Wentworth"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1841
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A Biographical sketch of Jane Sloman, the celebrated pianiste"
+          ],
+          "shelfMark": [
+            "*ZB-1040"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1841"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1841
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZB-1040"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000575"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000532-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100532"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200574"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000532-B"
+          ],
+          "updatedAt": 1674870772746,
+          "publicationStatement": [
+            "Boston : Dutton and Wentworth, 1841."
+          ],
+          "identifier": [
+            "urn:bnum:10000575",
+            "urn:oclc:NYPG001000532-B",
+            "urn:undefined:NNSZ00100532",
+            "urn:undefined:(WaOLN)nyp0200574"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1841"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sloman, Jane, 1824-",
+            "Pianists -- England -- Biography."
+          ],
+          "titleDisplay": [
+            "A Biographical sketch of Jane Sloman, the celebrated pianiste [microform]."
+          ],
+          "uri": "b10000575",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Boston"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          "b10000575"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17446753",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "*ZB-1040"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZB-1040",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZB-1040"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZB-001040"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000576",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxviii, 469 p. illus., maps (part fold.)"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published under title: A history of Egypt under the Pharaohs.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Egypt",
+            "Egypt -- History",
+            "Egypt -- History -- To 332 B.C"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "J. Murray"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1891
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Egypt under the Pharaohs a history derived entirely from the monuments."
+          ],
+          "shelfMark": [
+            "*ZO-185 no. 5"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Brugsch, Heinrich, 1827-1894."
+          ],
+          "createdString": [
+            "1891"
+          ],
+          "idLccn": [
+            "49042562"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1891
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-185 no. 5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000576"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "49042562"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000533-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100533"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200575"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000533-B"
+          ],
+          "updatedAt": 1674870767447,
+          "publicationStatement": [
+            "London, J. Murray, 1891."
+          ],
+          "identifier": [
+            "urn:bnum:10000576",
+            "urn:lccn:49042562",
+            "urn:oclc:NYPG001000533-B",
+            "urn:undefined:NNSZ00100533",
+            "urn:undefined:(WaOLN)nyp0200575"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1891"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Egypt -- History -- To 332 B.C."
+          ],
+          "titleDisplay": [
+            "Egypt under the Pharaohs [microform] a history derived entirely from the monuments."
+          ],
+          "uri": "b10000576",
+          "lccClassification": [
+            "DT83 .89 1891"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000576"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30080739",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-185 5 misc oriental titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-185 5 misc oriental titles",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673168"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "5 misc oriental titles"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-185"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673168"
+                    ],
+                    "idBarcode": [
+                      "33433105673168"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZO-185 5 misc oriental titles"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000577",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "137 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Chinese language",
+            "Chinese language -- Writing"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "C. B. Norton"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1854
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Discoveries in Chinese, or, The symbolism of the primitive characters of the Chinese system of writing As a contribution to philology and ethnology and a practical aid in the acquisition of the Chinese language"
+          ],
+          "shelfMark": [
+            "*ZO-185 no. 1"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Andrews, Stephen Pearl, 1812-1886."
+          ],
+          "createdString": [
+            "1854"
+          ],
+          "idLccn": [
+            "12008608"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1854
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-185 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000577"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "12008608"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000534-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100534"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200576"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000534-B"
+          ],
+          "updatedAt": 1674870772746,
+          "publicationStatement": [
+            "New York, C. B. Norton, 1854."
+          ],
+          "identifier": [
+            "urn:bnum:10000577",
+            "urn:lccn:12008608",
+            "urn:oclc:NYPG001000534-B",
+            "urn:undefined:NNSZ00100534",
+            "urn:undefined:(WaOLN)nyp0200576"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1854"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Chinese language -- Writing."
+          ],
+          "titleDisplay": [
+            "Discoveries in Chinese, or, The symbolism of the primitive characters of the Chinese system of writing [microform] As a contribution to philology and ethnology and a practical aid in the acquisition of the Chinese language, by Stephen Pearl Andrews."
+          ],
+          "uri": "b10000577",
+          "lccClassification": [
+            "PL1171 .A6"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Discoveries in Chinese",
+            "Symbolism of the primitive characters of the Chinese system of writing"
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000577"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30080739",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-185 5 misc oriental titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-185 5 misc oriental titles",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673168"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "5 misc oriental titles"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-185"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673168"
+                    ],
+                    "idBarcode": [
+                      "33433105673168"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZO-185 5 misc oriental titles"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000578",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "vi, 285 p. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindustani language",
+            "Hindustani language -- Glossaries, vocabularies, etc",
+            "Agriculture",
+            "Agriculture -- Terminology"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Supt. of Govt. Printing"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1888
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A rural and agricultural glossary for the N.-W. provinces and Oudh"
+          ],
+          "shelfMark": [
+            "*ZO-187 no. 6"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Crooke, William, 1848-1923."
+          ],
+          "createdString": [
+            "1888"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1888
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-187 no. 6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000578"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000535-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100535"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200577"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000535-B"
+          ],
+          "updatedAt": 1674870767447,
+          "publicationStatement": [
+            "Calcutta, Supt. of Govt. Printing, 1888."
+          ],
+          "identifier": [
+            "urn:bnum:10000578",
+            "urn:oclc:NYPG001000535-B",
+            "urn:undefined:NNSZ00100535",
+            "urn:undefined:(WaOLN)nyp0200577"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1888"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindustani language -- Glossaries, vocabularies, etc.",
+            "Agriculture -- Terminology."
+          ],
+          "titleDisplay": [
+            "A rural and agricultural glossary for the N.-W. provinces and Oudh [microform] [By] William Crooke."
+          ],
+          "uri": "b10000578",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Calcutta"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "4̕."
+          ]
+        },
+        "sort": [
+          "b10000578"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30081049",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-187 9 misc oriental titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-187 9 misc oriental titles",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673309"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "9 misc oriental titles"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-187"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673309"
+                    ],
+                    "idBarcode": [
+                      "33433105673309"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZO-187 9 misc oriental titles"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000985",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "22, 460 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reprint of the 1884 ed. published in Lahore.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Urdu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Lahore (Pakistan)",
+            "Lahore (Pakistan) -- History"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Majlis-i Taraqqī-i Adab"
+          ],
+          "language": [
+            {
+              "id": "lang:urd",
+              "label": "Urdu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1977
+          ],
+          "dateEndString": [
+            "1884"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tārīkh-i Lāhaur"
+          ],
+          "shelfMark": [
+            "*OKTY 82-4463"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "KanhaiyyĀ Lāl Hindī, 1830-1888."
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Fāiq, Kalb ʻAlī Khān."
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTY 82-4463"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000985"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002000395-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00200995"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200984"
+            }
+          ],
+          "idOclc": [
+            "NYPG002000395-B"
+          ],
+          "dateEndYear": [
+            1884
+          ],
+          "updatedAt": 1674870777259,
+          "publicationStatement": [
+            "Lāhau : Majlis-i Taraqqī-i Adab, 1977."
+          ],
+          "identifier": [
+            "urn:bnum:10000985",
+            "urn:oclc:NYPG002000395-B",
+            "urn:undefined:NNSZ00200995",
+            "urn:undefined:(WaOLN)nyp0200984"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Lahore (Pakistan) -- History."
+          ],
+          "titleDisplay": [
+            "Tārīkh-i Lāhaur / muṣannifah-yi Kanhaiyyā Lāl Hindī ;murattabah-yi Kalb ʻalī Khān Fāʼiq."
+          ],
+          "uri": "b10000985",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Lāhau"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000985"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000619",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTY 82-4463"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTY 82-4463",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011242603"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTY 82-4463"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011242603"
+                    ],
+                    "idBarcode": [
+                      "33433011242603"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTY 82-004463"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001056",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "67 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "s.l.,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1983"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Buḥūr al-ḥikmah [microform]."
+          ],
+          "shelfMark": [
+            "*ZO-243 no. 1"
+          ],
+          "creatorLiteral": [
+            "Baháʼuʼlláh, 1817-1892."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-243 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001056"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201067"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201055"
+            }
+          ],
+          "dateEndYear": [
+            1983
+          ],
+          "updatedAt": 1636079365906,
+          "publicationStatement": [
+            "[New Delhi? : s.l., 19-]"
+          ],
+          "identifier": [
+            "urn:bnum:10001056",
+            "urn:undefined:NNSZ00201067",
+            "urn:undefined:(WaOLN)nyp0201055"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Buḥūr al-ḥikmah [microform]."
+          ],
+          "uri": "b10001056",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[New Delhi? :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "14 cm."
+          ]
+        },
+        "sort": [
+          "b10001056"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673531"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-243"
+                    ],
+                    "shelfMark_sort": "a*ZO-243 11 Arabic titles",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30081267",
+                    "shelfMark": [
+                      "*ZO-243 11 Arabic titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZO-243 11 Arabic titles"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673531"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "11 Arabic titles"
+                    ],
+                    "idBarcode": [
+                      "33433105673531"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001080",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "577 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"The first printed book in Malayalam\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Facsimile reproduction of old Malayalam and transcription, paraphrase, and notes in modern Malayalam, on opposite pages.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Original t.p. reads: Nasṟāṇikaḷ okkakkuṃ aṟiyeṇṭunna saṅkṣepavedārtthaṃ=Compendiosa legis explanatio omnibus Christianis scitu necessaria. Malabarico idiomate. Romāyilninn Miśihā pirṟannīṭṭ 1772 śṟȧṣṭa melpaṭṭakkāraruṭe anuvādattāl=Romae An. A nativit. Christi 1772, praisidum facultate\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Catholic Church. Syro-Malabar rite",
+            "Christianity",
+            "Christianity -- Philosophy"
+          ],
+          "publisherLiteral": [
+            "Ḍi. Ṣi. Buks ; Kārmel Pabḷiṣiṅg Senṟar,"
+          ],
+          "language": [
+            {
+              "id": "lang:mal",
+              "label": "Malayalam"
+            }
+          ],
+          "dateEndString": [
+            "1772"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Saṅkṣēpavēdartthaṃ : tṟānsliṯṯaṟēṣanuṃ parāvarttanavuṃ vyākhayānavuṃ ataṅṅiya putiya patipp"
+          ],
+          "shelfMark": [
+            "*OLD 84-299"
+          ],
+          "creatorLiteral": [
+            "Piyāniyas, Kḷemanṟ, 1731-1782."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82904075"
+          ],
+          "contributorLiteral": [
+            "Choondal, Chummar, 1940-",
+            "Mathew, Ulakamthara."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLD 84-299"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001080"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82904075"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201091"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201079"
+            }
+          ],
+          "dateEndYear": [
+            1772
+          ],
+          "updatedAt": 1636128328325,
+          "publicationStatement": [
+            "Kōṭṭayaṃ : Ḍi. Ṣi. Buks ; Tiruvanantapuraṃ : Kārmel Pabḷiṣiṅg Senṟar, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10001080",
+            "urn:lccn:82904075",
+            "urn:undefined:NNSZ00201091",
+            "urn:undefined:(WaOLN)nyp0201079"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Catholic Church. Syro-Malabar rite.",
+            "Christianity -- Philosophy."
+          ],
+          "titleDisplay": [
+            "Saṅkṣēpavēdartthaṃ : tṟānsliṯṯaṟēṣanuṃ parāvarttanavuṃ vyākhayānavuṃ ataṅṅiya putiya patipp / Kḷemanṟ Piyāniyas = Samkshepa vedartham / by Clement Pianius ; introduction by Chummar Choondel ; commentary by Mathew Ulakamthara."
+          ],
+          "uri": "b10001080",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kōṭṭayaṃ : Tiruvanantapuraṃ :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10001080"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011099029"
+                    ],
+                    "physicalLocation": [
+                      "*OLD 84-299"
+                    ],
+                    "shelfMark_sort": "a*OLD 84-000299",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10000682",
+                    "shelfMark": [
+                      "*OLD 84-299"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLD 84-299"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011099029"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433011099029"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001550",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 v. (no paging) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Shīʻah",
+            "Shīʻah -- Doctrines"
+          ],
+          "publisherLiteral": [
+            "Chāpkhānah-ʼi Ḥajī ʻAbd al-Ḥamīd"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1851"
+          ],
+          "createdYear": [
+            1850
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "[Zubdat al-maʻārif"
+          ],
+          "shelfMark": [
+            "*OGI+ 82-3286"
+          ],
+          "creatorLiteral": [
+            "Iṣfahānī, Mullā ʻAlī Akbar."
+          ],
+          "createdString": [
+            "1850"
+          ],
+          "dateStartYear": [
+            1850
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGI+ 82-3286"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001550"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201585"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201548"
+            }
+          ],
+          "dateEndYear": [
+            1851
+          ],
+          "updatedAt": 1653404628152,
+          "publicationStatement": [
+            "[Tihrān?] : Chāpkhānah-ʼi Ḥajī ʻAbd al-Ḥamīd, 1267 [1850 or 1851]"
+          ],
+          "identifier": [
+            "urn:bnum:10001550",
+            "urn:undefined:NNSZ00201585",
+            "urn:undefined:(WaOLN)nyp0201548"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1850"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Shīʻah -- Doctrines."
+          ],
+          "titleDisplay": [
+            "[Zubdat al-maʻārif / Ākhund Mullā ʻAlī Akbar Iṣfahānī]."
+          ],
+          "uri": "b10001550",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Tihrān?]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "34 cm."
+          ]
+        },
+        "sort": [
+          "b10001550"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058659826"
+                    ],
+                    "shelfMark_sort": "a*OGI+ 82-003286",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784096",
+                    "shelfMark": [
+                      "*OGI+ 82-3286"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058659826"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433058659826"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001735",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Handbooks, vade-mecums, etc",
+            "Middle East",
+            "Middle East -- Biography"
+          ],
+          "publisherLiteral": [
+            "s.n"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1873
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nuzhat al-jalīs wa-munyat al-adīb al-anīs"
+          ],
+          "shelfMark": [
+            "*ZO-158 no. 9"
+          ],
+          "creatorLiteral": [
+            "Mūsawī, al-ʻAbbās ibn ʻAlī, active 1735."
+          ],
+          "createdString": [
+            "1873"
+          ],
+          "dateStartYear": [
+            1873
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-158 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001735"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201770"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201733"
+            }
+          ],
+          "updatedAt": 1657681910685,
+          "publicationStatement": [
+            "[al-Qāhirah : s.n, 1873?]"
+          ],
+          "identifier": [
+            "urn:bnum:10001735",
+            "urn:undefined:NNSZ00201770",
+            "urn:undefined:(WaOLN)nyp0201733"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1873"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Handbooks, vade-mecums, etc.",
+            "Middle East -- Biography."
+          ],
+          "titleDisplay": [
+            "Nuzhat al-jalīs wa-munyat al-adīb al-anīs [microform] / taʼlīf al-ʻAbbās ibn ʻAlī ibn Nūr al-Dīn al-Makkī al-Ḥusaynī al-Mūsawī."
+          ],
+          "uri": "b10001735",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "8̕."
+          ]
+        },
+        "sort": [
+          "b10001735"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433098135548"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-158"
+                    ],
+                    "shelfMark_sort": "a*ZO-158 no. 000001-10",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30154976",
+                    "shelfMark": [
+                      "*ZO-158 no. 1-10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZO-158 no. 1-10"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433098135548"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-10"
+                    ],
+                    "idBarcode": [
+                      "33433098135548"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001741",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "ʻIyāḍ ibn Mūsá, 1083-1149"
+          ],
+          "publisherLiteral": [
+            "Matbaa-yi Osmaniye,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1897"
+          ],
+          "createdYear": [
+            1894
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nasīm al-riyāḍ fī sharḥ Shifāʼ al-Qāḍī ʻIyāḍ [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-162"
+          ],
+          "creatorLiteral": [
+            "Khafājī, Aḥmad ibn Muḥammad, -1659."
+          ],
+          "createdString": [
+            "1894"
+          ],
+          "contributorLiteral": [
+            "Schiff Collection."
+          ],
+          "dateStartYear": [
+            1894
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-162"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001741"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201776"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201739"
+            }
+          ],
+          "dateEndYear": [
+            1897
+          ],
+          "updatedAt": 1641230723038,
+          "publicationStatement": [
+            "Der-i Saadet : Matbaa-yi Osmaniye, 1312-17 [1894-97]"
+          ],
+          "identifier": [
+            "urn:bnum:10001741",
+            "urn:undefined:NNSZ00201776",
+            "urn:undefined:(WaOLN)nyp0201739"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1894"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "ʻIyāḍ ibn Mūsá, 1083-1149."
+          ],
+          "titleDisplay": [
+            "Nasīm al-riyāḍ fī sharḥ Shifāʼ al-Qāḍī ʻIyāḍ [microform] / li-Aḥmad Shihāb al-Dīn al-Khafājī al-Miṣrī."
+          ],
+          "uri": "b10001741",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Der-i Saadet :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "4̕."
+          ]
+        },
+        "sort": [
+          "b10001741"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105672749"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-162"
+                    ],
+                    "shelfMark_sort": "a*ZO-162 1894-001897",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30079670",
+                    "shelfMark": [
+                      "*ZO-162 1894-1897"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZO-162 1894-1897"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105672749"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "1894-1897"
+                    ],
+                    "idBarcode": [
+                      "33433105672749"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001747",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "8, 148 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "On margin: Aṭbāq al-dhahab / ʻAbd al-Muʼmin al-Maghribī.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Middle East",
+            "Middle East -- Biography"
+          ],
+          "publisherLiteral": [
+            "al-Maṭbaʻah al-ʻĀmirah al-Sharafīyah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            1890
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tuḥfat ahl al-fukāhah fī al-munādamah wa-al-nazāhah"
+          ],
+          "shelfMark": [
+            "*ZO-158 no. 10"
+          ],
+          "creatorLiteral": [
+            "Muḥammad Saʻd ibn Muḥammad Saʻd al-Miṣrī."
+          ],
+          "createdString": [
+            "1890"
+          ],
+          "contributorLiteral": [
+            "Maghribī, ʻAbd al-Muʼmin.",
+            "Schiff Collection."
+          ],
+          "dateStartYear": [
+            1890
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-158 no. 10"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001747"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201782"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201745"
+            }
+          ],
+          "updatedAt": 1657681910685,
+          "publicationStatement": [
+            "al-Qāhirah : al-Maṭbaʻah al-ʻĀmirah al-Sharafīyah, 1307 [1890]"
+          ],
+          "identifier": [
+            "urn:bnum:10001747",
+            "urn:undefined:NNSZ00201782",
+            "urn:undefined:(WaOLN)nyp0201745"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1890"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Middle East -- Biography."
+          ],
+          "titleDisplay": [
+            "Tuḥfat ahl al-fukāhah [microform] : fī al-munādamah wa-al-nazāhah / li-Muḥammad Afandī Saʻd."
+          ],
+          "uri": "b10001747",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "8 degrees."
+          ]
+        },
+        "sort": [
+          "b10001747"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433098135548"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-158"
+                    ],
+                    "shelfMark_sort": "a*ZO-158 no. 000001-10",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30154976",
+                    "shelfMark": [
+                      "*ZO-158 no. 1-10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZO-158 no. 1-10"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433098135548"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-10"
+                    ],
+                    "idBarcode": [
+                      "33433098135548"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001936",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "400 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Publication date from cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Also available on microform;",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Armenian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Microfilmed;",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Armenians",
+            "Armenians -- Iran",
+            "Armenians -- Iran -- History"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tparan Hovhannu Tēr-Abrahamian"
+          ],
+          "language": [
+            {
+              "id": "lang:arm",
+              "label": "Armenian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1891
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Niwtʻer azgayin patmutʻian hamar Ereveli hay kazunkʻ ; Parskastan"
+          ],
+          "shelfMark": [
+            "*ONR 84-743"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Shermazanian, Galust."
+          ],
+          "createdString": [
+            "1891"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "dateStartYear": [
+            1891
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ONR 84-743"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001936"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG002001377-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201976"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201934"
+            }
+          ],
+          "idOclc": [
+            "NYPG002001377-B"
+          ],
+          "updatedAt": 1671714296499,
+          "publicationStatement": [
+            "Ṛostov (Doni Vra) : Tparan Hovhannu Tēr-Abrahamian, 1890 [i.e. 1891]"
+          ],
+          "identifier": [
+            "urn:bnum:10001936",
+            "urn:oclc:NYPG002001377-B",
+            "urn:undefined:NNSZ00201976",
+            "urn:undefined:(WaOLN)nyp0201934"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1891"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Armenians -- Iran -- History."
+          ],
+          "titleDisplay": [
+            "Niwtʻer azgayin patmutʻian hamar Ereveli hay kazunkʻ ; Parskastan / Ashkhatasirutʻiamb Galust Shermazaniani."
+          ],
+          "uri": "b10001936",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ṛostov (Doni Vra)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10001936"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10001936-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://hdl.handle.net/2027/nyp.33433001892276",
+                        "label": "Full text available via HathiTrust"
+                      }
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "bi10001936-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10001320",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ONR 84-743"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ONR 84-743",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001892276"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ONR 84-743"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001892276"
+                    ],
+                    "idBarcode": [
+                      "33433001892276"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ONR 84-000743"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002107",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "H. Laakmann,"
+          ],
+          "language": [
+            {
+              "id": "lang:est",
+              "label": "Estonian"
+            }
+          ],
+          "createdYear": [
+            1881
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Wenemaa ajaloost."
+          ],
+          "shelfMark": [
+            "JFB 82-48 no. 4"
+          ],
+          "createdString": [
+            "1881"
+          ],
+          "dateStartYear": [
+            1881
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFB 82-48 no. 4"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002107"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202149"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202103"
+            }
+          ],
+          "updatedAt": 1636143254095,
+          "publicationStatement": [
+            "Tartus: H. Laakmann, 1881."
+          ],
+          "identifier": [
+            "urn:bnum:10002107",
+            "urn:undefined:NNSZ00202149",
+            "urn:undefined:(WaOLN)nyp0202103"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1881"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Wenemaa ajaloost."
+          ],
+          "uri": "b10002107",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tartus:"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "13 cm"
+          ]
+        },
+        "sort": [
+          "b10002107"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005146166"
+                    ],
+                    "physicalLocation": [
+                      "JFB 82-48 no. 1"
+                    ],
+                    "shelfMark_sort": "aJFB 82-48 no. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10001452",
+                    "shelfMark": [
+                      "JFB 82-48 no. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFB 82-48 no. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005146166"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433005146166"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002108",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. ; 13 cm."
+          ],
+          "publicationStatement": [
+            "Tartus : M. Laakmann, 1881."
+          ],
+          "identifier": [
+            "urn:bnum:10002108",
+            "urn:undefined:NNSZ00202150",
+            "urn:undefined:(WaOLN)nyp0202104"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "M. Laakmann,"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1881"
+          ],
+          "language": [
+            {
+              "id": "lang:est",
+              "label": "Estonian"
+            }
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "createdYear": [
+            1881
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rätsepp Kergepüks."
+          ],
+          "titleDisplay": [
+            "Rätsepp Kergepüks."
+          ],
+          "shelfMark": [
+            "JFB 82-48 no. 3"
+          ],
+          "uri": "b10002108",
+          "createdString": [
+            "1881"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "dateStartYear": [
+            1881
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFB 82-48 no. 3"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002108"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202150"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202104"
+            }
+          ],
+          "placeOfPublication": [
+            "Tartus :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "updatedAt": 1636127692677
+        },
+        "sort": [
+          "b10002108"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005146166"
+                    ],
+                    "physicalLocation": [
+                      "JFB 82-48 no. 1"
+                    ],
+                    "shelfMark_sort": "aJFB 82-48 no. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10001452",
+                    "shelfMark": [
+                      "JFB 82-48 no. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFB 82-48 no. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005146166"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433005146166"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002109",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "H. Laakmann,"
+          ],
+          "language": [
+            {
+              "id": "lang:est",
+              "label": "Estonian"
+            }
+          ],
+          "createdYear": [
+            1881
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Masajalg."
+          ],
+          "shelfMark": [
+            "JFB 82-48 no. 1"
+          ],
+          "createdString": [
+            "1881"
+          ],
+          "dateStartYear": [
+            1881
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFB 82-48 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002109"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202151"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202105"
+            }
+          ],
+          "updatedAt": 1636115332522,
+          "publicationStatement": [
+            "Tartus : H. Laakmann, 1881."
+          ],
+          "identifier": [
+            "urn:bnum:10002109",
+            "urn:undefined:NNSZ00202151",
+            "urn:undefined:(WaOLN)nyp0202105"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1881"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Masajalg."
+          ],
+          "uri": "b10002109",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tartus :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "13 cm."
+          ]
+        },
+        "sort": [
+          "b10002109"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005146166"
+                    ],
+                    "physicalLocation": [
+                      "JFB 82-48 no. 1"
+                    ],
+                    "shelfMark_sort": "aJFB 82-48 no. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10001452",
+                    "shelfMark": [
+                      "JFB 82-48 no. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFB 82-48 no. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005146166"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433005146166"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002118",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "204 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Wakālat Nāy,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1999"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Awlād bi-al-jumlah"
+          ],
+          "shelfMark": [
+            "*OFD 82-4488"
+          ],
+          "creatorLiteral": [
+            "Gilbreth, Frank B. (Frank Bunker), 1911-2001."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "contributorLiteral": [
+            "Carey, Ernestine Moller, 1908-",
+            "Ṭāhā, Aḥmad."
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFD 82-4488"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202160"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202114"
+            }
+          ],
+          "uniformTitle": [
+            "Cheaper by the dozen. Arabic"
+          ],
+          "dateEndYear": [
+            1999
+          ],
+          "updatedAt": 1636076222810,
+          "publicationStatement": [
+            "Dimashq : Wakālat Nāy, 19--."
+          ],
+          "identifier": [
+            "urn:bnum:10002118",
+            "urn:undefined:NNSZ00202160",
+            "urn:undefined:(WaOLN)nyp0202114"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Awlād bi-al-jumlah / taʼlīf Firānk Bi. Jīlbrith wa-Irnistin Jīlbrith Kārī ; tarjumat Aḥmad Ṭaha."
+          ],
+          "uri": "b10002118",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Cheaper by the dozen."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10002118"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001997497"
+                    ],
+                    "physicalLocation": [
+                      "*OFD 82-4488"
+                    ],
+                    "shelfMark_sort": "a*OFD 82-004488",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10001459",
+                    "shelfMark": [
+                      "*OFD 82-4488"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFD 82-4488"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001997497"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001997497"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002588",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "24 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At head of title: Not published.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jews",
+            "Jews -- Conversion to Christianity",
+            "Missions to Jews"
+          ],
+          "publisherLiteral": [
+            "s.n."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1840
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Report of the late agency of the Rev. J.S.C.F. Frey presented to the Board of Managers of the American Society for Meliorating the Condition of the Jews."
+          ],
+          "shelfMark": [
+            "*XMH-2174"
+          ],
+          "creatorLiteral": [
+            "Frey, Joseph Samuel C. F. (Joseph Samuel Christian Frederick), 1771-1850."
+          ],
+          "createdString": [
+            "1840"
+          ],
+          "contributorLiteral": [
+            "American Society for Meliorating the Condition of the Jews."
+          ],
+          "dateStartYear": [
+            1840
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*XMH-2174"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002588"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00302930"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202584"
+            }
+          ],
+          "updatedAt": 1657980319626,
+          "publicationStatement": [
+            "[New York : s.n., 1840?]"
+          ],
+          "identifier": [
+            "urn:bnum:10002588",
+            "urn:undefined:NNSZ00302930",
+            "urn:undefined:(WaOLN)nyp0202584"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1840"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jews -- Conversion to Christianity.",
+            "Missions to Jews."
+          ],
+          "titleDisplay": [
+            "Report of the late agency of the Rev. J.S.C.F. Frey [microform] : presented to the Board of Managers of the American Society for Meliorating the Condition of the Jews."
+          ],
+          "uri": "b10002588",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "[New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10002588"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002627",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "48 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Horses"
+          ],
+          "publisherLiteral": [
+            "Bokförlaget Rediviva"
+          ],
+          "language": [
+            {
+              "id": "lang:swe",
+              "label": "Swedish"
+            }
+          ],
+          "dateEndString": [
+            "1837"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Undervisning i hästkännedom för korporals-skolorna vid kavalleriet inom fjerde militär-districtet"
+          ],
+          "shelfMark": [
+            "*XM-15430"
+          ],
+          "creatorLiteral": [
+            "Billing, J. S."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*XM-15430"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002627"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9171201017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00302971"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202622"
+            }
+          ],
+          "dateEndYear": [
+            1837
+          ],
+          "updatedAt": 1657981583132,
+          "publicationStatement": [
+            "Stockholm : Bokförlaget Rediviva, 1978."
+          ],
+          "identifier": [
+            "urn:bnum:10002627",
+            "urn:isbn:9171201017",
+            "urn:undefined:NNSZ00302971",
+            "urn:undefined:(WaOLN)nyp0202622"
+          ],
+          "idIsbn": [
+            "9171201017"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Horses."
+          ],
+          "titleDisplay": [
+            "Undervisning i hästkännedom för korporals-skolorna [microform] : vid kavalleriet inom fjerde militär-districtet / uppraättad af J. S. Billing."
+          ],
+          "uri": "b10002627",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Stockholm"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "9171201017"
+          ],
+          "dimensions": [
+            "15 cm."
+          ]
+        },
+        "sort": [
+          "b10002627"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002631",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "44 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Socialism"
+          ],
+          "publisherLiteral": [
+            "Trübsche Buchh."
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1882
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Wetterleuchten, der Staatssozialismus und seine Consequenzen. Erster Theil"
+          ],
+          "shelfMark": [
+            "*XME-10755"
+          ],
+          "creatorLiteral": [
+            "Locher, Friedrich, 1820-1911."
+          ],
+          "createdString": [
+            "1882"
+          ],
+          "dateStartYear": [
+            1882
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*XME-10755"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002631"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00302975"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202626"
+            }
+          ],
+          "updatedAt": 1657981583132,
+          "publicationStatement": [
+            "Zürich : Trübsche Buchh., 1882."
+          ],
+          "identifier": [
+            "urn:bnum:10002631",
+            "urn:undefined:NNSZ00302975",
+            "urn:undefined:(WaOLN)nyp0202626"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1882"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Socialism."
+          ],
+          "titleDisplay": [
+            "Wetterleuchten, der Staatssozialismus und seine Consequenzen. Erster Theil [microform] / von Friedrich Locher."
+          ],
+          "uri": "b10002631",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Zürich"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10002631"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003085",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "8, 172, 10 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A revision of the authoress' thesis, Varanaseya Sanskrit Vishwavidyalaya.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [1]-5 (3rd group)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hinduism",
+            "Hinduism -- Rites and ceremonies",
+            "Vedas"
+          ],
+          "publisherLiteral": [
+            "[Vārāṇaseya-Saṃskṛta-Viśvavidyālayaḥ."
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "1889"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Atharvavede śāntipuṣṭikarmāṇi."
+          ],
+          "shelfMark": [
+            "*OLY 83-704"
+          ],
+          "creatorLiteral": [
+            "Malaviya, Maya, 1939-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "sa 68016943"
+          ],
+          "seriesStatement": [
+            "Sarasvatībhavana - Adhyayanamālā, 17"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-704"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003085"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68016943"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303436"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203078"
+            }
+          ],
+          "dateEndYear": [
+            1889
+          ],
+          "updatedAt": 1636075653207,
+          "publicationStatement": [
+            "Vārāṇasyām [Vārāṇaseya-Saṃskṛta-Viśvavidyālayaḥ. 1889 tame Śakābde [1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10003085",
+            "urn:lccn:sa 68016943",
+            "urn:undefined:NNSZ00303436",
+            "urn:undefined:(WaOLN)nyp0203078"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hinduism -- Rites and ceremonies.",
+            "Vedas."
+          ],
+          "titleDisplay": [
+            "Atharvavede śāntipuṣṭikarmāṇi. Lekhikā sampādikā ca Māyā Mālavīyā."
+          ],
+          "uri": "b10003085",
+          "lccClassification": [
+            "BL1226.2 .M32 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasyām"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003085"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784336",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-704"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-704",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417965"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-704"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417965"
+                    ],
+                    "idBarcode": [
+                      "33433060417965"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-000704"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003088",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 16, 200 p. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- Varanaseya Sanskrit Vishwavidyalaya.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [198]-200.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Solar eclipses"
+          ],
+          "publisherLiteral": [
+            "Vārāṇaseya-Saṃskṛta-Viśvavidyālayaḥ["
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "1889"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sūryagrahaṇam."
+          ],
+          "shelfMark": [
+            "*OKQ 83-703"
+          ],
+          "creatorLiteral": [
+            "Dvivedī, Kṛṣṇacandra."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "sa 68014918"
+          ],
+          "seriesStatement": [
+            "Sarasvatībhavana - Adhyayanamālā, .15"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKQ 83-703"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003088"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68014918"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303439"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203081"
+            }
+          ],
+          "dateEndYear": [
+            1889
+          ],
+          "updatedAt": 1636132203514,
+          "publicationStatement": [
+            "Vārāṇasyām, Vārāṇaseya-Saṃskṛta-Viśvavidyālayaḥ[ 1889 tame śakāb de [1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10003088",
+            "urn:lccn:sa 68014918",
+            "urn:undefined:NNSZ00303439",
+            "urn:undefined:(WaOLN)nyp0203081"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Solar eclipses."
+          ],
+          "titleDisplay": [
+            "Sūryagrahaṇam. Lekhakaḥ sampādakaśca Kṛṣnacandra-dvivedī."
+          ],
+          "uri": "b10003088",
+          "lccClassification": [
+            "QB541 .D83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasyām,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003088"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002896748"
+                    ],
+                    "physicalLocation": [
+                      "*OKQ 83-703"
+                    ],
+                    "shelfMark_sort": "a*OKQ 83-000703",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002163",
+                    "shelfMark": [
+                      "*OKQ 83-703"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKQ 83-703"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002896748"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433002896748"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003117",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "10, 192, 52 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reprint of the 1313 H. (1895 or 1896) ed. published by al-Sharikah al-Ṣiḥāfīyah al-ʻUthmānīyah, Istanbul.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bukhārī, Muḥammad ibn Ismāʻīl, 810-870.",
+            "Bukhārī, Muḥammad ibn Ismāʻīl, 810-870. -- Indexes",
+            "Hadith",
+            "Hadith -- Indexes",
+            "Muslim ibn al-Ḥajjāj al-Qushayrī, approximately 821-875.",
+            "Muslim ibn al-Ḥajjāj al-Qushayrī, approximately 821-875. -- Indexes"
+          ],
+          "publisherLiteral": [
+            "Dār al-Kutub al-ʻIlmīyah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1895"
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Miftāḥ al-Ṣaḥīḥayn Bukhārī wa-Muslim"
+          ],
+          "shelfMark": [
+            "*OGF 84-1307"
+          ],
+          "creatorLiteral": [
+            "Tawqādī, Muḥammad al-Sharīf ibn Muṣṭafá."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "77960426"
+          ],
+          "contributorLiteral": [
+            "Bukhārī, Muḥammad ibn Ismāʻīl, 810-870.",
+            "Muslim ibn al-Ḥajjāj al-Qushayrī, approximately 821-875."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGF 84-1307"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003117"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77960426"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303468"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203110"
+            }
+          ],
+          "dateEndYear": [
+            1895
+          ],
+          "updatedAt": 1636116228553,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Kutub al-ʻIlmīyah, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10003117",
+            "urn:lccn:77960426",
+            "urn:undefined:NNSZ00303468",
+            "urn:undefined:(WaOLN)nyp0203110"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bukhārī, Muḥammad ibn Ismāʻīl, 810-870. -- Indexes.",
+            "Hadith -- Indexes.",
+            "Muslim ibn al-Ḥajjāj al-Qushayrī, approximately 821-875. -- Indexes."
+          ],
+          "titleDisplay": [
+            "Miftāḥ al-Ṣaḥīḥayn Bukhārī wa-Muslim / Muḥammad al-Sharīf ibn Muṣṭafá al-Tūqādī."
+          ],
+          "uri": "b10003117",
+          "lccClassification": [
+            "BP135.2. T86 1975"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Miftāḥ Ṣaḥīḥ al-Bukhārī: Irshād al-sārī lil-Qasṭallānī. Fatḥ al-Bārī li-ibn Ḥajar al-ʻAsqulānī. ʻUmdat al-qārī lil-ʻAynī. Matn Ṣaḥīḥ al-Bukhārī. -- Miftāḥ Ṣaḥīḥ Muslim: al-Nawawī ʻalá Ṣaḥīḥ Muslim. Matn Ṣaḥīḥ Muslim."
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10003117"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013217298"
+                    ],
+                    "physicalLocation": [
+                      "*OGF 84-1307"
+                    ],
+                    "shelfMark_sort": "a*OGF 84-001307",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002177",
+                    "shelfMark": [
+                      "*OGF 84-1307"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OGF 84-1307"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013217298"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013217298"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003143",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "20, 784 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reproduced from Ms. copy.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Reprint of the ed. published in Teheran, 1272 A. H.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Shīʻah",
+            "Shīʻah -- Doctrines"
+          ],
+          "publisherLiteral": [
+            "Muʼassasat al-Aʻlamī lil-Maṭbūʻāt,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1855"
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ghāyat al-marām fī ḥujjat al-khiṣ̣ām ʻan ṭarīq al-khāṣṣ wa-al-ʻāmm,"
+          ],
+          "shelfMark": [
+            "*OGI+ 84-1305"
+          ],
+          "creatorLiteral": [
+            "Baḥrānī, Hāshim ibn Sulaymān, -1695 or 6."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75961367"
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGI+ 84-1305"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003143"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75961367"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303494"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203136"
+            }
+          ],
+          "dateEndYear": [
+            1855
+          ],
+          "updatedAt": 1641231073322,
+          "publicationStatement": [
+            "[Bayrūt, Muʼassasat al-Aʻlamī lil-Maṭbūʻāt, 1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10003143",
+            "urn:lccn:75961367",
+            "urn:undefined:NNSZ00303494",
+            "urn:undefined:(WaOLN)nyp0203136"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Shīʻah -- Doctrines."
+          ],
+          "titleDisplay": [
+            "Ghāyat al-marām fī ḥujjat al-khiṣ̣ām ʻan ṭarīq al-khāṣṣ wa-al-ʻāmm, lil-Baḥrānī."
+          ],
+          "uri": "b10003143",
+          "lccClassification": [
+            "BP194 .B3 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10003143"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058659842"
+                    ],
+                    "shelfMark_sort": "a*OGI+ 84-001305",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784359",
+                    "shelfMark": [
+                      "*OGI+ 84-1305"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058659842"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433058659842"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003146",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[i], 4, 120, 796 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p. in English: ... ed. by Ananda Chandra Vedantavagisa.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Version",
+              "label": "Originally published:",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Lāṭyāyanaśrautasūtra",
+            "Vedas"
+          ],
+          "publisherLiteral": [
+            "Munshiram Manoharlal Publishers,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "1872"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Srautasūtram"
+          ],
+          "shelfMark": [
+            "*OKH 84-1426"
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "contributorLiteral": [
+            "Agnisvāmi.",
+            "Kashikar, C. G.",
+            "Lāṭyāyanaśrautasūtra.",
+            "Vedāntavāgīśa, Ānandacandra."
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKH 84-1426"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003146"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303497"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203139"
+            }
+          ],
+          "uniformTitle": [
+            "Vedas. Sāmaveda Srautasutra."
+          ],
+          "dateEndYear": [
+            1872
+          ],
+          "updatedAt": 1636130442624,
+          "publicationStatement": [
+            "New Delhi : Munshiram Manoharlal Publishers, 1982."
+          ],
+          "identifier": [
+            "urn:bnum:10003146",
+            "urn:undefined:NNSZ00303497",
+            "urn:undefined:(WaOLN)nyp0203139"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Lāṭyāyanaśrautasūtra.",
+            "Vedas."
+          ],
+          "titleDisplay": [
+            "Srautasūtram / Lāṭyāyanācārya praṇītam ; Agnisvāmiviracitabhāṣyasahitam ; Śrīānandacandravēdāntavāgīśena pariśodhitam ; [with new appendix containing corrections and emendations to the text by Dr. C. G. Kashikar]."
+          ],
+          "uri": "b10003146",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10003146"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058568993"
+                    ],
+                    "shelfMark_sort": "a*OKH 84-001426",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784362",
+                    "shelfMark": [
+                      "*OKH 84-1426"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058568993"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433058568993"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003158",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "608 p. in various pagings ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reprint ed.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Chinese.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Medicine, Chinese"
+          ],
+          "publisherLiteral": [
+            "Xuan feng chu ban she ; Taipei : Zong jing xiao da zhong tu shu Gong si,"
+          ],
+          "language": [
+            {
+              "id": "lang:chi",
+              "label": "Chinese"
+            }
+          ],
+          "dateEndString": [
+            "1670"
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zheng yin mo zhi : [4 juan]"
+          ],
+          "shelfMark": [
+            "*OVL 84-1330"
+          ],
+          "creatorLiteral": [
+            "Qin, Changyu, active 17th century."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "77839836"
+          ],
+          "seriesStatement": [
+            "zhongguo yi yao zong shu."
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OVL 84-1330"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003158"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77839836"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303509"
+            }
+          ],
+          "dateEndYear": [
+            1670
+          ],
+          "updatedAt": 1641391919318,
+          "publicationStatement": [
+            "Taipei xian yonghe zhen : Xuan feng chu ban she ; Taipei : Zong jing xiao da zhong tu shu Gong si, Min'Guo 61[1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10003158",
+            "urn:lccn:77839836",
+            "urn:undefined:NNSZ00303509"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Medicine, Chinese."
+          ],
+          "titleDisplay": [
+            "Zheng yin mo zhi : [4 juan] / Qin Jingming [Changyu] zhu ; Qin Zhizheng ji ; [Cao Binzhang quan dian]."
+          ],
+          "uri": "b10003158",
+          "lccClassification": [
+            "R128.7 .C545"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Taipei xian yonghe zhen :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10003158"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001746852"
+                    ],
+                    "physicalLocation": [
+                      "*OVL 84-1330"
+                    ],
+                    "shelfMark_sort": "a*OVL 84-001330",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002193",
+                    "shelfMark": [
+                      "*OVL 84-1330"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OVL 84-1330"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001746852"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001746852"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003190",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "606 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Basavapurāṇavu.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Kannaḍa sāhitya caritre.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Basava, active 1160",
+            "Basava, active 1160 -- Poetry",
+            "Lingayats",
+            "Lingayats -- Poetry"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "1899"
+          ],
+          "createdYear": [
+            1800
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Basavapurāṇavu"
+          ],
+          "shelfMark": [
+            "*OLA+ 82-1360"
+          ],
+          "creatorLiteral": [
+            "Palakuriki Somanatha, active 13th century."
+          ],
+          "createdString": [
+            "1800"
+          ],
+          "contributorLiteral": [
+            "Bhīmakavi, active 1369."
+          ],
+          "dateStartYear": [
+            1800
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA+ 82-1360"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003190"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303541"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203183"
+            }
+          ],
+          "uniformTitle": [
+            "Basavapurāṇamu. Kannada"
+          ],
+          "dateEndYear": [
+            1899
+          ],
+          "updatedAt": 1636076831370,
+          "publicationStatement": [
+            "[S.1. : s.n., 18--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10003190",
+            "urn:undefined:NNSZ00303541",
+            "urn:undefined:(WaOLN)nyp0203183"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1800"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Basava, active 1160 -- Poetry.",
+            "Lingayats -- Poetry."
+          ],
+          "titleDisplay": [
+            "Basavapurāṇavu / [Bhīmakavi viracita ; Sōmanātha kaviya Telugu Basavapurāṇamuvina Kannaḍa anuvāda]."
+          ],
+          "uri": "b10003190",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.1. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Basavapurāṇamu."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10003190"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433069579674"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 82-001360",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784381",
+                    "shelfMark": [
+                      "*OLA+ 82-1360"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433069579674"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433069579674"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003301",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., map, facsims. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kurds",
+            "Kurds -- Iran",
+            "Kurds -- Iran -- History"
+          ],
+          "publisherLiteral": [
+            "Chāpkhānah-ʼi Kūshish,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ḥarikat-i tārikhī-i Kurd bih Khurāsān dar difāʻ az istiqlāl-i Īrān"
+          ],
+          "shelfMark": [
+            "*OMR 84-1145"
+          ],
+          "creatorLiteral": [
+            "Tavaḥḥudī Awghāzī, Kalīm Allāh."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMR 84-1145"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003301"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303655"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0000007"
+            }
+          ],
+          "dateEndYear": [
+            999
+          ],
+          "updatedAt": 1636103985760,
+          "publicationStatement": [
+            "Mashhad : Chāpkhānah-ʼi Kūshish, 1359-  [1981-  ]"
+          ],
+          "identifier": [
+            "urn:bnum:10003301",
+            "urn:undefined:NNSZ00303655",
+            "urn:undefined:(WaOLN)nyp0000007"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kurds -- Iran -- History."
+          ],
+          "titleDisplay": [
+            "Ḥarikat-i tārikhī-i Kurd bih Khurāsān dar difāʻ az istiqlāl-i Īrān / taʼlīf-i Kalīm Allāh Tavaḥḥudī (Awghāzi)"
+          ],
+          "uri": "b10003301",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Mashhad :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003301"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013135854"
+                    ],
+                    "physicalLocation": [
+                      "*OMR 84-1145"
+                    ],
+                    "shelfMark_sort": "a*OMR 84-1145 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002283",
+                    "shelfMark": [
+                      "*OMR 84-1145 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMR 84-1145 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013135854"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433013135854"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013135847"
+                    ],
+                    "physicalLocation": [
+                      "*OMR 84-1145"
+                    ],
+                    "shelfMark_sort": "a*OMR 84-1145 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002282",
+                    "shelfMark": [
+                      "*OMR 84-1145 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMR 84-1145 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013135847"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433013135847"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013136530"
+                    ],
+                    "physicalLocation": [
+                      "*OMR 84-1145"
+                    ],
+                    "shelfMark_sort": "a*OMR 84-1145 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002281",
+                    "shelfMark": [
+                      "*OMR 84-1145 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMR 84-1145 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013136530"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433013136530"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003564",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13, 496 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Abū Ṭālib Shīrāzī,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "createdYear": [
+            1859
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ḥadīqat al-ḥaqīqah va sharīʻat al-ṭarīqah"
+          ],
+          "shelfMark": [
+            "*OMQ 82-3324"
+          ],
+          "creatorLiteral": [
+            "Sanāʼī al-Ghaznavī, Abū al-Majd Majdūd ibn Ādam, -approximately 1150."
+          ],
+          "createdString": [
+            "1859"
+          ],
+          "dateStartYear": [
+            1859
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMQ 82-3324"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303920"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203556"
+            }
+          ],
+          "updatedAt": 1636103985797,
+          "publicationStatement": [
+            "Bumbaʼī : Abū Ṭālib Shīrāzī, 1859."
+          ],
+          "identifier": [
+            "urn:bnum:10003564",
+            "urn:undefined:NNSZ00303920",
+            "urn:undefined:(WaOLN)nyp0203556"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1859"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Ḥadīqat al-ḥaqīqah va sharīʻat al-ṭarīqah / Abū al-Majd Majdūd ibn Ādam al-Sanāʼī al-Ghaznavī."
+          ],
+          "uri": "b10003564",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bumbaʼī :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10003564"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013144385"
+                    ],
+                    "physicalLocation": [
+                      "*OMQ 82-3324"
+                    ],
+                    "shelfMark_sort": "a*OMQ 82-003324",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002468",
+                    "shelfMark": [
+                      "*OMQ 82-3324"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMQ 82-3324"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013144385"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013144385"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003703",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "253 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "J.R. Vilímek,"
+          ],
+          "language": [
+            {
+              "id": "lang:cze",
+              "label": "Czech"
+            }
+          ],
+          "dateEndString": [
+            "1983"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Listí po krajích rozváté : básně"
+          ],
+          "shelfMark": [
+            "*QVH 83-187"
+          ],
+          "creatorLiteral": [
+            "Svoboda, František Xaver, 1860-"
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "seriesStatement": [
+            "Spisy / F.X. Svobody ; 23"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*QVH 83-187"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003703"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304061"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203695"
+            }
+          ],
+          "dateEndYear": [
+            1983
+          ],
+          "updatedAt": 1636113429964,
+          "publicationStatement": [
+            "V Praze : J.R. Vilímek, [19--]."
+          ],
+          "identifier": [
+            "urn:bnum:10003703",
+            "urn:undefined:NNSZ00304061",
+            "urn:undefined:(WaOLN)nyp0203695"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Listí po krajích rozváté : básně / F. X. Svoboda."
+          ],
+          "uri": "b10003703",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "V Praze :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10003703"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011955378"
+                    ],
+                    "physicalLocation": [
+                      "*QVH 83-187"
+                    ],
+                    "shelfMark_sort": "a*QVH 83-000187",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002586",
+                    "shelfMark": [
+                      "*QVH 83-187"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*QVH 83-187"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011955378"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433011955378"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003857",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "319 p. : ill., plates, maps ;"
+          ],
+          "parallelDisplayField": [
+            {
+              "fieldName": "publicationStatement",
+              "index": 0,
+              "value": "‏بيروت : دار مكتبة الحياة, [196-؟]"
+            },
+            {
+              "fieldName": "placeOfPublication",
+              "index": 0,
+              "value": "‏بيروت :"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Yemen (Republic)"
+          ],
+          "publisherLiteral": [
+            "Dār Maktabat al-Ḥayāh,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            196
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Yaman wa-ḥaḍārat al-ʻArab, maʻa dirāsah jughrāfīyah kāmilah /"
+          ],
+          "parallelTitle": [
+            "‏اليمن وحضارة العرب, مع دراسة جغرافية كاملة /"
+          ],
+          "shelfMark": [
+            "*OFI 82-4419"
+          ],
+          "creatorLiteral": [
+            "Tarsīsī, ʻAdnān."
+          ],
+          "createdString": [
+            "196"
+          ],
+          "parallelPublisher": [
+            "‏دار مكتبة الحياة,"
+          ],
+          "idLccn": [
+            "ne 64003290"
+          ],
+          "dateStartYear": [
+            196
+          ],
+          "parallelCreatorLiteral": [
+            "‏ترسيسي, عدنان."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFI 82-4419"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003857"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ne 64003290"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11272192"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11272192"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)221366702"
+            }
+          ],
+          "idOclc": [
+            "11272192"
+          ],
+          "updatedAt": 1649121307527,
+          "publicationStatement": [
+            "Bayrūt : Dār Maktabat al-Ḥayāh, [196-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10003857",
+            "urn:lccn:ne 64003290",
+            "urn:oclc:11272192",
+            "urn:undefined:(OCoLC)11272192",
+            "urn:undefined:(OCoLC)221366702"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "196"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Yemen (Republic)"
+          ],
+          "titleDisplay": [
+            "al-Yaman wa-ḥaḍārat al-ʻArab, maʻa dirāsah jughrāfīyah kāmilah / [taʼlīf] ʻAdnān Tarsīsī."
+          ],
+          "uri": "b10003857",
+          "lccClassification": [
+            "DS247.Y4 T3"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏اليمن وحضارة العرب, مع دراسة جغرافية كاملة / [تاليف] عدنان ترسيسي."
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Includes musical score of national anthem of Yemen Arab Republic."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003857"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101143836"
+                    ],
+                    "physicalLocation": [
+                      "*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                    ],
+                    "shelfMark_sort": "a*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i29202258",
+                    "shelfMark": [
+                      "*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101143836"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433101143836"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002023293"
+                    ],
+                    "physicalLocation": [
+                      "*OFI 82-4419"
+                    ],
+                    "shelfMark_sort": "a*OFI 82-004419",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002714",
+                    "shelfMark": [
+                      "*OFI 82-4419"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFI 82-4419"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002023293"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433002023293"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004026",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[15], 409 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Based on conversation with Sayyāḥ yamanī.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sufism"
+          ],
+          "publisherLiteral": [
+            "s.n.,]"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1890"
+          ],
+          "createdYear": [
+            1889
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Haẕā Kitāb-i hadīqat al-inṣāf"
+          ],
+          "shelfMark": [
+            "*OMQ 82-3319"
+          ],
+          "creatorLiteral": [
+            "Sarmast Rūmī, ʻAbd al-Karīm Maḥmūd."
+          ],
+          "createdString": [
+            "1889"
+          ],
+          "contributorLiteral": [
+            "Sayyāḥ yamanī."
+          ],
+          "dateStartYear": [
+            1889
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMQ 82-3319"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004026"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304387"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204018"
+            }
+          ],
+          "dateEndYear": [
+            1890
+          ],
+          "updatedAt": 1636101588849,
+          "publicationStatement": [
+            "[S.l. : s.n.,] 1307 [1889 or 1890]"
+          ],
+          "identifier": [
+            "urn:bnum:10004026",
+            "urn:undefined:NNSZ00304387",
+            "urn:undefined:(WaOLN)nyp0204018"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1889"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sufism."
+          ],
+          "titleDisplay": [
+            "Haẕā Kitāb-i hadīqat al-inṣāf / [ʻAbd al-Karīm Sarmast Rūmī]."
+          ],
+          "uri": "b10004026",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Ḥadīqat al-inṣāf."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10004026"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013144377"
+                    ],
+                    "physicalLocation": [
+                      "*OMQ 82-3319"
+                    ],
+                    "shelfMark_sort": "a*OMQ 82-003319",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002864",
+                    "shelfMark": [
+                      "*OMQ 82-3319"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMQ 82-3319"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013144377"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013144377"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004080",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Bengali.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Esosiẏeṭeḍa Pābaliśārsa"
+          ],
+          "language": [
+            {
+              "id": "lang:ben",
+              "label": "Bengali"
+            }
+          ],
+          "dateEndString": [
+            "62"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Junāpura Sṭīla."
+          ],
+          "shelfMark": [
+            "*OKV 82-3891"
+          ],
+          "creatorLiteral": [
+            "Mānnā, Guṇamaẏa, 1925-2010."
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "sa 63003864"
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKV 82-3891"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004080"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 63003864"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304442"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204072"
+            }
+          ],
+          "dateEndYear": [
+            62
+          ],
+          "updatedAt": 1636108800927,
+          "publicationStatement": [
+            "[Kalakātā] Esosiẏeṭeḍa Pābaliśārsa [1960-1962]"
+          ],
+          "identifier": [
+            "urn:bnum:10004080",
+            "urn:lccn:sa 63003864",
+            "urn:undefined:NNSZ00304442",
+            "urn:undefined:(WaOLN)nyp0204072"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Junāpura Sṭīla. [Lekhaka] Guṇamaẏa Mānnā."
+          ],
+          "uri": "b10004080",
+          "lccClassification": [
+            "PK1718.M253 53"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Kalakātā]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10004080"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011168402"
+                    ],
+                    "physicalLocation": [
+                      "*OKV 82-3891"
+                    ],
+                    "shelfMark_sort": "a*OKV 82-3891 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002917",
+                    "shelfMark": [
+                      "*OKV 82-3891 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKV 82-3891 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011168402"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433011168402"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011168394"
+                    ],
+                    "physicalLocation": [
+                      "*OKV 82-3891"
+                    ],
+                    "shelfMark_sort": "a*OKV 82-3891 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002916",
+                    "shelfMark": [
+                      "*OKV 82-3891 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKV 82-3891 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011168394"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433011168394"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004340",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "11, 552, 28 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Medicine, Arab"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Maṭbaʻat Muḥammad Rashīd ibn Dāvūd al-Saʻdī"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1895
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Hādhā kitāb Daqaʼiq al-ʻilāj fī al-ṭibb al-badanī"
+          ],
+          "shelfMark": [
+            "*OGB 83-1915"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kirmānī, Muḥammad Karīm Khān, 1809-1870."
+          ],
+          "createdString": [
+            "1895"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "dateStartYear": [
+            1895
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGB 83-1915"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004340"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG003001809-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304705"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204332"
+            }
+          ],
+          "idOclc": [
+            "NYPG003001809-B"
+          ],
+          "updatedAt": 1671713042723,
+          "publicationStatement": [
+            "Bumbaʼī : Maṭbaʻat Muḥammad Rashīd ibn Dāvūd al-Saʻdī, 1315 [1895]"
+          ],
+          "identifier": [
+            "urn:bnum:10004340",
+            "urn:oclc:NYPG003001809-B",
+            "urn:undefined:NNSZ00304705",
+            "urn:undefined:(WaOLN)nyp0204332"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1895"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Medicine, Arab."
+          ],
+          "titleDisplay": [
+            "Hādhā kitāb Daqaʼiq al-ʻilāj fī al-ṭibb al-badanī / min muṣannafāt Muḥammad Karīm Khān al-Kirmānī."
+          ],
+          "uri": "b10004340",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bumbaʼī"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Daqāʼiq al-ʻilāj."
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10004340"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10004340-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://hdl.handle.net/2027/nyp.33433019817224",
+                        "label": "Full text available via HathiTrust"
+                      }
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "bi10004340-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540130",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OGB 83-1915"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGB 83-1915",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019817224"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGB 83-1915"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019817224"
+                    ],
+                    "idBarcode": [
+                      "33433019817224"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGB 83-001915"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004504",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "34 p.;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Pronunciation"
+          ],
+          "publisherLiteral": [
+            "Naṭarācaṉ,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            197
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tamiḻ valliṉa eḻuttukkaḷ: olikaḷum vitikaḷum"
+          ],
+          "shelfMark": [
+            "*OLB 83-2757"
+          ],
+          "creatorLiteral": [
+            "Natarajan, Subbiah, 1911-"
+          ],
+          "createdString": [
+            "197"
+          ],
+          "idLccn": [
+            "75906338"
+          ],
+          "dateStartYear": [
+            197
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 83-2757"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004504"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75906338"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304869"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204496"
+            }
+          ],
+          "updatedAt": 1636132308475,
+          "publicationStatement": [
+            "[Tūttukkuṭi]: Naṭarācaṉ, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10004504",
+            "urn:lccn:75906338",
+            "urn:undefined:NNSZ00304869",
+            "urn:undefined:(WaOLN)nyp0204496"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "197"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Pronunciation."
+          ],
+          "titleDisplay": [
+            "Tamiḻ valliṉa eḻuttukkaḷ: olikaḷum vitikaḷum/ Cu. Naṭarājaṉ."
+          ],
+          "uri": "b10004504",
+          "lccClassification": [
+            "PL4754 .N33 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Tūttukkuṭi]:"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10004504"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061296681"
+                    ],
+                    "physicalLocation": [
+                      "*OLB 83-2757"
+                    ],
+                    "shelfMark_sort": "a*OLB 83-002757",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784546",
+                    "shelfMark": [
+                      "*OLB 83-2757"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLB 83-2757"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061296681"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433061296681"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004657",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 p. l., iii, 404, vi p. 1 plate."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Niscaladasa, supposed author.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "H. Dhole,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1885
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The metaphysics of the Upanishads, Vicharsagar [microform]."
+          ],
+          "shelfMark": [
+            "*ZO-179 no. 8"
+          ],
+          "createdString": [
+            "1885"
+          ],
+          "seriesStatement": [
+            "Dhole's Vedanta series, \\3"
+          ],
+          "contributorLiteral": [
+            "Niscaladasa."
+          ],
+          "dateStartYear": [
+            1885
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-179 no. 8"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004657"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405768"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204649"
+            }
+          ],
+          "uniformTitle": [
+            "Upanishads. English."
+          ],
+          "updatedAt": 1636136428813,
+          "publicationStatement": [
+            "Calcutta, H. Dhole, 1885."
+          ],
+          "identifier": [
+            "urn:bnum:10004657",
+            "urn:undefined:NNSZ00405768",
+            "urn:undefined:(WaOLN)nyp0204649"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1885"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "The metaphysics of the Upanishads, Vicharsagar [microform]. Translated with copious notes by Lala Sreeram."
+          ],
+          "uri": "b10004657",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Calcutta,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Vicharsagar."
+          ],
+          "dimensions": [
+            "8̕."
+          ]
+        },
+        "sort": [
+          "b10004657"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673085"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-179"
+                    ],
+                    "shelfMark_sort": "a*ZO-179 9 misc oriental titles",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30080087",
+                    "shelfMark": [
+                      "*ZO-179 9 misc oriental titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZO-179 9 misc oriental titles"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673085"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "9 misc oriental titles"
+                    ],
+                    "idBarcode": [
+                      "33433105673085"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004661",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "111 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Gregorius de Montelongo",
+            "Italy",
+            "Italy -- History",
+            "Italy -- History -- 476-1492"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1898
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Gregorius de Montelongo [microform]. Ein Beitrag zur Geschichte Oberitaliens in den Jahren 1238-1269."
+          ],
+          "shelfMark": [
+            "*Z-3433 no. 3"
+          ],
+          "creatorLiteral": [
+            "Frankfurth, Hermann."
+          ],
+          "createdString": [
+            "1898"
+          ],
+          "dateStartYear": [
+            1898
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3433 no. 3"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004661"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405772"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204653"
+            }
+          ],
+          "updatedAt": 1636100134306,
+          "publicationStatement": [
+            "Marburg, N.G. Elwert, 1808."
+          ],
+          "identifier": [
+            "urn:bnum:10004661",
+            "urn:undefined:NNSZ00405772",
+            "urn:undefined:(WaOLN)nyp0204653"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1898"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Gregorius de Montelongo.",
+            "Italy -- History -- 476-1492."
+          ],
+          "titleDisplay": [
+            "Gregorius de Montelongo [microform]. Ein Beitrag zur Geschichte Oberitaliens in den Jahren 1238-1269. Von Hermann Frankfurth."
+          ],
+          "uri": "b10004661",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Marburg,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "8̕."
+          ]
+        },
+        "sort": [
+          "b10004661"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107964664"
+                    ],
+                    "physicalLocation": [
+                      "*Z-3433"
+                    ],
+                    "shelfMark_sort": "a*Z-003433",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30141341",
+                    "shelfMark": [
+                      "*Z-3433"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*Z-3433"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107964664"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433107964664"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004664",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, [11]-149 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cuban question",
+            "Cuban question -- To 1895"
+          ],
+          "publisherLiteral": [
+            "Impr. de \"El Cronista,\""
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "createdYear": [
+            1872
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cuba puede ser independiente Folleto político de actualidad"
+          ],
+          "shelfMark": [
+            "*ZH-695 no. 6"
+          ],
+          "creatorLiteral": [
+            "Ferrer de Couto, José, 1820-1877."
+          ],
+          "createdString": [
+            "1872"
+          ],
+          "idLccn": [
+            "17000612"
+          ],
+          "dateStartYear": [
+            1872
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZH-695 no. 6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004664"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "17000612"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405775"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204656"
+            }
+          ],
+          "updatedAt": 1657687667468,
+          "publicationStatement": [
+            "Nueva York, Impr. de \"El Cronista,\" 1872."
+          ],
+          "identifier": [
+            "urn:bnum:10004664",
+            "urn:lccn:17000612",
+            "urn:undefined:NNSZ00405775",
+            "urn:undefined:(WaOLN)nyp0204656"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1872"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cuban question -- To 1895."
+          ],
+          "titleDisplay": [
+            "Cuba puede ser independiente [microform]. Folleto político de actualidad, por José Ferrer de Couto."
+          ],
+          "uri": "b10004664",
+          "lccClassification": [
+            "F1783 .F39"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Nueva York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10004664"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110498031"
+                    ],
+                    "physicalLocation": [
+                      "*ZH-695"
+                    ],
+                    "shelfMark_sort": "a*ZH-695 8 misc. American history titles",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30805021",
+                    "shelfMark": [
+                      "*ZH-695 8 misc. American history titles"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZH-695 8 misc. American history titles"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110498031"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "8 misc. American history titles"
+                    ],
+                    "idBarcode": [
+                      "33433110498031"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004665",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 p.l., v., 382 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Gustav III, King of Sweden, 1746-1792"
+          ],
+          "publisherLiteral": [
+            "Amyot,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1861
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Gustave III, roi de Suède, 1746-1792 [microform],"
+          ],
+          "shelfMark": [
+            "*Z-3354 no. 2"
+          ],
+          "creatorLiteral": [
+            "Léouzon Le Duc, L. (Louis), 1815-1889."
+          ],
+          "createdString": [
+            "1861"
+          ],
+          "idLccn": [
+            "05008965"
+          ],
+          "seriesStatement": [
+            "Les Couronnes sanglantes"
+          ],
+          "dateStartYear": [
+            1861
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3354 no. 2"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004665"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "05008965"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405776"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204657"
+            }
+          ],
+          "updatedAt": 1636100755031,
+          "publicationStatement": [
+            "Paris, Amyot, 1861."
+          ],
+          "identifier": [
+            "urn:bnum:10004665",
+            "urn:lccn:05008965",
+            "urn:undefined:NNSZ00405776",
+            "urn:undefined:(WaOLN)nyp0204657"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1861"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Gustav III, King of Sweden, 1746-1792."
+          ],
+          "titleDisplay": [
+            "Gustave III, roi de Suède, 1746-1792 [microform], par L. Léouzon Le Duc."
+          ],
+          "uri": "b10004665",
+          "lccClassification": [
+            "DL766 .L58"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Gustave trois, roi de Suède, 1746-1792."
+          ],
+          "dimensions": [
+            "19cm."
+          ]
+        },
+        "sort": [
+          "b10004665"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107663993"
+                    ],
+                    "physicalLocation": [
+                      "*Z-3354"
+                    ],
+                    "shelfMark_sort": "a*Z-3354 no. 000001-7",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30147719",
+                    "shelfMark": [
+                      "*Z-3354 no. 1-7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*Z-3354 no. 1-7"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107663993"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-7"
+                    ],
+                    "idBarcode": [
+                      "33433107663993"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-50d53ce3703a03677e17988ec8ab297f.json
+++ b/test/fixtures/query-50d53ce3703a03677e17988ec8ab297f.json
@@ -1,0 +1,918 @@
+{
+  "took": 468,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.902664,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.902664,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-52195e0a3f24cb1a7d7a3ee756be73a2.json
+++ b/test/fixtures/query-52195e0a3f24cb1a7d7a3ee756be73a2.json
@@ -1,0 +1,14078 @@
+{
+  "took": 1926,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 16356138,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Stauffenburg"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Gmelin, Hermann, 1900-1958.",
+            "Baum, Richard.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGNYPG-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "idOclc": [
+            "NYPGNYPG-B"
+          ],
+          "updatedAt": 1678937667178,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:oclc:NYPGNYPG-B",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen"
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "3923721544"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000003",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. : col. ill. maps ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrides (Scotland)",
+            "Hebrides (Scotland) -- Pictorial works"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Constable"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1989
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Scottish islands"
+          ],
+          "shelfMark": [
+            "JFF 89-526"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Waite, Charlie."
+          ],
+          "createdString": [
+            "1989"
+          ],
+          "idLccn": [
+            "gb 89012970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1989
+          ],
+          "donor": [
+            "Gift of the Drue Heinz Book Fund for English Literature"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 89-526"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000003"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0094675708 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "gb 89012970"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGUKBPGP8917-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200002"
+            }
+          ],
+          "idOclc": [
+            "NYPGUKBPGP8917-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Constable, 1989."
+          ],
+          "identifier": [
+            "urn:bnum:10000003",
+            "urn:isbn:0094675708 :",
+            "urn:lccn:gb 89012970",
+            "urn:oclc:NYPGUKBPGP8917-B",
+            "urn:undefined:(WaOLN)nyp0200002"
+          ],
+          "idIsbn": [
+            "0094675708 "
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1989"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrides (Scotland) -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Scottish islands / Charlie Waite."
+          ],
+          "uri": "b10000003",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0094675708"
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000003"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 89-526"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 89-526",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050409147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 89-526"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050409147"
+                    ],
+                    "idBarcode": [
+                      "33433050409147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFF 89-000526"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000004",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "23, 216 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1956.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mutaṟkuṟaḷ uvamai."
+          ],
+          "shelfMark": [
+            "*OLB 84-1934"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kothandapani Pillai, K., 1896-"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "74915265"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1247"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1934"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000004"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74915265"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200003"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tirunelvēli, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1965."
+          ],
+          "identifier": [
+            "urn:bnum:10000004",
+            "urn:lccn:74915265",
+            "urn:oclc:NYPG001000001-B",
+            "urn:undefined:NNSZ00100001",
+            "urn:undefined:(WaOLN)nyp0200003"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Mutaṟkuṟaḷ uvamai. Āciriyar Ku. Kōtaṇṭapāṇi Piḷḷai."
+          ],
+          "uri": "b10000004",
+          "lccClassification": [
+            "PL4758.9.T5 K6 1965"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirunelvēli"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000004"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783781",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1934",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1934"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301556"
+                    ],
+                    "idBarcode": [
+                      "33433061301556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001934"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000005",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (43 p.) + 1 part (12 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Acc. arr. for piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Soch. 22\"--Caption.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: 11049.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Concertos (Violin)",
+            "Concertos (Violin) -- Solo with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muzyka"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom"
+          ],
+          "shelfMark": [
+            "JMF 83-336"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Wieniawski, Henri, 1835-1880."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-336"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000005"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "11049. Muzyka"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100551"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200004"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-C"
+          ],
+          "uniformTitle": [
+            "Concertos, violin, orchestra, no. 2, op. 22, D minor; arranged"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Moskva : Muzyka, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000005",
+            "urn:oclc:NYPG001000001-C",
+            "urn:undefined:11049. Muzyka",
+            "urn:undefined:NNSZ00100551",
+            "urn:undefined:(WaOLN)nyp0200004"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Concertos (Violin) -- Solo with piano."
+          ],
+          "titleDisplay": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom / G. Ven︠i︡avskiĭ ; klavir."
+          ],
+          "uri": "b10000005",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Moskva"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Concertos, no. 2, op. 22"
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10000005"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942022",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-336"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-336",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032711909"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-336"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032711909"
+                    ],
+                    "idBarcode": [
+                      "33433032711909"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000336"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000006",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "227 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of The reconstruction of religious thought in Islam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām"
+          ],
+          "shelfMark": [
+            "*OGC 84-1984"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Iqbal, Muhammad, Sir, 1877-1938."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75962707"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Maḥmūd, ʻAbbās."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1984"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000006"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75962707"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100002"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200005"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "al-Qāhirah, Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000006",
+            "urn:lccn:75962707",
+            "urn:oclc:NYPG001000002-B",
+            "urn:undefined:NNSZ00100002",
+            "urn:undefined:(WaOLN)nyp0200005"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām, taʼlif Muhammad Iqbāl. Tarjamat ʻAbbās Maḥmūd. Rājaʻa muqaddimatahu wa-al-faṣl al-awwal minhu ʻAbd al-ʻAzīz al-Maraghī, wa-rājaʻa baqīyat al-Kitāb Mahdī ʻAllām."
+          ],
+          "uri": "b10000006",
+          "lccClassification": [
+            "BP161 .I712 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000006"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691665"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1984"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691665"
+                    ],
+                    "idBarcode": [
+                      "33433022691665"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001984"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 7:35.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: Z.8917.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Guitar music",
+            "Guitar",
+            "Guitar -- Studies and exercises"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Editio Musica"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Due studi per chitarra"
+          ],
+          "shelfMark": [
+            "JMG 83-276"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Patachich, Iván."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000007"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Z.8917. Editio Musica"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100552"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200006"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-C"
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Budapest : Editio Musica, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000007",
+            "urn:oclc:NYPG001000002-C",
+            "urn:undefined:Z.8917. Editio Musica",
+            "urn:undefined:NNSZ00100552",
+            "urn:undefined:(WaOLN)nyp0200006"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Guitar music.",
+            "Guitar -- Studies and exercises."
+          ],
+          "titleDisplay": [
+            "Due studi per chitarra / Patachich Iván."
+          ],
+          "uri": "b10000007",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Budapest"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies"
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000007"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942023",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-276"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-276",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883591"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-276"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883591"
+                    ],
+                    "idBarcode": [
+                      "33433032883591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000276"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000008",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "351 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Parimaḷam Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṇṇāviṉ ciṟukataikaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1986"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Annadurai, C. N., 1909-1969."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913998"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1986"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000008"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913998"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100003"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200007"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Parimaḷam Patippakam [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000008",
+            "urn:lccn:72913998",
+            "urn:oclc:NYPG001000003-B",
+            "urn:undefined:NNSZ00100003",
+            "urn:undefined:(WaOLN)nyp0200007"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Aṇṇāviṉ ciṟukataikaḷ. [Eḻutiyavar] Ci. Eṉ. Aṇṇāturai."
+          ],
+          "uri": "b10000008",
+          "lccClassification": [
+            "PL4758.9.A5 A84"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000008"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783782",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1986",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301689"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1986"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301689"
+                    ],
+                    "idBarcode": [
+                      "33433061301689"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001986"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000009",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "30 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Edition Peters Nr. 5489.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: E.P. 13028.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Edition Peters ; C.F. Peters"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Miniaturen II : 13 kleine Klavierstücke"
+          ],
+          "shelfMark": [
+            "JMG 83-278"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Golle, Jürgen, 1942-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-278"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000009"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters Nr. 5489 Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "E.P. 13028. Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200008"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-C"
+          ],
+          "uniformTitle": [
+            "Miniaturen, no. 2"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Leipzig : Edition Peters ; New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000009",
+            "urn:oclc:NYPG001000003-C",
+            "urn:undefined:Edition Peters Nr. 5489 Edition Peters",
+            "urn:undefined:E.P. 13028. Edition Peters",
+            "urn:undefined:NNSZ00100553",
+            "urn:undefined:(WaOLN)nyp0200008"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Miniaturen II : 13 kleine Klavierstücke / Jürgen Golle."
+          ],
+          "uri": "b10000009",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig : New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen, no. 2"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000009"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942024",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-278"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-278",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883617"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-278"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883617"
+                    ],
+                    "idBarcode": [
+                      "33433032883617"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000278"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000010",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "110 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cēkkiḻār, active 12th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaikkaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1938"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Irācamāṇikkaṉār, Mā., 1907-1967."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913466"
+          ],
+          "seriesStatement": [
+            "Corṇammāḷ corpoḻivu varicai, 6"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1938"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100004"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200009"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Aṇṇāmalainakar, Aṇṇāmalaip Palkalaikkaḻakam, 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000010",
+            "urn:lccn:72913466",
+            "urn:oclc:NYPG001000004-B",
+            "urn:undefined:NNSZ00100004",
+            "urn:undefined:(WaOLN)nyp0200009"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cēkkiḻār, active 12th century."
+          ],
+          "titleDisplay": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ. [Āṟṟiyavar] Mā. Irācamāṇikkaṉār."
+          ],
+          "uri": "b10000010",
+          "lccClassification": [
+            "PL4758.9.C385 Z8"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Aṇṇāmalainakar"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000010"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783783",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1938",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301598"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1938"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301598"
+                    ],
+                    "idBarcode": [
+                      "33433061301598"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001938"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "46 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)",
+            "Easter music (Organ)",
+            "Passion music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Boeijenga"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1982"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Passie en pasen : suite voor orgel, opus 50"
+          ],
+          "shelfMark": [
+            "JMG 83-279"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Berg, Jan J. van den."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-279"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000011"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200010"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-C"
+          ],
+          "dateEndYear": [
+            1982
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Sneek [Netherlands] : Boeijenga, [between 1976 and 1982]."
+          ],
+          "identifier": [
+            "urn:bnum:10000011",
+            "urn:oclc:NYPG001000004-C",
+            "urn:undefined:(WaOLN)nyp0200010"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)",
+            "Easter music (Organ)",
+            "Passion music."
+          ],
+          "titleDisplay": [
+            "Passie en pasen : suite voor orgel, opus 50 / door Jan J. van den Berg."
+          ],
+          "uri": "b10000011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Sneek [Netherlands]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Passie. I. Psalm 22. II. Leer mij O Heer. III. \"Mijn Verlosser hangt aan 't kruis.\" IV. \"O hoofd vol bloed en wonden.\" V. \"O kostbaar kruis.\" VI. \"Jezus, leven van mijn leven\" -- Pasen. VII. Toccata over \"Christus is opgestanden.\" VIII. Canon: \"Jesus unser Trost und Leben.\" IX. Trio: Ik zeg het allen dat Hij leeft.\" X. Trio: \"Staakt Uw rouwen Magdalene.\" XI. Postludium over \"Jesus leeft en wij met Hem\" (met \"Christus onze Heer verrees\" als tegenstem)."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000011"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942025",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-279"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-279",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883625"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-279"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883625"
+                    ],
+                    "idBarcode": [
+                      "33433032883625"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000279"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "223 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p.221.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Thaqāfah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi"
+          ],
+          "shelfMark": [
+            "*OFS 84-1997"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ḥāwī, Īlīyā Salīm."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 84-1997"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200011"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Thaqāfah, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000012",
+            "urn:oclc:NYPG001000005-B",
+            "urn:undefined:NNSZ00100005",
+            "urn:undefined:(WaOLN)nyp0200011"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "titleDisplay": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi / bi-qalam Īlīyā Ḥāwī."
+          ],
+          "uri": "b10000012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000012"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000003",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 84-1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514719"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 84-1997"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514719"
+                    ],
+                    "idBarcode": [
+                      "33433014514719"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFS 84-001997"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000013",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "32 p. of music : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Popular music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Arr. for piano with chord symbols; superlinear German words.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Popular music -- Germany (East)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Harth Musik Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "shelfMark": [
+            "JMF 83-366"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-366"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000013"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100555"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200012"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Leipzig : Harth Musik Verlag, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000013",
+            "urn:oclc:NYPG001000005-C",
+            "urn:undefined:NNSZ00100555",
+            "urn:undefined:(WaOLN)nyp0200012"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Popular music -- Germany (East)"
+          ],
+          "titleDisplay": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "uri": "b10000013",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Disko Treff eins."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000013"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942026",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-366"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-366",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032712204"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-366"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032712204"
+                    ],
+                    "idBarcode": [
+                      "33433032712204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000366"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000014",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "520 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on cover: Islamic unity or the Mutual approach among Muslim sects.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Panislamism",
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muʼassasat al-Aʻlamī lil-Maṭbūʻāt"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah"
+          ],
+          "shelfMark": [
+            "*OGC 84-1996"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Shīrāzī, ʻAbd al-Karīm Bī Āzār."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1996"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000014"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100006"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200013"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Muʼassasat al-Aʻlamī lil-Maṭbūʻāt, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000014",
+            "urn:oclc:NYPG001000006-B",
+            "urn:undefined:NNSZ00100006",
+            "urn:undefined:(WaOLN)nyp0200013"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Panislamism.",
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah / Jamʻ wa-tartīb ʻAbd al-Karīm Bī Āzār al-Shīrāzī."
+          ],
+          "uri": "b10000014",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Islamic unity."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000014"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691780"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1996"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691780"
+                    ],
+                    "idBarcode": [
+                      "33433022691780"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001996"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000015",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "25 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For organ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"A McAfee Music Publication.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: DM 220.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Belwin-Mills"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Suite no. 1 : 1977"
+          ],
+          "shelfMark": [
+            "JNG 83-102"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hampton, Calvin."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNG 83-102"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000015"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "DM 220. Belwin-Mills"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100556"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200014"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-C"
+          ],
+          "uniformTitle": [
+            "Suite, organ, no. 1"
+          ],
+          "updatedAt": 1678726416948,
+          "publicationStatement": [
+            "Melville, NY : Belwin-Mills, [1980?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000015",
+            "urn:oclc:NYPG001000006-C",
+            "urn:undefined:DM 220. Belwin-Mills",
+            "urn:undefined:NNSZ00100556",
+            "urn:undefined:(WaOLN)nyp0200014"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)"
+          ],
+          "titleDisplay": [
+            "Suite no. 1 : 1977 / Calvin Hampton."
+          ],
+          "uri": "b10000015",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Melville, NY"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Suite, no. 1"
+          ],
+          "tableOfContents": [
+            "Fanfares -- Antiphon -- Toccata."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000015"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000016",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "111 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuṟuntokai"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Manṅkaḷa Nūlakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nalla Kuṟuntokaiyil nāṉilam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1937"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Cellappaṉ, Cilampoli, 1929-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "74913402"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1937"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000016"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74913402"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200015"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Ceṉṉai, Manṅkaḷa Nūlakam, 1959 [i.e. 1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000016",
+            "urn:lccn:74913402",
+            "urn:oclc:NYPG001000007-B",
+            "urn:undefined:NNSZ00100007",
+            "urn:undefined:(WaOLN)nyp0200015"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuṟuntokai."
+          ],
+          "titleDisplay": [
+            "Nalla Kuṟuntokaiyil nāṉilam. [Eḻutiyavar] Cu. Cellappaṉ."
+          ],
+          "uri": "b10000016",
+          "lccClassification": [
+            "PL4758.9.K794 Z6 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000016"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783785",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1937",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301580"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1937"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301580"
+                    ],
+                    "idBarcode": [
+                      "33433061301580"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001937"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000017",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (17 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For baritone and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Words printed also as text.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 3:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Corbière, Tristan, 1845-1875",
+            "Corbière, Tristan, 1845-1875 -- Musical settings",
+            "Songs (Medium voice) with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lettre du Mexique : pour baryton et piano, 1942"
+          ],
+          "shelfMark": [
+            "JMG 83-395"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Escher, Rudolf."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Corbière, Tristan, 1845-1875."
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000017"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100557"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200016"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000017",
+            "urn:oclc:NYPG001000007-C",
+            "urn:undefined:NNSZ00100557",
+            "urn:undefined:(WaOLN)nyp0200016"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Corbière, Tristan, 1845-1875 -- Musical settings.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "Lettre du Mexique : pour baryton et piano, 1942 / Rudolf Escher ; poème de Tristan Corbière."
+          ],
+          "uri": "b10000017",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000017"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-395"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-395",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032735007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-395"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032735007"
+                    ],
+                    "idBarcode": [
+                      "33433032735007"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000395"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "68 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Lebanon"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Ṭalīʻah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā"
+          ],
+          "shelfMark": [
+            "*OFX 84-1995"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Bashshūr, Najlāʼ Naṣīr."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "78970449"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1995"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000018"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78970449"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100008"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200017"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Ṭalīʻah, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000018",
+            "urn:lccn:78970449",
+            "urn:oclc:NYPG001000008-B",
+            "urn:undefined:NNSZ00100008",
+            "urn:undefined:(WaOLN)nyp0200017"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Lebanon."
+          ],
+          "titleDisplay": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā / Najlāʼ Naṣīr Bashshūr."
+          ],
+          "uri": "b10000018",
+          "lccClassification": [
+            "HQ1728 .B37"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000018"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000004",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1995"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031718"
+                    ],
+                    "idBarcode": [
+                      "33433002031718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001995"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000019",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: M 18.487.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Waltzes (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zwölf Walzer und ein Epilog : für Klavier"
+          ],
+          "shelfMark": [
+            "JMG 83-111"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Benary, Peter."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-111"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000019"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Möseler M 18.487."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200018"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-C"
+          ],
+          "uniformTitle": [
+            "Walzer und ein Epilog"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000019",
+            "urn:oclc:NYPG001000008-C",
+            "urn:undefined:Möseler M 18.487.",
+            "urn:undefined:NNSZ00100558",
+            "urn:undefined:(WaOLN)nyp0200018"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Waltzes (Piano)"
+          ],
+          "titleDisplay": [
+            "Zwölf Walzer und ein Epilog : für Klavier / Peter Benary."
+          ],
+          "uri": "b10000019",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Walzer und ein Epilog",
+            "Walzer und ein Epilog."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000019"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942028",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-111"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-111",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-111"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845053"
+                    ],
+                    "idBarcode": [
+                      "33433032845053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000111"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000020",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 172, 320 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tolkāppiyar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaik Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tolkāppiyam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1936"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "creatorLiteral": [
+            "Veḷḷaivāraṇaṉ, Ka."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "74914844"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1936"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000020"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74914844"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200019"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "[Aṇṇāmalainakar] Aṇṇāmalaip Palkalaik Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000020",
+            "urn:lccn:74914844",
+            "urn:oclc:NYPG001000009-B",
+            "urn:undefined:NNSZ00100009",
+            "urn:undefined:(WaOLN)nyp0200019"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tolkāppiyar."
+          ],
+          "titleDisplay": [
+            "Tolkāppiyam. [Eḻutiyavar] Ka. Veḷḷaivāraṇaṉ."
+          ],
+          "uri": "b10000020",
+          "lccClassification": [
+            "PL4754.T583 V4 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Aṇṇāmalainakar]"
+          ],
+          "titleAlt": [
+            "Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Tolkāppiyam.--Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000020"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783786",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1936 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1936 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301572"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1936"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301572"
+                    ],
+                    "idBarcode": [
+                      "33433061301572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-1936 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000021",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (51 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: NM 384.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Verlag Neue Musik"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aurora : sinfonischer Prolog : Partitur"
+          ],
+          "shelfMark": [
+            "JMG 83-113"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Weitzendorf, Heinz."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-113"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000021"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NM 384. Verlag Neue Musik"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100559"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200020"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-C"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Berlin : Verlag Neue Musik, c1978."
+          ],
+          "identifier": [
+            "urn:bnum:10000021",
+            "urn:oclc:NYPG001000009-C",
+            "urn:undefined:NM 384. Verlag Neue Musik",
+            "urn:undefined:NNSZ00100559",
+            "urn:undefined:(WaOLN)nyp0200020"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "Aurora : sinfonischer Prolog : Partitur / Heinz Weitzendorf."
+          ],
+          "uri": "b10000021",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Berlin"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000021"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942029",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-113"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-113",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845079"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-113"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845079"
+                    ],
+                    "idBarcode": [
+                      "33433032845079"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000113"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000022",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "19, 493 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1942.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Grammar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1935"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Puttamittiraṉār, active 11th century."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "73913714"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1388"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Peruntēvaṉār, active 11th century.",
+            "Kōvintarāja Mutaliyār, Kā. Ra., 1874-1952."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1935"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73913714"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100010"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200021"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000022",
+            "urn:lccn:73913714",
+            "urn:oclc:NYPG001000010-B",
+            "urn:undefined:NNSZ00100010",
+            "urn:undefined:(WaOLN)nyp0200021"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ. Patippāciriyar Kā. Ra. Kōvintarāca Mutaliyār."
+          ],
+          "uri": "b10000022",
+          "lccClassification": [
+            "PL4754 .P8 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "titleAlt": [
+            "Viracōḻiyam."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000022"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783787",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1935",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301564"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1935"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301564"
+                    ],
+                    "idBarcode": [
+                      "33433061301564"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001935"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000023",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (18 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For band or wind ensemble.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Based on the composer's Veni creator spiritus.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: KC913.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Band music",
+            "Band music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Shawnee Press"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Musica sacra"
+          ],
+          "shelfMark": [
+            "JMF 83-38"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Zaninelli, Luigi."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-38"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000023"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "KC913 Shawnee Press"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100560"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200022"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-C"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Delaware Water Gap, Pa. : Shawnee Press, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000023",
+            "urn:oclc:NYPG001000010-C",
+            "urn:undefined:KC913 Shawnee Press",
+            "urn:undefined:NNSZ00100560",
+            "urn:undefined:(WaOLN)nyp0200022"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Band music -- Scores."
+          ],
+          "titleDisplay": [
+            "Musica sacra / Luigi Zaninelli."
+          ],
+          "uri": "b10000023",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Delaware Water Gap, Pa."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10000023"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942030",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-38"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-38",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709028"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-38"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709028"
+                    ],
+                    "idBarcode": [
+                      "33433032709028"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000038"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000024",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bahrain",
+            "Bahrain -- History",
+            "Bahrain -- History -- 20th century",
+            "Bahrain -- Economic conditions",
+            "Bahrain -- Social conditions"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār Ibn Khaldūn"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī"
+          ],
+          "shelfMark": [
+            "*OFK 84-1944"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rumayḥī, Muḥammad Ghānim."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "79971032"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFK 84-1944"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000024"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79971032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200023"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[Bayrūt] : Dār Ibn Khaldūn, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000024",
+            "urn:lccn:79971032",
+            "urn:oclc:NYPG001000011-B",
+            "urn:undefined:NNSZ00100011",
+            "urn:undefined:(WaOLN)nyp0200023"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bahrain -- History -- 20th century.",
+            "Bahrain -- Economic conditions.",
+            "Bahrain -- Social conditions."
+          ],
+          "titleDisplay": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī / Muḥammad al-Rumayḥī."
+          ],
+          "uri": "b10000024",
+          "lccClassification": [
+            "DS247.B28 R85"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000024"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000005",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK 84-1944",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005548676"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK 84-1944"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005548676"
+                    ],
+                    "idBarcode": [
+                      "33433005548676"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFK 84-001944"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000025",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei Sonatinen für Klavier"
+          ],
+          "shelfMark": [
+            "JMF 83-107"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stockmeier, Wolfgang."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 179"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-107"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000025"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100561"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200024"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-C"
+          ],
+          "uniformTitle": [
+            "Sonatinas, piano"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000025",
+            "urn:oclc:NYPG001000011-C",
+            "urn:undefined:NNSZ00100561",
+            "urn:undefined:(WaOLN)nyp0200024"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Drei Sonatinen für Klavier / Wolfgang Stockmeier."
+          ],
+          "uri": "b10000025",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatinas"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000025"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-107"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-107",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709697"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-107"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709697"
+                    ],
+                    "idBarcode": [
+                      "33433032709697"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000107"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000026",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "222 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 217-220.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Syria"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975"
+          ],
+          "shelfMark": [
+            "*OFX 84-1953"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Razzāz, Nabīlah."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76960987"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1953"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000026"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960987"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200025"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Dimashq : Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000026",
+            "urn:lccn:76960987",
+            "urn:oclc:NYPG001000012-B",
+            "urn:undefined:NNSZ00100012",
+            "urn:undefined:(WaOLN)nyp0200025"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Syria."
+          ],
+          "titleDisplay": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975 / Nabīlah al-Razzāz."
+          ],
+          "uri": "b10000026",
+          "lccClassification": [
+            "HQ402 .R39"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10000026"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000006",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1953",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031700"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1953"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031700"
+                    ],
+                    "idBarcode": [
+                      "33433002031700"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001953"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000027",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Violin)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei kleine Sonaten : für Violine solo"
+          ],
+          "shelfMark": [
+            "JMF 83-95"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Köhler, Friedemann."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 172"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-95"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000027"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100562"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200026"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-C"
+          ],
+          "uniformTitle": [
+            "Kleine Sonaten, violin"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler Verlag, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000027",
+            "urn:oclc:NYPG001000012-C",
+            "urn:undefined:NNSZ00100562",
+            "urn:undefined:(WaOLN)nyp0200026"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Violin)"
+          ],
+          "titleDisplay": [
+            "Drei kleine Sonaten : für Violine solo / Friedemann Köhler."
+          ],
+          "uri": "b10000027",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Kleine Sonaten"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000027"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-95"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-95",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-95"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709572"
+                    ],
+                    "idBarcode": [
+                      "33433032709572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000095"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000028",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "9, 3, 3, 324 p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Prastuta śodha-prabandha Rājasthāna Viśvavidyālaya, Jayapura kī Pī-eca.Ḍī-upāthi ke nimitta viśvavidyālaya anudāna āyoga kī risarca phailośipa ke antargata likhā gayā thā.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [321]-324.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sūryamalla Miśraṇa, 1815-1868"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Rājasthāna Sāhitya Akādamī (Saṅgama)"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vaṃśabhāskara : eka adhyayana"
+          ],
+          "shelfMark": [
+            "*OKTM 84-1945"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Khāna, Ālama Śāha, 1936-2003."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75903689"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000028"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75903689"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200027"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Udayapura : Rājasthāna Sāhitya Akādamī (Saṅgama), 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000028",
+            "urn:lccn:75903689",
+            "urn:oclc:NYPG001000013-B",
+            "urn:undefined:NNSZ00100013",
+            "urn:undefined:(WaOLN)nyp0200027"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sūryamalla Miśraṇa, 1815-1868."
+          ],
+          "titleDisplay": [
+            "Vaṃśabhāskara : eka adhyayana / lekhaka Ālamaśāha Khāna."
+          ],
+          "uri": "b10000028",
+          "lccClassification": [
+            "PK2708.9.S9 V334"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Udayapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000028"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-1945",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011094210"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-1945"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011094210"
+                    ],
+                    "idBarcode": [
+                      "33433011094210"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-001945"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000029",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Wilhelm Hansen edition no. 4372.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: 29589.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Organ music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "W. Hansen ; Distribution, Magnamusic-Baton"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cruor : for organ solo, 1977"
+          ],
+          "shelfMark": [
+            "JMF 83-93"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lorentzen, Bent."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82771131"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-93"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000029"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82771131"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Wilhelm Hansen edition no. 4372."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "29589."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100563"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200028"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Copenhagen ; New York : W. Hansen ; [s.l.] : Distribution, Magnamusic-Baton, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000029",
+            "urn:lccn:82771131",
+            "urn:oclc:NYPG001000013-C",
+            "urn:undefined:Wilhelm Hansen edition no. 4372.",
+            "urn:undefined:29589.",
+            "urn:undefined:NNSZ00100563",
+            "urn:undefined:(WaOLN)nyp0200028"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Organ music."
+          ],
+          "titleDisplay": [
+            "Cruor : for organ solo, 1977 / B. Lorentzen."
+          ],
+          "uri": "b10000029",
+          "lccClassification": [
+            "M11 .L"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Copenhagen ; New York : [s.l.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000029"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942034",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-93"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-93",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-93"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709556"
+                    ],
+                    "idBarcode": [
+                      "33433032709556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000093"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000030",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21, 264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Āryasamāja-śatābdī-saṃskaraṇam.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Authorship uncertain. Attributed variously to Āpiśali, Pānini and Śākaṭāyana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit: introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Suffixes and prefixes"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; prāptisthānam, Rāmalāla Kapūra Ṭrasṭa"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Uṇādi-koṣaḥ"
+          ],
+          "shelfMark": [
+            "*OKA 84-1931"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902275"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Āpiśali.",
+            "Pāṇini.",
+            "Śākatāyana.",
+            "Dayananda Sarasvati, Swami, 1824-1883.",
+            "Yudhiṣṭhira Mīmāṃsaka, 1909-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKA 84-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000030"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902275"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200029"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-B"
+          ],
+          "uniformTitle": [
+            "Uṇādisūtra."
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Karanāla : Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; Bahālagaḍha, Harayāṇa : prāptisthānam, Rāmalāla Kapūra Ṭrasṭa, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000030",
+            "urn:lccn:75902275",
+            "urn:oclc:NYPG001000014-B",
+            "urn:undefined:NNSZ00100014",
+            "urn:undefined:(WaOLN)nyp0200029"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Suffixes and prefixes."
+          ],
+          "titleDisplay": [
+            "Uṇādi-koṣaḥ / Dayānanda Sarasvatī Svāminā viracitayā Vaidika-laukika-koṣābhidhayā vyākhyayā sahitaḥ vividhābhi-ṣṭippaṇībhiḥ sūcībhiśca saṃyutaḥ ; sampādakaḥ Yudhiṣṭhiro Mīmāṃsakaḥ."
+          ],
+          "uri": "b10000030",
+          "lccClassification": [
+            "PK551 .U73"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Karanāla : Bahālagaḍha, Harayāṇa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000030"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000007",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKA 84-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012968222"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKA 84-1931"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012968222"
+                    ],
+                    "idBarcode": [
+                      "33433012968222"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKA 84-001931"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000031",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "W. Müller"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Neun Miniaturen : für Klavier : op. 52"
+          ],
+          "shelfMark": [
+            "JMG 83-17"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Petersen, Wilhelm, 1890-1957."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-17"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000031"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "W. Müller WM 1713 SM."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200030"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-C"
+          ],
+          "uniformTitle": [
+            "Miniaturen"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Heidelberg : W. Müller, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000031",
+            "urn:oclc:NYPG001000014-C",
+            "urn:undefined:W. Müller WM 1713 SM.",
+            "urn:undefined:NNSZ00100564",
+            "urn:undefined:(WaOLN)nyp0200030"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Neun Miniaturen : für Klavier : op. 52 / Wilhelm Petersen."
+          ],
+          "uri": "b10000031",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Heidelberg"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen",
+            "Miniaturen."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000031"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942035",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-17"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-17",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841631"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841631"
+                    ],
+                    "idBarcode": [
+                      "33433032841631"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000017"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000032",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14, 405, 7 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jahrom (Iran : Province)",
+            "Jahrom (Iran : Province) -- Biography",
+            "Khafr (Iran)",
+            "Khafr (Iran) -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kitābfurūshī-i Khayyām"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr"
+          ],
+          "shelfMark": [
+            "*OMP 84-2007"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ishrāq, Muḥammad Karīm."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2007"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200031"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tihrān : Kitābfurūshī-i Khayyām, 1351 [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000032",
+            "urn:oclc:NYPG001000015-B",
+            "urn:undefined:NNSZ00100015",
+            "urn:undefined:(WaOLN)nyp0200031"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jahrom (Iran : Province) -- Biography.",
+            "Khafr (Iran) -- Biography."
+          ],
+          "titleDisplay": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr / taʼlīf-i Muḥammad Karīm Ishrāq."
+          ],
+          "uri": "b10000032",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm"
+          ]
+        },
+        "sort": [
+          "b10000032"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2007",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173012"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2007"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173012"
+                    ],
+                    "idBarcode": [
+                      "33433013173012"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002007"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000033",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (20 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For voice and organ.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sacred songs (Medium voice) with organ",
+            "Psalms (Music)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Agápe"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Psalm settings"
+          ],
+          "shelfMark": [
+            "JMG 83-59"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Nelhybel, Vaclav."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-59"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000033"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100565"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200032"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Carol Stream, Ill. : Agápe, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000033",
+            "urn:oclc:NYPG001000015-C",
+            "urn:undefined:NNSZ00100565",
+            "urn:undefined:(WaOLN)nyp0200032"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sacred songs (Medium voice) with organ.",
+            "Psalms (Music)"
+          ],
+          "titleDisplay": [
+            "Psalm settings / Vaclav Nelhybel."
+          ],
+          "uri": "b10000033",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Carol Stream, Ill."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Hear me when I call -- Be not far from me -- Hear my voice -- The Lord is my rock."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000033"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942037",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-59",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-59"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942036",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-59",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842035"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-59"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842035"
+                    ],
+                    "idBarcode": [
+                      "33433032842035"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "366 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Brhatkathāślokasaṁgrahaḥ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Colophon: Iti Śrībhaṭṭabudhasvāminā krte ślokasaṁgrahe Brhatkathāyāṁ--",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Text in Sanskrit; apparatus in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Prithivi Prakashan"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brhatkathāślokasaṁgraha : a study"
+          ],
+          "shelfMark": [
+            "*OKR 84-2006"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Budhasvāmin."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903273"
+          ],
+          "seriesStatement": [
+            "Indian civilization series ; no. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Guṇāḍhya.",
+            "Agrawala, Vasudeva Sharana.",
+            "Agrawala, Prithvi Kumar."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKR 84-2006"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000034"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903273"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100016"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200033"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Varanasi : Prithivi Prakashan, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000034",
+            "urn:lccn:74903273",
+            "urn:oclc:NYPG001000016-B",
+            "urn:undefined:NNSZ00100016",
+            "urn:undefined:(WaOLN)nyp0200033"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Brhatkathāślokasaṁgraha : a study / by V.S. Agrawala ; with Sanskrit text, edited by P.K. Agrawala."
+          ],
+          "uri": "b10000034",
+          "lccClassification": [
+            "PK3794.B84 B7 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Varanasi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000034"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKR 84-2006",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011528696"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKR 84-2006"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011528696"
+                    ],
+                    "idBarcode": [
+                      "33433011528696"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKR 84-002006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000035",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "22 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Suite.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 12:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Serenade voor piano : 1980"
+          ],
+          "shelfMark": [
+            "JMG 83-6"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kasbergen, Marinus, 1936-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000035"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100566"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200034"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-C"
+          ],
+          "uniformTitle": [
+            "Serenade, piano"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000035",
+            "urn:oclc:NYPG001000016-C",
+            "urn:undefined:NNSZ00100566",
+            "urn:undefined:(WaOLN)nyp0200034"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Piano)"
+          ],
+          "titleDisplay": [
+            "Serenade voor piano : 1980 / Marinus Kasbergen."
+          ],
+          "uri": "b10000035",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Serenade"
+          ],
+          "tableOfContents": [
+            "Varianten -- Nocturne -- Toccata I -- Intermezzo -- Toccata II."
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000035"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942038",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841490"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-6"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841490"
+                    ],
+                    "idBarcode": [
+                      "33433032841490"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-6",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-6"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000036",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "viii, 38 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; prefatory matter in Sanskrit or Telegu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nārāyaṇatīrtha, 17th cent",
+            "Nārāyaṇatīrtha, 17th cent -- In literature"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic]"
+          ],
+          "shelfMark": [
+            "*OKB 84-1928"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75902755"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKB 84-1928"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000036"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902755"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200035"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[s.1. : s.n.], 1972"
+          ],
+          "identifier": [
+            "urn:bnum:10000036",
+            "urn:lccn:75902755",
+            "urn:oclc:NYPG001000017-B",
+            "urn:undefined:NNSZ00100017",
+            "urn:undefined:(WaOLN)nyp0200035"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nārāyaṇatīrtha, 17th cent -- In literature."
+          ],
+          "titleDisplay": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic] / praṇetā Garikapāṭi Lakṣmīkāntaḥ."
+          ],
+          "uri": "b10000036",
+          "lccClassification": [
+            "PK3799.L28 S68"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[s.1."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000036"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKB 84-1928"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKB 84-1928",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058548433"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKB 84-1928"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058548433"
+                    ],
+                    "idBarcode": [
+                      "33433058548433"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKB 84-001928"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000037",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13a p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 15:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Guitar)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Eight studies for guitar : in form of a suite : 1979"
+          ],
+          "shelfMark": [
+            "JMG 83-5"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hekster, Walter."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000037"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100567"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200036"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-C"
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000037",
+            "urn:oclc:NYPG001000017-C",
+            "urn:undefined:NNSZ00100567",
+            "urn:undefined:(WaOLN)nyp0200036"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Guitar)"
+          ],
+          "titleDisplay": [
+            "Eight studies for guitar : in form of a suite : 1979 / Walter Hekster."
+          ],
+          "uri": "b10000037",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies"
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000037"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841482"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-5"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841482"
+                    ],
+                    "idBarcode": [
+                      "33433032841482"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000005"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000038",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 160 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit, with verse and prose translations in Hindi; prefatory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit poetry",
+            "Sanskrit poetry -- Himachal Pradesh"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Himācala Kalā-Saṃskrti-Bhāṣā Akādamī"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana"
+          ],
+          "shelfMark": [
+            "*OKP 84-1932"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900772"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Prarthi, Lall Chand, 1916-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 84-1932"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000038"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900772"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200037"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Śimalā : Himācala Kalā-Saṃskrti-Bhāṣā Akādamī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000038",
+            "urn:lccn:76900772",
+            "urn:oclc:NYPG001000018-B",
+            "urn:undefined:NNSZ00100018",
+            "urn:undefined:(WaOLN)nyp0200037"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit poetry -- Himachal Pradesh."
+          ],
+          "titleDisplay": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana / mukhya sampādaka Lāla Canda Prārthī ; sampādaka maṇḍala, Manasā Rāma Śarmā 'Arūṇa'...[et al.]."
+          ],
+          "uri": "b10000038",
+          "lccClassification": [
+            "PK3800.H52 R7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Śimalā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000038"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783788",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 84-1932",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 84-1932"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153572"
+                    ],
+                    "idBarcode": [
+                      "33433058153572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKP 84-001932"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000039",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "49 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "C.F. Peters"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Five sonatas for pianoforte"
+          ],
+          "shelfMark": [
+            "JMG 83-66"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hässler, Johann Wilhelm, 1747-1822."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Oberdoerffer, Fritz."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000039"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters no. 66799. C.F. Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100568"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200038"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-C"
+          ],
+          "uniformTitle": [
+            "Sonatas, piano. Selections"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000039",
+            "urn:oclc:NYPG001000018-C",
+            "urn:undefined:Edition Peters no. 66799. C.F. Peters",
+            "urn:undefined:NNSZ00100568",
+            "urn:undefined:(WaOLN)nyp0200038"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Five sonatas for pianoforte / Johann Wilhelm Hässler ; edited by Fritz Oberdoerffer."
+          ],
+          "uri": "b10000039",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatas"
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000039"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842100"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-66"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842100"
+                    ],
+                    "idBarcode": [
+                      "33433032842100"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000066"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000040",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "146 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār."
+          ],
+          "shelfMark": [
+            "*OLB 84-1947"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Pulavar Arasu, 1900-"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "78913375"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 672"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1947"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000040"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78913375"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200039"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000040",
+            "urn:lccn:78913375",
+            "urn:oclc:NYPG001000019-B",
+            "urn:undefined:NNSZ00100019",
+            "urn:undefined:(WaOLN)nyp0200039"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953."
+          ],
+          "titleDisplay": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār. Āciriyar Pulavar Aracu."
+          ],
+          "uri": "b10000040",
+          "lccClassification": [
+            "PL4758.9.K223 Z83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000040"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783789",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1947",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301622"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1947"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301622"
+                    ],
+                    "idBarcode": [
+                      "33433061301622"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001947"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000041",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (23 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 5 clarinets.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Woodwind quintets (Clarinets (5))",
+            "Woodwind quintets (Clarinets (5)) -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Primavera"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Encounter"
+          ],
+          "shelfMark": [
+            "JMF 83-66"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Usher, Julia."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "81770739"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000041"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770739"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100569"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200040"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Primavera, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000041",
+            "urn:lccn:81770739",
+            "urn:oclc:NYPG001000019-C",
+            "urn:undefined:NNSZ00100569",
+            "urn:undefined:(WaOLN)nyp0200040"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Woodwind quintets (Clarinets (5)) -- Scores."
+          ],
+          "titleDisplay": [
+            "Encounter / Julia Usher."
+          ],
+          "uri": "b10000041",
+          "lccClassification": [
+            "M557.2.U8 E5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Greeting -- Circular argument -- Escape."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000041"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709291"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-66"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709291"
+                    ],
+                    "idBarcode": [
+                      "33433032709291"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000066"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000042",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 108 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit: pref. in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Advaita",
+            "Vedanta"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Devabhāṣā Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "dateEndString": [
+            "1972"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita."
+          ],
+          "shelfMark": [
+            "*OKN 84-1926"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902870"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Brahmashram, Śwami, 1915-"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 84-1926"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000042"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902870"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100020"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200041"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-B"
+          ],
+          "uniformTitle": [
+            "Mahābhārata. Sanatsugātīya."
+          ],
+          "dateEndYear": [
+            1972
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Prayāga, Devabhāṣā Prakāśana, Samvat 2028, i.e. 1971 or 2]"
+          ],
+          "identifier": [
+            "urn:bnum:10000042",
+            "urn:lccn:72902870",
+            "urn:oclc:NYPG001000020-B",
+            "urn:undefined:NNSZ00100020",
+            "urn:undefined:(WaOLN)nyp0200041"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Advaita.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita. Vyākhyātā Svāmī Brahmāśrama."
+          ],
+          "uri": "b10000042",
+          "lccClassification": [
+            "B132.V3 M264"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Prayāga"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000042"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783790",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 84-1926"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 84-1926",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618392"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKN 84-1926"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618392"
+                    ],
+                    "idBarcode": [
+                      "33433058618392"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 84-001926"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (28 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 2 flutes, 2 oboes, 2 clarinets, 2 horns, and 2 bassoons.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 5:00-6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: D.15 579.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Wind ensembles",
+            "Wind ensembles -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Verlag Doblinger"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Capriccio : für 10 Blasinstrumente"
+          ],
+          "shelfMark": [
+            "JMC 83-9"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Eröd, Iván."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Doblingers Studienpartituren ; Stp. 410"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMC 83-9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000043"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Stp. 410 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "D.15 579 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100570"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200042"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Wien : Verlag Doblinger, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000043",
+            "urn:oclc:NYPG001000020-C",
+            "urn:undefined:Stp. 410 Verlag Doblinger",
+            "urn:undefined:D.15 579 Verlag Doblinger",
+            "urn:undefined:NNSZ00100570",
+            "urn:undefined:(WaOLN)nyp0200042"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Wind ensembles -- Scores."
+          ],
+          "titleDisplay": [
+            "Capriccio : für 10 Blasinstrumente / Iván Eröd."
+          ],
+          "uri": "b10000043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wien"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000043"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMC 83-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMC 83-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004744128"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMC 83-9"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004744128"
+                    ],
+                    "idBarcode": [
+                      "33433004744128"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMC 83-000009"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000044",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[99] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Biographies of Khri-chen Byaṅ-chub-chos-ʼphel and Śel-dkar Bla-ma Saṅs-rgyas-bstan-ʼphel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from prints from blocks from Lhasa and Śel-dkar Dgaʼ-ldan-legs-bśad-gliṅ.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884",
+            "Lamas",
+            "Lamas -- Tibet",
+            "Lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ngawang Sopa"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2361"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rgal-dbaṅ Chos-rje Blo-bzaṅ-ʼphrin-las-rnam-rgyal, active 1840-1860."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77901316"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ngag-dbang-blo-bzang-rgya-mtsho, Dalai Lama V, 1617-1682."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2361"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000044"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77901316"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000021-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100021"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200043"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000021-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "New Delhi : Ngawang Sopa, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000044",
+            "urn:lccn:77901316",
+            "urn:oclc:NYPG001000021-B",
+            "urn:undefined:NNSZ00100021",
+            "urn:undefined:(WaOLN)nyp0200043"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838.",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884.",
+            "Lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel / by Dar-han Mkhan-sprul Blo-bzaṅ-ʼphrin-las-rnam-rgyal. Bkaʼ-gdams bstan-paʼi mdzod-ʼdzin Rje-btsun Bla-ma Saṅs-rgyas-bstan-ʼphel dpal-bzaṅ-poʼi rnam par thar pa dad ldan yid kyi dgaʼ ston : the biography of Saṅs-rgyas-bstan-ʼphel of Śel-dkar / by Śel-dkar Bkaʼ-ʼgyur Bla-ma Ṅag-dbaṅ-blo-bzaṅ-bstan-ʼdzin-tshul-khrims-rgyal-mtshan."
+          ],
+          "uri": "b10000044",
+          "lccClassification": [
+            "BQ942.Y367 R47 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000044"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000011",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2361",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080645"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080645"
+                    ],
+                    "idBarcode": [
+                      "33433015080645"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002361"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000045",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "12 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Violin music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sole selling agents, Or-Tav"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Thoughts & feelings : for violin solo"
+          ],
+          "shelfMark": [
+            "JMG 82-688"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stutschewsky, Joachim, 1891-1982."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "80770813"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 82-688"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000045"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80770813"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000021-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100571"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200044"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000021-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tel-Aviv : Sole selling agents, Or-Tav, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000045",
+            "urn:lccn:80770813",
+            "urn:oclc:NYPG001000021-C",
+            "urn:undefined:NNSZ00100571",
+            "urn:undefined:(WaOLN)nyp0200044"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Violin music."
+          ],
+          "titleDisplay": [
+            "Thoughts & feelings : for violin solo / Joachim Stutschewsky."
+          ],
+          "uri": "b10000045",
+          "lccClassification": [
+            "M42 .S"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tel-Aviv"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000045"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942043",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 82-688"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 82-688",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032707568"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 82-688"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032707568"
+                    ],
+                    "idBarcode": [
+                      "33433032707568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 82-000688"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000046",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[83] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Kye rdor rnam bśad.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from tracing and manuscripts from the library of Mkhan-po Rin-chen by Trayang and Jamyang Samten.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456",
+            "Tripiṭaka.",
+            "Tripiṭaka. -- Commentaries",
+            "Sa-skya-pa lamas",
+            "Sa-skya-pa lamas -- Tibet",
+            "Sa-skya-pa lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Trayang and Jamyang Samten"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2362"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Tshe-dbaṅ-rdo-rje-rig-ʼdzin, Prince of Sde-dge."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77900893"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sangs-rgyas-phun-tshogs, Ngor-chen, 1649-1705."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000046"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77900893"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000022-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100022"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200045"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000022-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "New Delhi : Trayang and Jamyang Samten, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000046",
+            "urn:lccn:77900893",
+            "urn:oclc:NYPG001000022-B",
+            "urn:undefined:NNSZ00100022",
+            "urn:undefined:(WaOLN)nyp0200045"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456.",
+            "Tripiṭaka. -- Commentaries.",
+            "Sa-skya-pa lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra / by Sde-dge Yab-chen Tshe-dbaṅ-rdo-rje-rig-ʼdzin alias Byams-pa-kun-dgaʼ-bstan-paʼi-rgyal-mtshan. Rgyal ba Rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas : the life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po / by Ṅor-chen Saṅs-rgyas-phun-tshogs."
+          ],
+          "uri": "b10000046",
+          "lccClassification": [
+            "BG974.0727 T75"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "titleAlt": [
+            "Rgyal ba rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas.",
+            "Detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra.",
+            "Life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000046"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080413"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080413"
+                    ],
+                    "idBarcode": [
+                      "33433015080413"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002362"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000047",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (30 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"This work was written between 14 March and 1 May, 1979\"--verso t.p.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 15 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vocalises (High voice) with instrumental ensemble",
+            "Vocalises (High voice) with instrumental ensemble -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello"
+          ],
+          "shelfMark": [
+            "JMG 83-79"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "81770634"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-79"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000047"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770634"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000022-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100572"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200046"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000022-C"
+          ],
+          "uniformTitle": [
+            "Vocalise, soprano, instrumental ensemble, op. 38"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London, England (Arlington Park House, London W4) : Redcliffe Edition, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000047",
+            "urn:lccn:81770634",
+            "urn:oclc:NYPG001000022-C",
+            "urn:undefined:NNSZ00100572",
+            "urn:undefined:(WaOLN)nyp0200046"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vocalises (High voice) with instrumental ensemble -- Scores."
+          ],
+          "titleDisplay": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello / Francis Routh."
+          ],
+          "uri": "b10000047",
+          "lccClassification": [
+            "M1613.3 .R8 op.38"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London, England (Arlington Park House, London W4)"
+          ],
+          "titleAlt": [
+            "Vocalise, op. 38"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "38 cm."
+          ]
+        },
+        "sort": [
+          "b10000047"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942044",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-79"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-79",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842233"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-79"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842233"
+                    ],
+                    "idBarcode": [
+                      "33433032842233"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000079"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000048",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[150] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a MS. preserved at Pha-lo-ldiṅ Monastery in Bhutan.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Buddhism",
+            "Buddhism -- Rituals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kunzang Topgey"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2382"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901012"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2382"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000048"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000023-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100023"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200047"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000023-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Thimphu : Kunzang Topgey, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000048",
+            "urn:lccn:76901012",
+            "urn:oclc:NYPG001000023-B",
+            "urn:undefined:NNSZ00100023",
+            "urn:undefined:(WaOLN)nyp0200047"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Buddhism -- Rituals."
+          ],
+          "titleDisplay": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "uri": "b10000048",
+          "lccClassification": [
+            "BQ7695 .B55"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Thimphu"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 38 cm."
+          ]
+        },
+        "sort": [
+          "b10000048"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2382",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080439"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080439"
+                    ],
+                    "idBarcode": [
+                      "33433015080439"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002382"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000049",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (105 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 25 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Symphony, op. 26 : full score"
+          ],
+          "shelfMark": [
+            "JMG 83-80"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "81770641"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-80"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000049"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770641"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000023-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100573"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200048"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000023-C"
+          ],
+          "uniformTitle": [
+            "Symphony, op. 26"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "London (Arlington Park House, London W4 4HD) : Redcliffe Edition, c1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000049",
+            "urn:lccn:81770641",
+            "urn:oclc:NYPG001000023-C",
+            "urn:undefined:NNSZ00100573",
+            "urn:undefined:(WaOLN)nyp0200048"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "Symphony, op. 26 : full score / Francis Routh."
+          ],
+          "uri": "b10000049",
+          "lccClassification": [
+            "M1001 .R8615 op.26"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London (Arlington Park House, London W4 4HD)"
+          ],
+          "titleAlt": [
+            "Symphony, op. 26"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000049"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942045",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-80"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-80",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842241"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-80"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842241"
+                    ],
+                    "idBarcode": [
+                      "33433032842241"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000080"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000050",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[188] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a print from the early 16th century western Tibetan blocks by Urgyan Dorje.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?",
+            "Bkaʼ-brgyud-pa lamas",
+            "Bkaʼ-brgyud-pa lamas -- Tibet",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography",
+            "Spiritual life",
+            "Spiritual life -- Buddhism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Urgyan Dorje"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2381"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901747"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2381"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000050"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901747"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000024-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100024"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200049"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000024-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "New Delhi : Urgyan Dorje, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000050",
+            "urn:lccn:76901747",
+            "urn:oclc:NYPG001000024-B",
+            "urn:undefined:NNSZ00100024",
+            "urn:undefined:(WaOLN)nyp0200049"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography.",
+            "Spiritual life -- Buddhism."
+          ],
+          "titleDisplay": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "uri": "b10000050",
+          "lccClassification": [
+            "BQ942.A187 A35 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000050"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2381",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080421"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080421"
+                    ],
+                    "idBarcode": [
+                      "33433015080421"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002381"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000051",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "score (64 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Samfundet til udgivelse af dansk musik"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972"
+          ],
+          "shelfMark": [
+            "JMG 83-75"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Christiansen, Henning."
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "idLccn": [
+            "78770955"
+          ],
+          "seriesStatement": [
+            "[Publikation] - Samfundet til udgivelse af dansk musik : 3. serie, nr. 264"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-75"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000051"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78770955"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000024-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100574"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200050"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000024-C"
+          ],
+          "uniformTitle": [
+            "Symphony, no. 2, op. 69c",
+            "Samfundet til udgivelse af dansk musik (Series) ; 3. ser., nr. 264."
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "København : Samfundet til udgivelse af dansk musik, 1977."
+          ],
+          "identifier": [
+            "urn:bnum:10000051",
+            "urn:lccn:78770955",
+            "urn:oclc:NYPG001000024-C",
+            "urn:undefined:NNSZ00100574",
+            "urn:undefined:(WaOLN)nyp0200050"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972 / Henning Christiansen."
+          ],
+          "uri": "b10000051",
+          "lccClassification": [
+            "M1001 .C533 op.69c"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "København"
+          ],
+          "titleAlt": [
+            "Symphony, no. 2, op. 69c",
+            "Den forsvundne."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "37 cm."
+          ]
+        },
+        "sort": [
+          "b10000051"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942046",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-75"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-75",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842191"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-75"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842191"
+                    ],
+                    "idBarcode": [
+                      "33433032842191"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000075"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-5ab0fe10cd85d356d015bdc132deaebc.json
+++ b/test/fixtures/query-5ab0fe10cd85d356d015bdc132deaebc.json
@@ -1,0 +1,918 @@
+{
+  "took": 50,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.902664,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.902664,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-5edfd5ce280c52725dbcf0ceaadcad29.json
+++ b/test/fixtures/query-5edfd5ce280c52725dbcf0ceaadcad29.json
@@ -1,0 +1,28034 @@
+{
+  "took": 935,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 18415692,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000103",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "11, 602 p.: port.;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Sharikah al-Waṭanīyah lil-Nashr wa-al-Tawzīʻ"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dīwān Muḥammad al-ʻĪd Muḥammad ʻAlī Khalīfah."
+          ],
+          "shelfMark": [
+            "*OFA 82-5137"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Khalīfah, Muḥammad al-ʻĪd, 1904-1979."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "75960366"
+          ],
+          "seriesStatement": [
+            "Manshūrāt Wizārat al-Tarbiyah al-Waṭanīyah bi-al-Jazāʼir; 1"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFA 82-5137"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000103"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960366"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000051-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100051"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200102"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000051-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "[al-Jazāʼir]: al-Sharikah al-Waṭanīyah lil-Nashr wa-al-Tawzīʻ, 1967."
+          ],
+          "identifier": [
+            "urn:bnum:10000103",
+            "urn:lccn:75960366",
+            "urn:oclc:NYPG001000051-B",
+            "urn:undefined:NNSZ00100051",
+            "urn:undefined:(WaOLN)nyp0200102"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Dīwān Muḥammad al-ʻĪd Muḥammad ʻAlī Khalīfah."
+          ],
+          "uri": "b10000103",
+          "lccClassification": [
+            "PJ7842.H2937 A17 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[al-Jazāʼir]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000103"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFA 82-5137"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFA 82-5137",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002000671"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFA 82-5137"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002000671"
+                    ],
+                    "idBarcode": [
+                      "33433002000671"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFA 82-005137"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000104",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xiv, 211 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Ceṉṉai, mayilai Vivēkānantar Kallūri Śrī Rājāji Caivacittānta aṟakkaṭṭaḷaiyiṉ cārpil nikaḻttiyavai.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Śaivism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Caivacittāntac coṟpoḻivukaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 82-5150"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Somasundaram Chettiar, Kayappakkah, 1897-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "73902751"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Jagannatacharya, C."
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 82-5150"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000104"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73902751"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000052-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100052"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200103"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000052-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "[Ceṉṉai] 1972."
+          ],
+          "identifier": [
+            "urn:bnum:10000104",
+            "urn:lccn:73902751",
+            "urn:oclc:NYPG001000052-B",
+            "urn:undefined:NNSZ00100052",
+            "urn:undefined:(WaOLN)nyp0200103"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Śaivism."
+          ],
+          "titleDisplay": [
+            "Caivacittāntac coṟpoḻivukaḷ. Āciriyar Kayappākkam Cōmacuntaram Ceṭṭiyār. Tokuttavar C. Jakannātācāryar."
+          ],
+          "uri": "b10000104",
+          "lccClassification": [
+            "BL1245.S5 S64"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Ceṉṉai]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000104"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000043",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 82-5150"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 82-5150",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001838949"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 82-5150"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001838949"
+                    ],
+                    "idBarcode": [
+                      "33433001838949"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 82-005150"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000105",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "60 p. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Murugan (Hindu deity)",
+            "Murugan (Hindu deity) -- Poetry"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "innūlkaḷ kiṭaikkumiṭam Liṭṭil Pḷavar Kampeṉi"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nakkīrar aruḷiya Tirumurukāṟṟuppaṭai; teḷivurai, viḷakkavuraikaḷuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLB 82-5148"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Nakkīrar."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "73902452"
+          ],
+          "seriesStatement": [
+            "Murukaṉ aruḷ veḷiyīṭu, 3"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Kachapesvaran, S. R., 1909-"
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 82-5148"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000105"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73902452"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000053-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100053"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200104"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000053-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "[Ceṉṉai]; innūlkaḷ kiṭaikkumiṭam Liṭṭil Pḷavar Kampeṉi, 1972."
+          ],
+          "identifier": [
+            "urn:bnum:10000105",
+            "urn:lccn:73902452",
+            "urn:oclc:NYPG001000053-B",
+            "urn:undefined:NNSZ00100053",
+            "urn:undefined:(WaOLN)nyp0200104"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Murugan (Hindu deity) -- Poetry."
+          ],
+          "titleDisplay": [
+            "Nakkīrar aruḷiya Tirumurukāṟṟuppaṭai; teḷivurai, viḷakkavuraikaḷuṭaṉ. Uraiyāciriyar Ca. Rā. Kaccapēcuvaraṉ."
+          ],
+          "uri": "b10000105",
+          "lccClassification": [
+            "PL4758.9.N28 T54"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Ceṉṉai];"
+          ],
+          "titleAlt": [
+            "Tirumurukāṟṟuppaṭai."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000105"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000044",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 82-5148"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 82-5148",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001838964"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 82-5148"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001838964"
+                    ],
+                    "idBarcode": [
+                      "33433001838964"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 82-005148"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000106",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "78 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tai Nūlakam ; viṟpaṉai urimai, Kavitā Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nallakati : kuṟunāval"
+          ],
+          "shelfMark": [
+            "*OLB 82-5149"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Shanmugam, A. P., 1929-"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76903205"
+          ],
+          "seriesStatement": [
+            "Tai Nūlaka veḷiyīṭu ; 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 82-5149"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000106"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76903205"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000054-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100054"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200105"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000054-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Nācciyār Kōvil, Tañcai Māvaṭṭam : Tai Nūlakam ; Ceṉṉai : viṟpaṉai urimai, Kavitā Patippakam, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000106",
+            "urn:lccn:76903205",
+            "urn:oclc:NYPG001000054-B",
+            "urn:undefined:NNSZ00100054",
+            "urn:undefined:(WaOLN)nyp0200105"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Nallakati : kuṟunāval / Ē. Pi. Caṇmukam."
+          ],
+          "uri": "b10000106",
+          "lccClassification": [
+            "PL4758.9.S46 N3"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Nācciyār Kōvil, Tañcai Māvaṭṭam : Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000106"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000045",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 82-5149"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 82-5149",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001838956"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 82-5149"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001838956"
+                    ],
+                    "idBarcode": [
+                      "33433001838956"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 82-005149"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000107",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "X, 271 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"1958 il Em. Liṭ. Āyvukkut...innūlai...āyntu Ceṉṉaip Palkalaikkaḻakattil 1961 il Āṅkilattil eṉ āyvukkaṭṭuraiyaik koṭuttēṉ. Ataṉait taḻuvi eḻutappeṟṟatē it Tamiḻ nūl.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Paripāṭal"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Maṇivācakam Nūlakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Paripāṭal tiṟaṉ."
+          ],
+          "shelfMark": [
+            "*OLB 82-5147"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Cāraṅkapāṇi, Irā. (Irācakōpāl), 1925-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "72901252"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 82-5147"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000107"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72901252"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000055-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100055"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200106"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000055-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Citamparam, Maṇivācakam Nūlakam [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000107",
+            "urn:lccn:72901252",
+            "urn:oclc:NYPG001000055-B",
+            "urn:undefined:NNSZ00100055",
+            "urn:undefined:(WaOLN)nyp0200106"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Paripāṭal."
+          ],
+          "titleDisplay": [
+            "Paripāṭal tiṟaṉ. [Eḻutiyavar] Irā. Cāraṅkapāṇi."
+          ],
+          "uri": "b10000107",
+          "lccClassification": [
+            "PL4758.6.P37 S2"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Citamparam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000107"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000046",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 82-5147"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 82-5147",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001838972"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 82-5147"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001838972"
+                    ],
+                    "idBarcode": [
+                      "33433001838972"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 82-005147"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000108",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "314 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Yugavāṇī Prakāśana; [Ekādhikārī Vitaraka Sahacārī Prakāśana Prasāraṇa"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nīhārikā; Kalāpūrṇa sāmājika upanyāsa."
+          ],
+          "shelfMark": [
+            "*OKTN 82-5146"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Pant, Govind Ballabh, 1887-1961."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "sa 68007148"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTN 82-5146"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000108"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68007148"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000056-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100056"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200107"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000056-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Kānapura, Yugavāṇī Prakāśana; [Ekādhikārī Vitaraka Sahacārī Prakāśana Prasāraṇa, 1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000108",
+            "urn:lccn:sa 68007148",
+            "urn:oclc:NYPG001000056-B",
+            "urn:undefined:NNSZ00100056",
+            "urn:undefined:(WaOLN)nyp0200107"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Nīhārikā; Kalāpūrṇa sāmājika upanyāsa. Lekhaka Govindavallabha Panta."
+          ],
+          "uri": "b10000108",
+          "lccClassification": [
+            "PK2098.P319 N5 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kānapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000108"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942050",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTN 82-5146"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTN 82-5146",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012457234"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTN 82-5146"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012457234"
+                    ],
+                    "idBarcode": [
+                      "33433012457234"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTN 82-005146"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000109",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxii, 321 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [305]-321).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Americans",
+            "Americans -- History",
+            "Americans -- History -- China",
+            "Americans -- History -- China -- 19th century",
+            "Public opinion",
+            "Public opinion -- United States",
+            "Public opinion -- United States -- History",
+            "Public opinion -- United States -- History -- 19th century",
+            "United States",
+            "United States -- Chinese influences",
+            "United States -- Intellectual life",
+            "United States -- Intellectual life -- 19th century",
+            "China",
+            "China -- History",
+            "China -- History -- 19th century",
+            "China -- Description and travel",
+            "China -- In popular culture",
+            "United States -- Relations",
+            "United States -- Relations -- China",
+            "China -- Relations",
+            "China -- Relations -- United States"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Columbia University Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            2008
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The romance of China : excursions to China in U.S. culture, 1776-1876"
+          ],
+          "shelfMark": [
+            "JFE 09-1362"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Haddad, John Rogers."
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "idLccn": [
+            "2008037637"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2008
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 09-1362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000109"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780231130943 (cloth : alk. paper)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0231130945 (cloth : alk. paper)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2008037637"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "184821618"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "184821618"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)184821618"
+            }
+          ],
+          "idOclc": [
+            "184821618"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "New York : Columbia University Press, c2008."
+          ],
+          "identifier": [
+            "urn:bnum:10000109",
+            "urn:isbn:9780231130943 (cloth : alk. paper)",
+            "urn:isbn:0231130945 (cloth : alk. paper)",
+            "urn:lccn:2008037637",
+            "urn:oclc:184821618",
+            "urn:undefined:(OCoLC)184821618"
+          ],
+          "idIsbn": [
+            "9780231130943 (cloth : alk. paper)",
+            "0231130945 (cloth : alk. paper)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Americans -- History -- China -- 19th century.",
+            "Public opinion -- United States -- History -- 19th century.",
+            "United States -- Chinese influences.",
+            "United States -- Intellectual life -- 19th century.",
+            "China -- History -- 19th century.",
+            "China -- Description and travel.",
+            "China -- In popular culture.",
+            "United States -- Relations -- China.",
+            "China -- Relations -- United States."
+          ],
+          "titleDisplay": [
+            "The romance of China : excursions to China in U.S. culture, 1776-1876 / John Rogers Haddad."
+          ],
+          "uri": "b10000109",
+          "lccClassification": [
+            "E183.8.C5 H175 2008"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Xanadu : an envoy at the throne of a monarch -- Romantic domesticity : a Chinese world invented at home -- Pursuing the China effect : a country described through marketing -- China in miniature : Nathan Dunn's Chinese museum -- A floating ethnology : the strange voyage of the Chinese junk Keying -- God's China : the Middle Kingdom of Samuel Wells Williams -- The cultural fruits of diplomacy : Chinese museum and panorama -- The ugly face of China : Bayard Taylor's travels in Asia -- Traditional China and Chinese Yankees : the Centennial Exposition of 1876."
+          ],
+          "idIsbn_clean": [
+            "9780231130943",
+            "0231130945"
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000109"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23117386",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 09-1362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 09-1362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084847221"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 09-1362"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084847221"
+                    ],
+                    "idBarcode": [
+                      "33433084847221"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFE 09-001362"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783799",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLF 82-5145"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLF 82-5145",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061318089"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLF 82-5145"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061318089"
+                    ],
+                    "idBarcode": [
+                      "33433061318089"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLF 82-005145"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000110",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xi, 207 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Economic ideas in Kural.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 184-188.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Maturaip Palkalaik Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kuṟaḷ kaṇṭa poruḷvāḻvu"
+          ],
+          "shelfMark": [
+            "*OLB 82-5121"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Murukarattaṉam, Ti., 1934-"
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75902500"
+          ],
+          "seriesStatement": [
+            "Tirukkuṟaḷ Āyvaka veḷiyīṭu ; 1"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 82-5121"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000110"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902500"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000058-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100058"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200109"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000058-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Maturai : Maturaip Palkalaik Kaḻakam, 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000110",
+            "urn:lccn:75902500",
+            "urn:oclc:NYPG001000058-B",
+            "urn:undefined:NNSZ00100058",
+            "urn:undefined:(WaOLN)nyp0200109"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Kuṟaḷ kaṇṭa poruḷvāḻvu / Āciriyar Ti. Murukarattaṉam."
+          ],
+          "uri": "b10000110",
+          "lccClassification": [
+            "PL4758.9T5 M834"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maturai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000110"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000047",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 82-5121"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 82-5121",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001837818"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 82-5121"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001837818"
+                    ],
+                    "idBarcode": [
+                      "33433001837818"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 82-005121"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000111",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "330 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islamic law"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "s.n."
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Taʻāmul fī al-Islām"
+          ],
+          "shelfMark": [
+            "*OGM 82-5151"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Samāwī, ʻAbd al-Wahhāb ibn Muḥammad."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "75960238"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGM 82-5151"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000111"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960238"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000059-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100059"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200110"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000059-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "[S.l. : s.n., 1975]"
+          ],
+          "identifier": [
+            "urn:bnum:10000111",
+            "urn:lccn:75960238",
+            "urn:oclc:NYPG001000059-B",
+            "urn:undefined:NNSZ00100059",
+            "urn:undefined:(WaOLN)nyp0200110"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islamic law."
+          ],
+          "titleDisplay": [
+            "al-Taʻāmul fī al-Islām / ʻAbd al-Wahhāb ibn Muḥammad al-Samāwī."
+          ],
+          "uri": "b10000111",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000111"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000048",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGM 82-5151"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGM 82-5151",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001944218"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGM 82-5151"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001944218"
+                    ],
+                    "idBarcode": [
+                      "33433001944218"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGM 82-005151"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000112",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "397 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 397.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tax accounting",
+            "Tax accounting -- Libya"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Jāmiʻah al-Lībīyah, Kullīyat al-Iqtiṣād wa-al-Tijārah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Muḥāsib al-ḍarībī; dirāsah naẓarīyah taṭbīqīyah muqāranah maʻa al-tashrīʻ al-ḍarībī al-Lībī"
+          ],
+          "shelfMark": [
+            "*OFO 82-5122"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "ʻAbd al-Raḥīm, Nūḥ Muḥammad."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "74222293"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFO 82-5122"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000112"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74222293"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000060-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100060"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200111"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000060-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "[Ṭarābulus] al-Jāmiʻah al-Lībīyah, Kullīyat al-Iqtiṣād wa-al-Tijārah [1971]"
+          ],
+          "identifier": [
+            "urn:bnum:10000112",
+            "urn:lccn:74222293",
+            "urn:oclc:NYPG001000060-B",
+            "urn:undefined:NNSZ00100060",
+            "urn:undefined:(WaOLN)nyp0200111"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tax accounting -- Libya."
+          ],
+          "titleDisplay": [
+            "al-Muḥāsib al-ḍarībī; dirāsah naẓarīyah taṭbīqīyah muqāranah maʻa al-tashrīʻ al-ḍarībī al-Lībī [taʼlīf] Nūḥ Muḥammad ʻAbd al-Raḥīm."
+          ],
+          "uri": "b10000112",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Ṭarābulus]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000112"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000049",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFO 82-5122"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFO 82-5122",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586205"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5122"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586205"
+                    ],
+                    "idBarcode": [
+                      "33433005586205"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFO 82-005122"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000113",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "140 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Previously published in Centamiḻ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kalaimakaḷ Kāriyālayam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vipulānanta ārāyvu."
+          ],
+          "shelfMark": [
+            "*OLB 82-5157"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Vipulānanta, 1892-1947."
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "78903058"
+          ],
+          "seriesStatement": [
+            "His Ilakkiyam, tokuti, 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Selvanayagam, Arul."
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 82-5157"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000113"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78903058"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000061-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100061"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200112"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000061-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Ceṉṉai, Kalaimakaḷ Kāriyālayam [1965]"
+          ],
+          "identifier": [
+            "urn:bnum:10000113",
+            "urn:lccn:78903058",
+            "urn:oclc:NYPG001000061-B",
+            "urn:undefined:NNSZ00100061",
+            "urn:undefined:(WaOLN)nyp0200112"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Vipulānanta ārāyvu. Tokuppāciriyar Aruḷ Celvanāyakam. Matippurai: Ka. Ce. Naṭarācā."
+          ],
+          "uri": "b10000113",
+          "lccClassification": [
+            "AC165.T3 V48"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000113"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000050",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 82-5157"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 82-5157",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001838923"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 82-5157"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001838923"
+                    ],
+                    "idBarcode": [
+                      "33433001838923"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 82-005157"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000114",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "134 p. : ill., map ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran-Iraq War, 1980-1988"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muʼassisah-ʼi Maṭbūʻātī-i ʻAṭāʼī"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Jang-i Īran va ʻIrāq"
+          ],
+          "shelfMark": [
+            "*OMZ 82-5156"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Dildam, Iskandar."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 82-5156"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000114"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000062-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100062"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200113"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000062-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Tihrān : Muʼassisah-ʼi Maṭbūʻātī-i ʻAṭāʼī, 1359 [1980]"
+          ],
+          "identifier": [
+            "urn:bnum:10000114",
+            "urn:oclc:NYPG001000062-B",
+            "urn:undefined:NNSZ00100062",
+            "urn:undefined:(WaOLN)nyp0200113"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran-Iraq War, 1980-1988."
+          ],
+          "titleDisplay": [
+            "Jang-i Īran va ʻIrāq / Iskandar Dildam."
+          ],
+          "uri": "b10000114",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000114"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942051",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMZ 82-5156"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMZ 82-5156",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014543452"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 82-5156"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014543452"
+                    ],
+                    "idBarcode": [
+                      "33433014543452"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMZ 82-005156"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000115",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "105, [2] p. : map ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Disputes of Iran and Iraq over Sovereignty and shipping rights of the two countries on Arvand Roud, by Maḥmoud M. Aghili.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [1-2] (second group).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran-Iraq War, 1980-1988"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Chāpkhānah-ʼi Sipihr"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ikhtilāfāt-i Īrān va ʻIrāq : dar khuṣūṣ-i haqq-i ḥākimīyat va ḥuqūq-i kishtīrānī-i du kishvar dar Arvand Rūd (Shaṭṭ al-ʻArab)"
+          ],
+          "shelfMark": [
+            "*OMZ 82-5155"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Musallamī ʻAqīlī, Maḥmūd."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 82-5155"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000115"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000063-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100063"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200114"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000063-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Tihrān : Chāpkhānah-ʼi Sipihr, 1359 [1980]"
+          ],
+          "identifier": [
+            "urn:bnum:10000115",
+            "urn:oclc:NYPG001000063-B",
+            "urn:undefined:NNSZ00100063",
+            "urn:undefined:(WaOLN)nyp0200114"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran-Iraq War, 1980-1988."
+          ],
+          "titleDisplay": [
+            "Ikhtilāfāt-i Īrān va ʻIrāq : dar khuṣūṣ-i haqq-i ḥākimīyat va ḥuqūq-i kishtīrānī-i du kishvar dar Arvand Rūd (Shaṭṭ al-ʻArab) / taʼlīf-i Maḥmūd Musallamī ʻAqīlī."
+          ],
+          "uri": "b10000115",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000115"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942052",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMZ 82-5155"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMZ 82-5155",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014543445"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 82-5155"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014543445"
+                    ],
+                    "idBarcode": [
+                      "33433014543445"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMZ 82-005155"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000116",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "8, 733p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cuntarar.",
+            "Cuntarar. -- Indexes",
+            "Hindu hymns, Tamil",
+            "Hindu hymns, Tamil -- Indexes"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1963
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tēvāra oḷineṟi, Cuntarar"
+          ],
+          "shelfMark": [
+            "*OLB 82-5123"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ceṅkalvarāya Piḷḷai, Va. Cu., 1883-1971."
+          ],
+          "createdString": [
+            "1963"
+          ],
+          "idLccn": [
+            "75901411"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu; 1139"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Cuntarar."
+          ],
+          "dateStartYear": [
+            1963
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 82-5123"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000116"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75901411"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000064-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100064"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200115"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000064-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Tirunelvēli : Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1963."
+          ],
+          "identifier": [
+            "urn:bnum:10000116",
+            "urn:lccn:75901411",
+            "urn:oclc:NYPG001000064-B",
+            "urn:undefined:NNSZ00100064",
+            "urn:undefined:(WaOLN)nyp0200115"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1963"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cuntarar. -- Indexes.",
+            "Hindu hymns, Tamil -- Indexes."
+          ],
+          "titleDisplay": [
+            "Tēvāra oḷineṟi, Cuntarar / Va. Cu. Ceṅkalvarāya Piḷḷai eḻutiyatu."
+          ],
+          "uri": "b10000116",
+          "lccClassification": [
+            "BL1226.3.C862 C47"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirunelvēli"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000116"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000051",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 82-5123"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 82-5123",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001839004"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 82-5123"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001839004"
+                    ],
+                    "idBarcode": [
+                      "33433001839004"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 82-005123"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000117",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "515 p. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 491-506.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Abū Hurayrah, -677?"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Maktabat al-Nahḍah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Difāʻ ʻan Abī Hurayrah"
+          ],
+          "shelfMark": [
+            "*OFS 82-5125"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "ʻIzzī, ʻAbd al-Munʻim Ṣāliḥ al-ʻAlī."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75587091"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 82-5125"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000117"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75587091"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000065-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100065"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200116"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000065-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Baghdād, Maktabat al-Nahḍah, 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000117",
+            "urn:lccn:75587091",
+            "urn:oclc:NYPG001000065-B",
+            "urn:undefined:NNSZ00100065",
+            "urn:undefined:(WaOLN)nyp0200116"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Abū Hurayrah, -677?"
+          ],
+          "titleDisplay": [
+            "Difāʻ ʻan Abī Hurayrah [taʼlīf] ʻAbd al-Munʻim Ṣāliḥ al-ʻAlī al-ʻIzzī."
+          ],
+          "uri": "b10000117",
+          "lccClassification": [
+            "BP80.A227 A67"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Baghdād"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10000117"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000052",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 82-5125"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 82-5125",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514537"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 82-5125"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514537"
+                    ],
+                    "idBarcode": [
+                      "33433014514537"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFS 82-005125"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000118",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "310 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 305-308.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Socialism",
+            "Socialism -- Egypt",
+            "Egypt",
+            "Egypt -- History",
+            "Egypt -- History -- 1919-1952"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Thaqāfah al-Jadīdah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tārīkh al-ḥarakah al-ishtirākīyah fī Miṣr 1900-1925"
+          ],
+          "shelfMark": [
+            "*OFP 82-5152"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Saʻīd, Rifʻat."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "75960371"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFP 82-5152"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000118"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960371"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000066-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100066"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200117"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000066-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "al-Qāhirah : Dār al-Thaqāfah al-Jadīdah, [1975?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000118",
+            "urn:lccn:75960371",
+            "urn:oclc:NYPG001000066-B",
+            "urn:undefined:NNSZ00100066",
+            "urn:undefined:(WaOLN)nyp0200117"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Socialism -- Egypt.",
+            "Egypt -- History -- 1919-1952."
+          ],
+          "titleDisplay": [
+            "Tārīkh al-ḥarakah al-ishtirākīyah fī Miṣr 1900-1925 / Rifʻat al-Saʻīd."
+          ],
+          "uri": "b10000118",
+          "lccClassification": [
+            "Hx442 .S233 1975"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000118"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000053",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 82-5152"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 82-5152",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001937576"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFP 82-5152"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001937576"
+                    ],
+                    "idBarcode": [
+                      "33433001937576"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFP 82-005152"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000119",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "120 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Urdu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ḵẖāṉ, Aḥmad Razā, 1856-1921"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Markazī Majlis Razā"
+          ],
+          "language": [
+            {
+              "id": "lang:urd",
+              "label": "Urdu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aʻlāḥazrat kā fiqhī maqām"
+          ],
+          "shelfMark": [
+            "*OKTY 82-5154"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Aḵẖtar Shāhjahānpūrī."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72930336"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTY 82-5154"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000119"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72930336"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000067-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100067"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200118"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000067-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Lāhaur, Markazī Majlis Razā [1971]"
+          ],
+          "identifier": [
+            "urn:bnum:10000119",
+            "urn:lccn:72930336",
+            "urn:oclc:NYPG001000067-B",
+            "urn:undefined:NNSZ00100067",
+            "urn:undefined:(WaOLN)nyp0200118"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ḵẖāṉ, Aḥmad Razā, 1856-1921."
+          ],
+          "titleDisplay": [
+            "Aʻlāḥazrat kā fiqhī maqām, az Akhtar Shāhjahānpūrī."
+          ],
+          "uri": "b10000119",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Lāhaur"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000119"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000054",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTY 82-5154"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTY 82-5154",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011242736"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTY 82-5154"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011242736"
+                    ],
+                    "idBarcode": [
+                      "33433011242736"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTY 82-005154"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000120",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "120 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Vāṉati Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṇṇāviṉ navamaṇikaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 82-5139"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Annadurai, C. N., 1909-1969."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "71901945"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Tarumarācaṉ, Nākai M."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 82-5139"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000120"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "71901945"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000068-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100068"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200119"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000068-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Ceṉṉai, Vāṉati Patippakam [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000120",
+            "urn:lccn:71901945",
+            "urn:oclc:NYPG001000068-B",
+            "urn:undefined:NNSZ00100068",
+            "urn:undefined:(WaOLN)nyp0200119"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Aṇṇāviṉ navamaṇikaḷ. Tokuttavar Nākai-Tarumaṉ."
+          ],
+          "uri": "b10000120",
+          "lccClassification": [
+            "DS481.A64 A48"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000120"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000055",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 82-5139"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 82-5139",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001838998"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 82-5139"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001838998"
+                    ],
+                    "idBarcode": [
+                      "33433001838998"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 82-005139"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000121",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "184 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Bengali.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Triveṇī Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:ben",
+              "label": "Bengali"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1963
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Natuna hāoẏā."
+          ],
+          "shelfMark": [
+            "*OKV 82-5138"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kar, Bimal, 1921-"
+          ],
+          "createdString": [
+            "1963"
+          ],
+          "idLccn": [
+            "sa 64001851"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1963
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKV 82-5138"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000121"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 64001851"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000069-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100069"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200120"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000069-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Kalikātā, Triveṇī Prakāśana [1963]"
+          ],
+          "identifier": [
+            "urn:bnum:10000121",
+            "urn:lccn:sa 64001851",
+            "urn:oclc:NYPG001000069-B",
+            "urn:undefined:NNSZ00100069",
+            "urn:undefined:(WaOLN)nyp0200120"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1963"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Natuna hāoẏā. [Lekhaka] Bimala Kara."
+          ],
+          "uri": "b10000121",
+          "lccClassification": [
+            "PK1718.K3 N3"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kalikātā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000121"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000056",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKV 82-5138"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKV 82-5138",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011167834"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKV 82-5138"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011167834"
+                    ],
+                    "idBarcode": [
+                      "33433011167834"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKV 82-005138"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000122",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "96 p. port."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Series romanized: Urdū ke lokapriya śāyara.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Urdu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Rājapāla"
+          ],
+          "language": [
+            {
+              "id": "lang:urd",
+              "label": "Urdu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sāhira Ludhyānavī aura unakī śāyarī."
+          ],
+          "shelfMark": [
+            "*OKTX 82-5136"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Sāḥir Ludhiyānvī, 1921-1980."
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "idLccn": [
+            "sa 68008215"
+          ],
+          "seriesStatement": [
+            "Urdū ke lokapriya śāyara"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Panḍit, Prakāsh, 1924-"
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTX 82-5136"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000122"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68008215"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000070-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100070"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200121"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000070-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Dillī, Rājapāla [1966]"
+          ],
+          "identifier": [
+            "urn:bnum:10000122",
+            "urn:lccn:sa 68008215",
+            "urn:oclc:NYPG001000070-B",
+            "urn:undefined:NNSZ00100070",
+            "urn:undefined:(WaOLN)nyp0200121"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Sāhira Ludhyānavī aura unakī śāyarī. Sampādaka Prakāśa Paṇḍita."
+          ],
+          "uri": "b10000122",
+          "lccClassification": [
+            "PK2200.S27 A6 1966"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dillī"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000122"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000057",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTX 82-5136"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTX 82-5136",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004673145"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTX 82-5136"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004673145"
+                    ],
+                    "idBarcode": [
+                      "33433004673145"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTX 82-005136"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000123",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "96 p. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Bengali.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Śrī Prakāśa Bhavana"
+          ],
+          "language": [
+            {
+              "id": "lang:ben",
+              "label": "Bengali"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1962
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Elomelo."
+          ],
+          "shelfMark": [
+            "*OKV 82-5135"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Bose, Buddhadeva."
+          ],
+          "createdString": [
+            "1962"
+          ],
+          "idLccn": [
+            "sa 63003593"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1962
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKV 82-5135"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000123"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 63003593"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000071-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100071"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200122"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000071-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Kalakātā, Śrī Prakāśa Bhavana [1962]"
+          ],
+          "identifier": [
+            "urn:bnum:10000123",
+            "urn:lccn:sa 63003593",
+            "urn:oclc:NYPG001000071-B",
+            "urn:undefined:NNSZ00100071",
+            "urn:undefined:(WaOLN)nyp0200122"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1962"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Elomelo. [Lekhaka] Buddhadeba Basu."
+          ],
+          "uri": "b10000123",
+          "lccClassification": [
+            "PZ90.B4 B6"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kalakātā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000123"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000058",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKV 82-5135"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKV 82-5135",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011167826"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKV 82-5135"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011167826"
+                    ],
+                    "idBarcode": [
+                      "33433011167826"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKV 82-005135"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000124",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "190 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Bengali.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Es. Si. Sarakāra"
+          ],
+          "language": [
+            {
+              "id": "lang:ben",
+              "label": "Bengali"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1963
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Samudra śaṅkha."
+          ],
+          "shelfMark": [
+            "*OKV 82-5134"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rājaguru, Śaktipada."
+          ],
+          "createdString": [
+            "1963"
+          ],
+          "idLccn": [
+            "sa 63004625"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1963
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKV 82-5134"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000124"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 63004625"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000072-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100072"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200123"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000072-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Kalikātā, Es. Si. Sarakāra [1963]"
+          ],
+          "identifier": [
+            "urn:bnum:10000124",
+            "urn:lccn:sa 63004625",
+            "urn:oclc:NYPG001000072-B",
+            "urn:undefined:NNSZ00100072",
+            "urn:undefined:(WaOLN)nyp0200123"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1963"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Samudra śaṅkha. [Lekhaka] Śaktipada Rājaguru."
+          ],
+          "uri": "b10000124",
+          "lccClassification": [
+            "PK1718.R24 S23"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kalikātā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000124"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000059",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKV 82-5134"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKV 82-5134",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011167818"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKV 82-5134"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011167818"
+                    ],
+                    "idBarcode": [
+                      "33433011167818"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKV 82-005134"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000125",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "214 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 209-214.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Poets, Arab",
+            "Poets, Arab -- Iraq",
+            "Poets, Arab -- Iraq -- Bibliography",
+            "Yezidis",
+            "Yezidis -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tawzīʻ Maktabat al-Andalus]"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Shiʻr al-Yazīdīyīn"
+          ],
+          "shelfMark": [
+            "*OFS 82-3836"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ghayāḍ, Muḥsin."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "74222306"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 82-3836"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000125"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74222306"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000073-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100073"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200124"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000073-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "[Baghdād, Tawzīʻ Maktabat al-Andalus] 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000125",
+            "urn:lccn:74222306",
+            "urn:oclc:NYPG001000073-B",
+            "urn:undefined:NNSZ00100073",
+            "urn:undefined:(WaOLN)nyp0200124"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Poets, Arab -- Iraq -- Bibliography.",
+            "Yezidis -- Biography."
+          ],
+          "titleDisplay": [
+            "Shiʻr al-Yazīdīyīn, jamaʻahu wa-ḥaqqaqahu Muḥsin Ghayāḍ."
+          ],
+          "uri": "b10000125",
+          "lccClassification": [
+            "PJ8034 .G5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Baghdād"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000125"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000060",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 82-3836"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 82-3836",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514172"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 82-3836"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514172"
+                    ],
+                    "idBarcode": [
+                      "33433014514172"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFS 82-003836"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000126",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "72 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ramana, Maharshi",
+            "Ramana, Maharshi -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Śrī Ramaṇāśrama"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrī Ramaṇa Maharshi : eka saṃkshipta jīvanī : sacitra."
+          ],
+          "shelfMark": [
+            "*OLY 82-4666"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 82-4666"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000126"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000074-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100074"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200125"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000074-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Tirūvaṇṇāmalai : Śrī Ramaṇāśrama, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000126",
+            "urn:oclc:NYPG001000074-B",
+            "urn:undefined:NNSZ00100074",
+            "urn:undefined:(WaOLN)nyp0200125"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ramana, Maharshi -- Biography."
+          ],
+          "titleDisplay": [
+            "Śrī Ramaṇa Maharshi : eka saṃkshipta jīvanī : sacitra."
+          ],
+          "uri": "b10000126",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirūvaṇṇāmalai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000126"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783800",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 82-4666"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 82-4666",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060417551"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 82-4666"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060417551"
+                    ],
+                    "idBarcode": [
+                      "33433060417551"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 82-004666"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000127",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "269 p. maps."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of The modern history of Lebanon.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Lebanon",
+            "Lebanon -- History"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Nahār lil-Nashr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tārīkh Lubnān al-ḥadīth"
+          ],
+          "shelfMark": [
+            "*OFP 82-3837"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Salibi, Kamal S. (Kamal Suleiman), 1929-2011."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "75232402"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFP 82-3837"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000127"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75232402"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000075-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100075"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200126"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000075-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Bayrūt, Dār al-Nahār lil-Nashr [1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000127",
+            "urn:lccn:75232402",
+            "urn:oclc:NYPG001000075-B",
+            "urn:undefined:NNSZ00100075",
+            "urn:undefined:(WaOLN)nyp0200126"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Lebanon -- History."
+          ],
+          "titleDisplay": [
+            "Tārīkh Lubnān al-ḥadīth [taʼlīf] Kamāl Sulaymān al-Ṣalībī."
+          ],
+          "uri": "b10000127",
+          "lccClassification": [
+            "DS84 .S25"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000127"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000061",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 82-3837"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 82-3837",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001542319"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFP 82-3837"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001542319"
+                    ],
+                    "idBarcode": [
+                      "33433001542319"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFP 82-003837"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000128",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "247 p. maps, ports."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Lawrence, T. E. 1888-1935"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Nahār"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lūrins kamā ʻaraftuh"
+          ],
+          "shelfMark": [
+            "*OFS 82-3903"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "ʻUmarī, Ṣubḥī, 1898-"
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "79282457"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 82-3903"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000128"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79282457"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000076-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100076"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200127"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000076-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "[Bayrūt] Dār al-Nahār [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000128",
+            "urn:lccn:79282457",
+            "urn:oclc:NYPG001000076-B",
+            "urn:undefined:NNSZ00100076",
+            "urn:undefined:(WaOLN)nyp0200127"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Lawrence, T. E. 1888-1935."
+          ],
+          "titleDisplay": [
+            "Lūrins kamā ʻaraftuh [taʼlīf] Ṣubḥī al-ʻUmarī."
+          ],
+          "uri": "b10000128",
+          "lccClassification": [
+            "D568.4.L45 U45"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000128"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000062",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 82-3903"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 82-3903",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514271"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 82-3903"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514271"
+                    ],
+                    "idBarcode": [
+                      "33433014514271"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFS 82-003903"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000129",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "117 p. : facsims. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 99-104.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Jumhūrīyah al-ʻIrāqīyah, Wizārat al-Iʻlām, Mudīrīyat al-Thaqāfah al-ʻĀmmah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dīwān ʻAmr ibn Qamīʼah"
+          ],
+          "shelfMark": [
+            "*OEM 82-3896"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "ʻAmr ibn Qamīʼah."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75587883"
+          ],
+          "seriesStatement": [
+            "Silsilat Kutub al-turāth."
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "ʻAṭīyah, Khalīl Ibrāhīm."
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OEM 82-3896"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000129"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75587883"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000077-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100077"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200128"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000077-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Baghdād : al-Jumhūrīyah al-ʻIrāqīyah, Wizārat al-Iʻlām, Mudīrīyat al-Thaqāfah al-ʻĀmmah, 1972."
+          ],
+          "identifier": [
+            "urn:bnum:10000129",
+            "urn:lccn:75587883",
+            "urn:oclc:NYPG001000077-B",
+            "urn:undefined:NNSZ00100077",
+            "urn:undefined:(WaOLN)nyp0200128"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Dīwān ʻAmr ibn Qamīʼah / ʻuniya bi-taḥqīqihi wa-sharḥih Khalīl Ibrāhīm al-ʻAṭīyah."
+          ],
+          "uri": "b10000129",
+          "lccClassification": [
+            "PJ7696.A5 A6 1972"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Baghdād"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000129"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000063",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OEM 82-3896"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OEM 82-3896",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002038218"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OEM 82-3896"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002038218"
+                    ],
+                    "idBarcode": [
+                      "33433002038218"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OEM 82-003896"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000130",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "478 p. facsims."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: al-Burhan, edited with an introd. by Ahmad Matloub [and] Khadijah al-Hadithi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "The work, under title Naqd al-Nathr, has been attributed by Ṭāhā Ḥusayn and ʻAbd al-Ḥamīd al-ʻAbbādī to Qudāmah. The present editors, on the basis of a newly discovered MS., attribute it to Abū al-Ḥusayn Isḥāq ibn Ibrāhīm al-Kātib, an otherwise unknown author.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Arabic language",
+            "Arabic language -- Rhetoric"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Jāmiʻat Baghdād"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Burhān fī wujūh al-bayān"
+          ],
+          "shelfMark": [
+            "*OEQ 82-4707"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "ne 68003583"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Abū al-Ḥusayn Isḥāq ibn Ibrāhīm al-Kātib.",
+            "Qudāmah ibn Jaʻfar, -922?",
+            "Maṭlūb, Aḥmad.",
+            "Ḥadīthī, Khadījah."
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OEQ 82-4707"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000130"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ne 68003583"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000078-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100078"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200129"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000078-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "[Baghdād] Jāmiʻat Baghdād 1967."
+          ],
+          "identifier": [
+            "urn:bnum:10000130",
+            "urn:lccn:ne 68003583",
+            "urn:oclc:NYPG001000078-B",
+            "urn:undefined:NNSZ00100078",
+            "urn:undefined:(WaOLN)nyp0200129"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Arabic language -- Rhetoric."
+          ],
+          "titleDisplay": [
+            "al-Burhān fī wujūh al-bayān [allafahu] Abū al-Ḥusayn Isḥāq ibn Ibrāhīm ibn Sulaymān ibn Wahb al-Kātib. Taḥqīq Aḥmad Maṭlūb [wa]-Khadījah al-Ḥadīthī."
+          ],
+          "uri": "b10000130",
+          "lccClassification": [
+            "PJ6161 .B78 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Baghdād]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Naqd al-nathr."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000130"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000064",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OEQ 82-4707"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OEQ 82-4707",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014519783"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OEQ 82-4707"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014519783"
+                    ],
+                    "idBarcode": [
+                      "33433014519783"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OEQ 82-004707"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000131",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "631 p. ; 24 cm."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 577-601.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic: Summary in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Muqtadir billāh, Caliph, 895-932",
+            "Abbasids",
+            "Islamic Empire",
+            "Islamic Empire -- History",
+            "Islamic Empire -- History -- 750-1258"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʻAṣr al-Khalīfah al-Muqtadir billāh, 295-320 H / (907-932 M) : dirāsah fī aḥwāl al-ʻIrāq al-dākhilīyah"
+          ],
+          "shelfMark": [
+            "*OFM 82-4705"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kubaysī, Ḥamdān ʻAbd al-Majīd."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "78970114"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFM 82-4705"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000131"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78970114"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000079-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100079"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200130"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000079-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "[5.1. : s.n.], 1974"
+          ],
+          "identifier": [
+            "urn:bnum:10000131",
+            "urn:lccn:78970114",
+            "urn:oclc:NYPG001000079-B",
+            "urn:undefined:NNSZ00100079",
+            "urn:undefined:(WaOLN)nyp0200130"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Muqtadir billāh, Caliph, 895-932.",
+            "Abbasids.",
+            "Islamic Empire -- History -- 750-1258."
+          ],
+          "titleDisplay": [
+            "ʻAṣr al-Khalīfah al-Muqtadir billāh, 295-320 H / (907-932 M) : dirāsah fī aḥwāl al-ʻIrāq al-dākhilīyah / taʼlīf Ḥamdān ʻAbd al-Majīd al-Kubaysī."
+          ],
+          "uri": "b10000131",
+          "lccClassification": [
+            "DS38.6 .K82"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[5.1."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          "b10000131"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000065",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFM 82-4705"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFM 82-4705",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014463446"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFM 82-4705"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014463446"
+                    ],
+                    "idBarcode": [
+                      "33433014463446"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFM 82-004705"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000132",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "302 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 293-297.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Almohades"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Suqūṭ Dawlat al-Muwaḥḥidīn"
+          ],
+          "shelfMark": [
+            "*OFO 82-4577"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ghannāy, Marājiʻ ʻAqīlah."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "seriesStatement": [
+            "Manshūrāt Jāmiʻat Binghāzī"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFO 82-4577"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000132"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000080-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100080"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200131"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000080-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "[S.l. : s.n.] 1975"
+          ],
+          "identifier": [
+            "urn:bnum:10000132",
+            "urn:oclc:NYPG001000080-B",
+            "urn:undefined:NNSZ00100080",
+            "urn:undefined:(WaOLN)nyp0200131"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Almohades."
+          ],
+          "titleDisplay": [
+            "Suqūṭ Dawlat al-Muwaḥḥidīn / taʼlīf Marājiʻ ʻAqīlah al-Ghannāy."
+          ],
+          "uri": "b10000132",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000132"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000066",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFO 82-4577"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFO 82-4577",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586346"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-4577"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586346"
+                    ],
+                    "idBarcode": [
+                      "33433005586346"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFO 82-004577"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000133",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "177 p. ; port."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Socialism",
+            "Socialism -- Sudan",
+            "Sudan",
+            "Sudan -- Politics and government"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Maktabah al-ʻAṣrīyah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Dīmūqrāṭīyah wa-al-ishtirākīyah fī al-Sūdān"
+          ],
+          "shelfMark": [
+            "*OFP 82-4578"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Amīn, ʻAlī ʻAbd al-Raḥmān."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFP 82-4578"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000133"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000081-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100081"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200132"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000081-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Ṣaydā : al-Maktabah al-ʻAṣrīyah, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000133",
+            "urn:oclc:NYPG001000081-B",
+            "urn:undefined:NNSZ00100081",
+            "urn:undefined:(WaOLN)nyp0200132"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Socialism -- Sudan.",
+            "Sudan -- Politics and government."
+          ],
+          "titleDisplay": [
+            "al-Dīmūqrāṭīyah wa-al-ishtirākīyah fī al-Sūdān / taʼlīf ʻAlī ʻAbd al-Raḥmān al-Amīn."
+          ],
+          "uri": "b10000133",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ṣaydā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000133"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000067",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 82-4578"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 82-4578",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001937469"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFP 82-4578"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001937469"
+                    ],
+                    "idBarcode": [
+                      "33433001937469"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFP 82-004578"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000134",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "192, 12 p. illus., map, plans."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added title: Political [sic] and aspects [sic] of the cultural life in Samarra in the third century of Hejra, by Jahadia al-Karghouli.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Risālat al-Mājistīr-- Jāmiʻat al-Qāhirah.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 141-167.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Summary in  English.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sāmarrāʼ (Iraq)",
+            "Sāmarrāʼ (Iraq) -- History"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Maṭbaʻat Dār al-Baṣrī"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Ḥayāh al-siyāsīyah wa-maẓāhir al-ḥādārah fī Sāmarrāʼ khilāl al-qarn al-thālith al-Hijrī"
+          ],
+          "shelfMark": [
+            "*OFQ 81-2737"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Qaraghūllī, Jihādīyah."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "74248948"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFQ 81-2737"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000134"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74248948"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000082-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100082"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200133"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000082-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Baghdād, Maṭbaʻat Dār al-Baṣrī [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000134",
+            "urn:lccn:74248948",
+            "urn:oclc:NYPG001000082-B",
+            "urn:undefined:NNSZ00100082",
+            "urn:undefined:(WaOLN)nyp0200133"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sāmarrāʼ (Iraq) -- History."
+          ],
+          "titleDisplay": [
+            "al-Ḥayāh al-siyāsīyah wa-maẓāhir al-ḥādārah fī Sāmarrāʼ khilāl al-qarn al-thālith al-Hijrī [taʼlīf] Jihādīyah al-Qaraghūllī."
+          ],
+          "uri": "b10000134",
+          "lccClassification": [
+            "DS51.S2 Q3"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Baghdād"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000134"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000068",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFQ 81-2737"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFQ 81-2737",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014504074"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFQ 81-2737"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014504074"
+                    ],
+                    "idBarcode": [
+                      "33433014504074"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFQ 81-002737"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000135",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "216 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Short stories",
+            "Short stories -- Iraq"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "[Maktabat Baghdād]"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Qiṣaṣ ʻIrāqīyah muʻāṣirah"
+          ],
+          "shelfMark": [
+            "*OFC 81-3162"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "75972325"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Thāmir, Fāḍil.",
+            "Naṣīr, Yāsīn."
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFC 81-3162"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000135"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75972325"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000083-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100083"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200134"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000083-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Baghdād : [Maktabat Baghdād], 1971."
+          ],
+          "identifier": [
+            "urn:bnum:10000135",
+            "urn:lccn:75972325",
+            "urn:oclc:NYPG001000083-B",
+            "urn:undefined:NNSZ00100083",
+            "urn:undefined:(WaOLN)nyp0200134"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Short stories -- Iraq."
+          ],
+          "titleDisplay": [
+            "Qiṣaṣ ʻIrāqīyah muʻāṣirah / Muḥammad Khuḍayr ... [et al.] ; ditāsat Fāḍil Thāmir, Yāsīn al-Naṣīr."
+          ],
+          "uri": "b10000135",
+          "lccClassification": [
+            "75972325"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Baghdād"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000135"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000069",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFC 81-3162"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFC 81-3162",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001965965"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFC 81-3162"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001965965"
+                    ],
+                    "idBarcode": [
+                      "33433001965965"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFC 81-003162"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000136",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "6, 488 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 6 (1st group)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Love"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dar al-Ṣafā, yuṭlab min Maktabat al-Jāmiʻah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rawḍat al-muḥibbīn wa-nuzhat al-mushtāqīn"
+          ],
+          "shelfMark": [
+            "*OFC 81-3166"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ibn Qayyim al-Jawzīyah, Muḥammad ibn Abī Bakr, 1292-1350."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "74960035"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Yūsuf, Ṣābir."
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFC 81-3166"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000136"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74960035"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000084-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100084"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200135"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000084-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "al-Qāhirah, Dar al-Ṣafā, yuṭlab min Maktabat al-Jāmiʻah [1973]"
+          ],
+          "identifier": [
+            "urn:bnum:10000136",
+            "urn:lccn:74960035",
+            "urn:oclc:NYPG001000084-B",
+            "urn:undefined:NNSZ00100084",
+            "urn:undefined:(WaOLN)nyp0200135"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Love."
+          ],
+          "titleDisplay": [
+            "Rawḍat al-muḥibbīn wa-nuzhat al-mushtāqīn [taʼlīf] Shams al-Dīn Muḥammad ibn Abī Bakr ibn Qayyim al-Jawzīyah. Fassara gharībahu wa-rājaʻahu Ṣābir Yūsuf."
+          ],
+          "uri": "b10000136",
+          "lccClassification": [
+            "HQ801 .I25 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000136"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000070",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFC 81-3166"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFC 81-3166",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001965734"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFC 81-3166"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001965734"
+                    ],
+                    "idBarcode": [
+                      "33433001965734"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFC 81-003166"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000137",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "947 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wizārat al-Iʻlām, Mudīrīyat al-Thaqāfah al-ʻĀmmah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dīwān al-Qarawī"
+          ],
+          "shelfMark": [
+            "*OFA 81-3160"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Shāʻir al-Qarawī."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "74960574"
+          ],
+          "seriesStatement": [
+            "Dīwān al-Shiʻr al-ʻArabī al-ḥadīth ; 27"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFA 81-3160"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000137"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74960574"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000085-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100085"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200136"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000085-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "[Baghdād] : Wizārat al-Iʻlām, Mudīrīyat al-Thaqāfah al-ʻĀmmah, [1973]"
+          ],
+          "identifier": [
+            "urn:bnum:10000137",
+            "urn:lccn:74960574",
+            "urn:oclc:NYPG001000085-B",
+            "urn:undefined:NNSZ00100085",
+            "urn:undefined:(WaOLN)nyp0200136"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Dīwān al-Qarawī / Rashīd Salīm Khūrī."
+          ],
+          "uri": "b10000137",
+          "lccClassification": [
+            "PJ7842.H858 A6 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Baghdād]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10000137"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000071",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFA 81-3160"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFA 81-3160",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001999683"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFA 81-3160"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001999683"
+                    ],
+                    "idBarcode": [
+                      "33433001999683"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFA 81-003160"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000138",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "112 p. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "In the Egyptian dialect.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Jamʻīyat Udabāʼ al-Shaʻb"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aḥibb baladī"
+          ],
+          "shelfMark": [
+            "*OFA 81-3163"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Faraj, Faraj Khamīs."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "73961049"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFA 81-3163"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000138"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73961049"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000086-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200137"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000086-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "al-Iskandarīyah, Jamʻīyat Udabāʼ al-Shaʻb [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000138",
+            "urn:lccn:73961049",
+            "urn:oclc:NYPG001000086-B",
+            "urn:undefined:NNSZ00100086",
+            "urn:undefined:(WaOLN)nyp0200137"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Aḥibb baladī, azjāl Faraj Khamīs Faraj <<Abū Ruwāsh>>"
+          ],
+          "uri": "b10000138",
+          "lccClassification": [
+            "PJ7824.A68 A7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Iskandarīyah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000138"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000072",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFA 81-3163"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFA 81-3163",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001999675"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFA 81-3163"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001999675"
+                    ],
+                    "idBarcode": [
+                      "33433001999675"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFA 81-003163"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000139",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "292 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [289]-290.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nadīm, ʻAbd Allāh, 1845-1896"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Maktabat al-Kullīyat al-Azharīyah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʻAbd Allāh al-Nadīm Khaṭīb al-Thawrah al-ʻUrābīyah"
+          ],
+          "shelfMark": [
+            "*OFS 81-3165"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Tawfīq, Najīb."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "74963003"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 81-3165"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000139"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74963003"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000087-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100087"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200138"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000087-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "[al-Qāhirah] Maktabat al-Kullīyat al-Azharīyah [1970]"
+          ],
+          "identifier": [
+            "urn:bnum:10000139",
+            "urn:lccn:74963003",
+            "urn:oclc:NYPG001000087-B",
+            "urn:undefined:NNSZ00100087",
+            "urn:undefined:(WaOLN)nyp0200138"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nadīm, ʻAbd Allāh, 1845-1896."
+          ],
+          "titleDisplay": [
+            "ʻAbd Allāh al-Nadīm Khaṭīb al-Thawrah al-ʻUrābīyah, bi-qalam Najīb Tawfīq. Taqdīm ʻAbd al-Raḥmān al-Rāfiʻī."
+          ],
+          "uri": "b10000139",
+          "lccClassification": [
+            "DT107.2.N25 T38"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[al-Qāhirah]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000139"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000073",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 81-3165"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 81-3165",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005562628"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 81-3165"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005562628"
+                    ],
+                    "idBarcode": [
+                      "33433005562628"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFS 81-003165"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000140",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "184 p. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Muslim pilgrims and pilgrimages",
+            "Muslim pilgrims and pilgrimages -- Mecca"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "s.n."
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1979"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ḥajj"
+          ],
+          "shelfMark": [
+            "*OGH 82-280"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ṭāliqānī, Maḥmūd."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGH 82-280"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000140"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000088-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100088"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200139"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000088-B"
+          ],
+          "dateEndYear": [
+            1979
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "[S.l. : s.n., 197-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000140",
+            "urn:oclc:NYPG001000088-B",
+            "urn:undefined:NNSZ00100088",
+            "urn:undefined:(WaOLN)nyp0200139"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Muslim pilgrims and pilgrimages -- Mecca."
+          ],
+          "titleDisplay": [
+            "Ḥajj / Āyat Allāh Sayyid Maḥmūd Ṭāliqānī."
+          ],
+          "uri": "b10000140",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10000140"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGH 82-280"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGH 82-280",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058007638"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGH 82-280"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058007638"
+                    ],
+                    "idBarcode": [
+                      "33433058007638"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGH 82-000280"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000141",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "703 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Jis prugrim yūnivirsṭī n̲e muʼallif kū 1966 meṉ Ph.D. kī ra̤tā kī tahī.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Urdu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Urdu poetry",
+            "Urdu poetry -- History and criticism",
+            "Women",
+            "Women -- Language"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Nasīm Bukḍipu"
+          ],
+          "language": [
+            {
+              "id": "lang:urd",
+              "label": "Urdu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rekḥtī kā tanqīdī mṳtālaʻah"
+          ],
+          "shelfMark": [
+            "*OKTW 82-277"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Mushīr, Khalīl Aḥmad."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903710"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTW 82-277"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000141"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903710"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000089-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100089"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200140"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000089-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Likhnu : Nasīm Bukḍipu, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000141",
+            "urn:lccn:74903710",
+            "urn:oclc:NYPG001000089-B",
+            "urn:undefined:NNSZ00100089",
+            "urn:undefined:(WaOLN)nyp0200140"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Urdu poetry -- History and criticism.",
+            "Women -- Language."
+          ],
+          "titleDisplay": [
+            "Rekḥtī kā tanqīdī mṳtālaʻah / az Khalīl Aḥmad Ṣiddīqī Mushīr."
+          ],
+          "uri": "b10000141",
+          "lccClassification": [
+            "PK2167 .M794"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Likhnu"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000141"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000074",
+                    "status": [
+                      {
+                        "id": "status:co",
+                        "label": "Loaned"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:co||Loaned"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTW 82-277 "
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTW 82-277 ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004668285"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTW 82-277 "
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004668285"
+                    ],
+                    "idBarcode": [
+                      "33433004668285"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dueDate": [
+                      "2020-10-27"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTW 82-277 "
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000142",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "65, 41 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Islamic government and the present revolution in Iran/by Yahja Noori.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian or English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam and state",
+            "Iran",
+            "Iran -- Politics and government",
+            "Iran -- Politics and government -- 1979-1997"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Majmaʻ-i Maʻārif-i Islāmī"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ḥukūmat-i Islāmī va taḥlīlī az nihẓat-i ḥāẓir"
+          ],
+          "shelfMark": [
+            "*OGC 82-274"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Nūrī, Yaḥyá."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 82-274"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000142"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000090-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100090"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200141"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000090-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Tihrān : Majmaʻ-i Maʻārif-i Islāmī, 1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000142",
+            "urn:oclc:NYPG001000090-B",
+            "urn:undefined:NNSZ00100090",
+            "urn:undefined:(WaOLN)nyp0200141"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam and state.",
+            "Iran -- Politics and government -- 1979-1997."
+          ],
+          "titleDisplay": [
+            "Ḥukūmat-i Islāmī va taḥlīlī az nihẓat-i ḥāẓir / muntakhabī az chand muṣāḥibah bā Āyat Allāh Nūrī."
+          ],
+          "uri": "b10000142",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Islamic government and the present revolution in Iran."
+          ],
+          "dimensions": [
+            "22cm."
+          ]
+        },
+        "sort": [
+          "b10000142"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 82-274"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 82-274",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022688901"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 82-274"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022688901"
+                    ],
+                    "idBarcode": [
+                      "33433022688901"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 82-000274"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000143",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "244 p. : maps. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 243-244.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Urdu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Oudh (India)",
+            "Oudh (India) -- History"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "taqsīmkār, Vājid ʻAlī Shāh Akāḍmī"
+          ],
+          "language": [
+            {
+              "id": "lang:urd",
+              "label": "Urdu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tārīkh-i Avadh kā mukhtaṣar jāʼizah"
+          ],
+          "shelfMark": [
+            "*OLL 82-275"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ḵẖāṉ, Amjad ʻAlī."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "idLccn": [
+            "78908573"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLL 82-275"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000143"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78908573"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000091-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100091"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200142"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000091-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Lakhaʼū : taqsīmkār, Vājid ʻAlī Shāh Akāḍmī, 1978."
+          ],
+          "identifier": [
+            "urn:bnum:10000143",
+            "urn:lccn:78908573",
+            "urn:oclc:NYPG001000091-B",
+            "urn:undefined:NNSZ00100091",
+            "urn:undefined:(WaOLN)nyp0200142"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Oudh (India) -- History."
+          ],
+          "titleDisplay": [
+            "Tārīkh-i Avadh kā mukhtaṣar jāʼizah / Amjad ʻAlī Khāṉ."
+          ],
+          "uri": "b10000143",
+          "lccClassification": [
+            "DS485.094 K42"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Lakhaʼū"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000143"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783801",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLL 82-275"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLL 82-275",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061320515"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLL 82-275"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061320515"
+                    ],
+                    "idBarcode": [
+                      "33433061320515"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLL 82-000275"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000144",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "116 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Nashr-i Rafʻat"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1979"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Īshīq"
+          ],
+          "shelfMark": [
+            "*OOX 82-272"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Nābadal, ʻAlī Rizā."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OOX 82-272"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000144"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000092-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100092"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200143"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000092-B"
+          ],
+          "dateEndYear": [
+            1979
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "[Tihrān?] : Nashr-i Rafʻat, 1357 [1978 or 1979]"
+          ],
+          "identifier": [
+            "urn:bnum:10000144",
+            "urn:oclc:NYPG001000092-B",
+            "urn:undefined:NNSZ00100092",
+            "urn:undefined:(WaOLN)nyp0200143"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Īshīq / ʻAlī Rizā Nābadal Ukhtāy."
+          ],
+          "uri": "b10000144",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Tihrān?]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000144"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000075",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OOX 82-272"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OOX 82-272",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001718117"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OOX 82-272"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001718117"
+                    ],
+                    "idBarcode": [
+                      "33433001718117"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OOX 82-000272"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000145",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "275 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Maktabat Miṣr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Khān al-Khalīlī"
+          ],
+          "shelfMark": [
+            "*OFC 82-271"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Maḥfūẓ, Najīb, 1911-2006."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "73962212"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFC 82-271"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000145"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73962212"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000093-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100093"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200144"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000093-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "[al-Qāhirah] Maktabat Miṣr [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000145",
+            "urn:lccn:73962212",
+            "urn:oclc:NYPG001000093-B",
+            "urn:undefined:NNSZ00100093",
+            "urn:undefined:(WaOLN)nyp0200144"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Khān al-Khalīlī, taʼlīf Najīb Maḥfūẓ"
+          ],
+          "uri": "b10000145",
+          "lccClassification": [
+            "PJ7846.A46 K48 1969"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[al-Qāhirah]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "A novel"
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000145"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000076",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFC 82-271"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFC 82-271",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001965767"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFC 82-271"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001965767"
+                    ],
+                    "idBarcode": [
+                      "33433001965767"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFC 82-000271"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000146",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "767 p. port., fold. map."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 33-34.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Urdu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tipu Sultan, Fath ʻAli, Nawab of Mysore, 1753-1799"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Himaliyah Pablishīng Haus"
+          ],
+          "language": [
+            {
+              "id": "lang:urd",
+              "label": "Urdu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ṣaḥīfah-yi Ṭīpū Sul̤tān"
+          ],
+          "shelfMark": [
+            "*OLO 82-265"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Maḥmūd Banglaurī."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "79928817"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLO 82-265"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000146"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79928817"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000094-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100094"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200145"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000094-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Dihlī, Himaliyah Pablishīng Haus [1971]"
+          ],
+          "identifier": [
+            "urn:bnum:10000146",
+            "urn:lccn:79928817",
+            "urn:oclc:NYPG001000094-B",
+            "urn:undefined:NNSZ00100094",
+            "urn:undefined:(WaOLN)nyp0200145"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tipu Sultan, Fath ʻAli, Nawab of Mysore, 1753-1799."
+          ],
+          "titleDisplay": [
+            "Ṣaḥīfah-yi Ṭīpū Sul̤tān, az Maḥmūd Khāṉ Maḥmūd Banglaurī."
+          ],
+          "uri": "b10000146",
+          "lccClassification": [
+            "DS470.T6 M34"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dihlī"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000146"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783802",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLO 82-265"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLO 82-265",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061328062"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLO 82-265"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061328062"
+                    ],
+                    "idBarcode": [
+                      "33433061328062"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLO 82-000265"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000147",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "70 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Vacana Māḷavikāgnimitraṃ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Telugu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Jayantipablikēṣans"
+          ],
+          "language": [
+            {
+              "id": "lang:tel",
+              "label": "Telugu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Māḷavikāgnimitraṃ."
+          ],
+          "shelfMark": [
+            "*OLC 82-270"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Gōpālakrṣṇa, Reṇṭāla, 1922-"
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "77901180"
+          ],
+          "seriesStatement": [
+            "Vacana prabandha sāhityaṃ."
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Kālidāsa."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLC 82-270"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000147"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77901180"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000095-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100095"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200146"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000095-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Vijayavāḍa, Jayantipablikēṣans [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000147",
+            "urn:lccn:77901180",
+            "urn:oclc:NYPG001000095-B",
+            "urn:undefined:NNSZ00100095",
+            "urn:undefined:(WaOLN)nyp0200146"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Māḷavikāgnimitraṃ. Vacana racana: Reṇṭāla Gōpālakrṣna."
+          ],
+          "uri": "b10000147",
+          "lccClassification": [
+            "PL4780.9.G563 M27"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vijayavāḍa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000147"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000077",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 82-270"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 82-270",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004552323"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 82-270"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004552323"
+                    ],
+                    "idBarcode": [
+                      "33433004552323"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLC 82-000270"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000148",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "68 p. port."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Proverbs, Kannada"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sāhitya Sadana"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa ogaṭugaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 82-269"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Paramashivaiah, Ji. Sam., 1933-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "sa 68011006"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-269"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000148"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68011006"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000096-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100096"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200147"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000096-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Maisūru, Sāhitya Sadana [1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000148",
+            "urn:lccn:sa 68011006",
+            "urn:oclc:NYPG001000096-B",
+            "urn:undefined:NNSZ00100096",
+            "urn:undefined:(WaOLN)nyp0200147"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Proverbs, Kannada."
+          ],
+          "titleDisplay": [
+            "Kannaḍa ogaṭugaḷu. Sampādaka Jī. Śaṃ. Paramaśivayya. Hinnuḍi Si. Pi. Ke."
+          ],
+          "uri": "b10000148",
+          "lccClassification": [
+            "PN6519.K25 P3"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maisūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000148"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000078",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-269"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 82-269",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013118892"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 82-269"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013118892"
+                    ],
+                    "idBarcode": [
+                      "33433013118892"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-000269"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000149",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Urdu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Majlis-i Taraqqī-i Adab"
+          ],
+          "language": [
+            {
+              "id": "lang:urd",
+              "label": "Urdu"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "dateEndString": [
+            "1976"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kullīyāt-i Saudā"
+          ],
+          "shelfMark": [
+            "*OKTX 82-5167"
+          ],
+          "numItemVolumesParsed": [
+            2
+          ],
+          "creatorLiteral": [
+            "Saudā, Mirzā Muḥammad Rafiʻ, 1713-1781."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ṣiddīqī, Muḥammad Shamsuddīn."
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTX 82-5167"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000149"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000097-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100097"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200148"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000097-B"
+          ],
+          "dateEndYear": [
+            1976
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Lāhaur : Majlis-i Taraqqī-i Adab, 1973-1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000149",
+            "urn:oclc:NYPG001000097-B",
+            "urn:undefined:NNSZ00100097",
+            "urn:undefined:(WaOLN)nyp0200148"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Kullīyāt-i Saudā / murattabah-yi Muḥammad Shamsuddīn Ṣiddīqī."
+          ],
+          "uri": "b10000149",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Lāhaur"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Jild-i 1. Ghazaliyyāt.--Jild-i 2. Qaṣāʼid."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000149"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000080",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTX 82-5167 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTX 82-5167 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004673160"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "physicalLocation": [
+                      "*OKTX 82-5167"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004673160"
+                    ],
+                    "idBarcode": [
+                      "33433004673160"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTX 82-5167 v. 000002"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000079",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTX 82-5167 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTX 82-5167 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004673152"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OKTX 82-5167"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004673152"
+                    ],
+                    "idBarcode": [
+                      "33433004673152"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTX 82-5167 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000150",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "270 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Maktab al-Tijārī lil-Ṭibāʻah wa-al-Tawzīʻ wa-al-Nashr, 196-]"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1969"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Min al-Yaman"
+          ],
+          "shelfMark": [
+            "*OFA 82-4408"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Shāmī, Aḥmad Muḥammad, 1924-"
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "ne 66000571"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFA 82-4408"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000150"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ne 66000571"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000098-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100098"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200149"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000098-B"
+          ],
+          "dateEndYear": [
+            1969
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "[Bayrūt, al-Maktab al-Tijārī lil-Ṭibāʻah wa-al-Tawzīʻ wa-al-Nashr, 196-]"
+          ],
+          "identifier": [
+            "urn:bnum:10000150",
+            "urn:lccn:ne 66000571",
+            "urn:oclc:NYPG001000098-B",
+            "urn:undefined:NNSZ00100098",
+            "urn:undefined:(WaOLN)nyp0200149"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Min al-Yaman, shiʻr Aḥmad Muḥammad al-Shāmī."
+          ],
+          "uri": "b10000150",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000150"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000081",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFA 82-4408"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFA 82-4408",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002000598"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFA 82-4408"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002000598"
+                    ],
+                    "idBarcode": [
+                      "33433002000598"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFA 82-004408"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000151",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "9, 158 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Muslim saints"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Maktab al-Islāmī"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Furqān bayna awliyāʼ al-Raḥmān wa-awliyāʼ al-Shayṭān"
+          ],
+          "shelfMark": [
+            "*OGL 82-4418"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ibn Taymīyah, Aḥmad ibn ʻAbd al-Ḥalīm, 1263-1328."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGL 82-4418"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000151"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000099-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100099"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200150"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000099-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Bayrūt : al-Maktab al-Islāmī, [1971]"
+          ],
+          "identifier": [
+            "urn:bnum:10000151",
+            "urn:oclc:NYPG001000099-B",
+            "urn:undefined:NNSZ00100099",
+            "urn:undefined:(WaOLN)nyp0200150"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Muslim saints."
+          ],
+          "titleDisplay": [
+            "al-Furqān bayna awliyāʼ al-Raḥmān wa-awliyāʼ al-Shayṭān / taʼlīf Shaykh al-Islām Ibn Taymīyah."
+          ],
+          "uri": "b10000151",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000151"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858034",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGL 82-4418"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGL 82-4418",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058069497"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGL 82-4418"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058069497"
+                    ],
+                    "idBarcode": [
+                      "33433058069497"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGL 82-004418"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000152",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[iv] 92, xi [1] p. port."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Kailāsaṃra Iṅglīṣ nāṭakagaḷu. [Lēkhaka] Ji. Es. Amūra:\" p. [73]-92.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Bi. Es. Rāmarāv"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ēkalavya."
+          ],
+          "shelfMark": [
+            "*OLA 83-693"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kailāsaṃ, Ṭī. Pi., 1885-1948."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "73925571"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Rāmarāv, B. S."
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-693"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000152"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73925571"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000100-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100100"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200151"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000100-B"
+          ],
+          "uniformTitle": [
+            "Purpose. Kannada"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Beṅgaḷūru, Bi. Es. Rāmarāv [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000152",
+            "urn:lccn:73925571",
+            "urn:oclc:NYPG001000100-B",
+            "urn:undefined:NNSZ00100100",
+            "urn:undefined:(WaOLN)nyp0200151"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Ēkalavya. Mūla Kailāsaṃ avara Iṅgliṣina ʻPurpose.ʼ Anuvāda Bi. Es. Rāmarāv. Pariṣkaraṇa: ʻŚriraṅgaʼ[sic]"
+          ],
+          "uri": "b10000152",
+          "lccClassification": [
+            "PR9480.9.K32 P814"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru"
+          ],
+          "titleAlt": [
+            "Purpose."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000152"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000082",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-693"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-693",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013125202"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-693"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013125202"
+                    ],
+                    "idBarcode": [
+                      "33433013125202"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-000693"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000153",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "69, 472 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 471-472.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sufism",
+            "Sufism -- Early works to 1800"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Anjuman-i Ustādān-i Zabān va Adabīyāt-i Fārsī"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Yanbūʻ al-asrār fī naṣāʼiḥ al-abrār : taʼlīf shudah bi-sāl-i 832 Hijrī Qamarī"
+          ],
+          "shelfMark": [
+            "*OMQ 83-4676"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Khvārazmī, Kamāl al-Dīn Ḥusayn."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "seriesStatement": [
+            "Intishārāt-i Anjuman-i Ustādān-i Zabān va Adabīyāt-i Fārsī ; 7"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Dirakhshān, Mahdī."
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMQ 83-4676"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000153"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000101-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100101"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200152"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000101-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Anjuman-i Ustādān-i Zabān va Adabīyāt-i Fārsī, 1360 [1981]"
+          ],
+          "identifier": [
+            "urn:bnum:10000153",
+            "urn:oclc:NYPG001000101-B",
+            "urn:undefined:NNSZ00100101",
+            "urn:undefined:(WaOLN)nyp0200152"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sufism -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "Yanbūʻ al-asrār fī naṣāʼiḥ al-abrār : taʼlīf shudah bi-sāl-i 832 Hijrī Qamarī / taʼlīf-i Kamāl al-Dīn Ḥusayn Khvārazmī ; bi-ihtimām-i Mahdī Dirakhshān."
+          ],
+          "uri": "b10000153",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000153"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000083",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMQ 83-4676"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMQ 83-4676",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013145382"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMQ 83-4676"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013145382"
+                    ],
+                    "idBarcode": [
+                      "33433013145382"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMQ 83-004676"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000154",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "26, 117 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Rshabhadeva"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Śrī Vivēkōdaya Granthamāle"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Āditīrthankara Rṣabhadēva."
+          ],
+          "shelfMark": [
+            "*OLA 83-4815"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Anna Rao Appanna, Mirji, 1918-"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72903657"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-4815"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000154"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72903657"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000102-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100102"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200153"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000102-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Guḍibaṇḍe, Kōlārajille, Śrī Vivēkōdaya Granthamāle [1971]"
+          ],
+          "identifier": [
+            "urn:bnum:10000154",
+            "urn:lccn:72903657",
+            "urn:oclc:NYPG001000102-B",
+            "urn:undefined:NNSZ00100102",
+            "urn:undefined:(WaOLN)nyp0200153"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rshabhadeva."
+          ],
+          "titleDisplay": [
+            "Āditīrthankara Rṣabhadēva. [Lēkhaka] Mirji Aṇṇārāya."
+          ],
+          "uri": "b10000154",
+          "lccClassification": [
+            "BL1373.R7 A66"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Guḍibaṇḍe, Kōlārajille"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000154"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000084",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-4815"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-4815",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012996868"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-4815"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012996868"
+                    ],
+                    "idBarcode": [
+                      "33433012996868"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-004815"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000155",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "270 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jāḥiẓ, -868 or 869",
+            "Jāḥiẓ, -868 or 869 -- Knowledge",
+            "Jāḥiẓ, -868 or 869 -- Knowledge -- Folklore",
+            "Jāḥiẓ, -868 or 869 -- Mythology"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Wizārah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Mawrūth al-shaʻbī fī āthār al-Jāḥiẓ i : muʻjam mufahras"
+          ],
+          "shelfMark": [
+            "*OEM 83-4899"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Markaz al-Fūlklurī al-ʻIrāqī."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "78971085"
+          ],
+          "seriesStatement": [
+            "Silsilat al-maʻājim wa-al-fahāris ; 10"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OEM 83-4899"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000155"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78971085"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000103-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100103"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200154"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000103-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "[Baghdād] : al-Wizārah, [1976]"
+          ],
+          "identifier": [
+            "urn:bnum:10000155",
+            "urn:lccn:78971085",
+            "urn:oclc:NYPG001000103-B",
+            "urn:undefined:NNSZ00100103",
+            "urn:undefined:(WaOLN)nyp0200154"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jāḥiẓ, -868 or 869 -- Knowledge -- Folklore.",
+            "Jāḥiẓ, -868 or 869 -- Mythology."
+          ],
+          "titleDisplay": [
+            "al-Mawrūth al-shaʻbī fī āthār al-Jāḥiẓ i : muʻjam mufahras / aṣdarahu al-Markaz al-fulklūrī al-ʻIrāqī, Wizārat al-Iʻlām."
+          ],
+          "uri": "b10000155",
+          "lccClassification": [
+            "PJ7745.J3 Z785"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Baghdād]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000155"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000085",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OEM 83-4899"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OEM 83-4899",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001925001"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OEM 83-4899"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001925001"
+                    ],
+                    "idBarcode": [
+                      "33433001925001"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OEM 83-004899"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000156",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "10, 9 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Additions and corrections in MS.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; introductory matter in Sanskrit or English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindu gods",
+            "Hindu hymns, Sanskrit"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Go. Venkaṭarāmaśāstri]"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṣṭakapañcakam = Ashtaka-panchakam ; Jaladhijānandalaharī = Jaladhijanandalahari"
+          ],
+          "shelfMark": [
+            "*OLY 83-4674"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75902648"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-4674"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000156"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902648"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000104-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100104"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200155"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000104-B"
+          ],
+          "uniformTitle": [
+            "Aṣṭakapañcaka"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "[S.l. : Go. Venkaṭarāmaśāstri], 1972."
+          ],
+          "identifier": [
+            "urn:bnum:10000156",
+            "urn:lccn:75902648",
+            "urn:oclc:NYPG001000104-B",
+            "urn:undefined:NNSZ00100104",
+            "urn:undefined:(WaOLN)nyp0200155"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindu gods.",
+            "Hindu hymns, Sanskrit."
+          ],
+          "titleDisplay": [
+            "Aṣṭakapañcakam = Ashtaka-panchakam ; Jaladhijānandalaharī = Jaladhijanandalahari / praṇetā Garikapāṭi Lakshmīkāntaḥ."
+          ],
+          "uri": "b10000156",
+          "lccClassification": [
+            "BL1216 .L34"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l."
+          ],
+          "titleAlt": [
+            "Aṣṭakapañcaka",
+            "Jaladhijānandalaharī."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000156"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783803",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-4674"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-4674",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060370396"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-4674"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060370396"
+                    ],
+                    "idBarcode": [
+                      "33433060370396"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-004674"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000157",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "342 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Prophets in the Qurʼan"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-shaʻb"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Anbiyāʼ fī al-Qurʼān al-karīm"
+          ],
+          "shelfMark": [
+            "*OGDM 83-4900"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Sharqāwī, Maḥmūd."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "75961943"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGDM 83-4900"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000157"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75961943"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000105-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100105"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200156"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000105-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "al-Qāhirah, Dār al-shaʻb [1970]"
+          ],
+          "identifier": [
+            "urn:bnum:10000157",
+            "urn:lccn:75961943",
+            "urn:oclc:NYPG001000105-B",
+            "urn:undefined:NNSZ00100105",
+            "urn:undefined:(WaOLN)nyp0200156"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Prophets in the Qurʼan."
+          ],
+          "titleDisplay": [
+            "al-Anbiyāʼ fī al-Qurʼān al-karīm [taʼlīf] Maḥmūd al-Sharqāwī."
+          ],
+          "uri": "b10000157",
+          "lccClassification": [
+            "BP134.P745 S5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000157"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000086",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGDM 83-4900"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGDM 83-4900",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005577659"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGDM 83-4900"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005577659"
+                    ],
+                    "idBarcode": [
+                      "33433005577659"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGDM 83-004900"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000158",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "241, [27] p. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Telugu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Śrīnātha, active 1400-1440",
+            "Śrīnātha, active 1400-1440 -- Criticism and interpretation"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tammayya"
+          ],
+          "language": [
+            {
+              "id": "lang:tel",
+              "label": "Telugu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrīnāthamahākavi"
+          ],
+          "shelfMark": [
+            "*OLC 83-4816"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Thammaiah, Bandaru, 1891-1970."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "79901118"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLC 83-4816"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000158"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79901118"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000106-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100106"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200157"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000106-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Kākināḍa : Tammayya, 1968."
+          ],
+          "identifier": [
+            "urn:bnum:10000158",
+            "urn:lccn:79901118",
+            "urn:oclc:NYPG001000106-B",
+            "urn:undefined:NNSZ00100106",
+            "urn:undefined:(WaOLN)nyp0200157"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Śrīnātha, active 1400-1440 -- Criticism and interpretation."
+          ],
+          "titleDisplay": [
+            "Śrīnāthamahākavi / granthakarta Baṇḍāru Tamayya."
+          ],
+          "uri": "b10000158",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kākināḍa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000158"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000087",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-4816"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-4816",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004689307"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-4816"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004689307"
+                    ],
+                    "idBarcode": [
+                      "33433004689307"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-004816"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000159",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "64 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tales, Kannada"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Āśā Sāhitya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Jānapada kathālōka"
+          ],
+          "shelfMark": [
+            "*OLA 83-4817"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902609"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Srikripananda Basavani, 1933-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-4817"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000159"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902609"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000107-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100107"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200158"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000107-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Beṅgaḷūru : Āśā Sāhitya, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000159",
+            "urn:lccn:75902609",
+            "urn:oclc:NYPG001000107-B",
+            "urn:undefined:NNSZ00100107",
+            "urn:undefined:(WaOLN)nyp0200158"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tales, Kannada."
+          ],
+          "titleDisplay": [
+            "Jānapada kathālōka / Krpānanda."
+          ],
+          "uri": "b10000159",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000159"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000088",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-4817"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-4817",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012996876"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-4817"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012996876"
+                    ],
+                    "idBarcode": [
+                      "33433012996876"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-004817"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000160",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "143 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil literature",
+            "Tamil literature -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Paḻaṉiyappā Piratars"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ilakkiya nayam"
+          ],
+          "shelfMark": [
+            "*OLB 83-4818"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Irācāmaṇi, R."
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "idLccn": [
+            "75908529"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 83-4818"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000160"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75908529"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000108-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100108"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200159"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000108-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Ceṉṉai : Paḻaṉiyappā Piratars, [1966]."
+          ],
+          "identifier": [
+            "urn:bnum:10000160",
+            "urn:lccn:75908529",
+            "urn:oclc:NYPG001000108-B",
+            "urn:undefined:NNSZ00100108",
+            "urn:undefined:(WaOLN)nyp0200159"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Ilakkiya nayam / [Eḻutiyavar] Ra. Irācāmaṇi."
+          ],
+          "uri": "b10000160",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000160"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783804",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 83-4818"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 83-4818",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061299065"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 83-4818"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061299065"
+                    ],
+                    "idBarcode": [
+                      "33433061299065"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 83-004818"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000161",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xiv, 71 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on t.p. verso: Manitha soroobangal.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Short stories.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Civaṉ Kalvi Nilaiya Veḷiyīṭu"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Maṉita coṟūpaṅkaḷ : paṉṉiru ciṟu kataikaḷ"
+          ],
+          "shelfMark": [
+            "*OLB 83-4819"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kohila Mahendiran."
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "idLccn": [
+            "83900649"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 83-4819"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000161"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83900649"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000109-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100109"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200160"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000109-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "[Tellippalai] : Civaṉ Kalvi Nilaiya Veḷiyīṭu, 1982."
+          ],
+          "identifier": [
+            "urn:bnum:10000161",
+            "urn:lccn:83900649",
+            "urn:oclc:NYPG001000109-B",
+            "urn:undefined:NNSZ00100109",
+            "urn:undefined:(WaOLN)nyp0200160"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Maṉita coṟūpaṅkaḷ : paṉṉiru ciṟu kataikaḷ / Kōkilā Makēntiraṉ."
+          ],
+          "uri": "b10000161",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Tellippalai]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000161"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783805",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 83-4819"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 83-4819",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061299073"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 83-4819"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061299073"
+                    ],
+                    "idBarcode": [
+                      "33433061299073"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 83-004819"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000162",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "x, 96 p. (p. 95-96 advertisements)"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Running title: Candrahāsa nāṭaka samīkṣe.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "On page 96: x + 96 = 106.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuvempu, 1904-1994"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Pampa Prakāśạna"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mahākavi Kuvempu avara Candrahāsa nāṭaka samīkṣe."
+          ],
+          "shelfMark": [
+            "*OLA 83-4864"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Vasantakumār, Maḷali."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902165"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-4864"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000162"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902165"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000110-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100110"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200161"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000110-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Maisūru, Pampa Prakāśạna [1971]"
+          ],
+          "identifier": [
+            "urn:bnum:10000162",
+            "urn:lccn:72902165",
+            "urn:oclc:NYPG001000110-B",
+            "urn:undefined:NNSZ00100110",
+            "urn:undefined:(WaOLN)nyp0200161"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "titleDisplay": [
+            "Mahākavi Kuvempu avara Candrahāsa nāṭaka samīkṣe. Sampādaka Eṃ. Si. Vasantakumār."
+          ],
+          "uri": "b10000162",
+          "lccClassification": [
+            "PL4659.P797 C339"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maisūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Candrahāsa nāṭaka samīkṣe."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000162"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000089",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-4864"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-4864",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012996892"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-4864"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012996892"
+                    ],
+                    "idBarcode": [
+                      "33433012996892"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-004864"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000163",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Novelette.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Kalaiñar Patippaka veḷiyīṭu-3.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kalaiñar Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Iruḷiṉ viṭivu : kuṟunāval"
+          ],
+          "shelfMark": [
+            "*OLB 83-4821"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Tāvaiyūr Kāṇṭīpaṉ."
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "idLccn": [
+            "83900646"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 83-4821"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000163"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83900646"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000111-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100111"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200162"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000111-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Tirunelvēli, Yāḻppāṇam : Kalaiñar Patippakam, 1982."
+          ],
+          "identifier": [
+            "urn:bnum:10000163",
+            "urn:lccn:83900646",
+            "urn:oclc:NYPG001000111-B",
+            "urn:undefined:NNSZ00100111",
+            "urn:undefined:(WaOLN)nyp0200162"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Iruḷiṉ viṭivu : kuṟunāval / Tāvaiyūr Kāṇṭīpaṉ."
+          ],
+          "uri": "b10000163",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirunelvēli, Yāḻppāṇam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000163"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783806",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 83-4821"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 83-4821",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061299099"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 83-4821"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061299099"
+                    ],
+                    "idBarcode": [
+                      "33433061299099"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 83-004821"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000164",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "148 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannadhasan, 1927-",
+            "Kannadhasan, 1927- -- Criticism and interpretation"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Vāṉati Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kaṇṇatācaṉ kavinayam"
+          ],
+          "shelfMark": [
+            "*OLB 83-4822"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Gunasekar, P., 1936-"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900404"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 83-4822"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000164"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900404"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000112-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100112"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200163"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000112-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Ceṉṉai : Vāṉati Patippakam, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000164",
+            "urn:lccn:76900404",
+            "urn:oclc:NYPG001000112-B",
+            "urn:undefined:NNSZ00100112",
+            "urn:undefined:(WaOLN)nyp0200163"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannadhasan, 1927- -- Criticism and interpretation."
+          ],
+          "titleDisplay": [
+            "Kaṇṇatācaṉ kavinayam / Pa. Kuṇacēkar."
+          ],
+          "uri": "b10000164",
+          "lccClassification": [
+            "PL4758.9.K327 Z65"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000164"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783807",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 83-4822"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 83-4822",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061299107"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 83-4822"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061299107"
+                    ],
+                    "idBarcode": [
+                      "33433061299107"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 83-004822"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000165",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "47, 112 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vaishnavism",
+            "Vaishnavism -- Prayer books and devotions",
+            "Vaishnavism -- Prayer books and devotions -- Tamil"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Nārāyaṇacāmi Nāyaṭu"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Āḻv̲arkaḷ Tamiḻil akkārak kaṉikaḷ"
+          ],
+          "shelfMark": [
+            "*OLY 83-4895"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76901471"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Narayanaswami Naidu, Tiruchirrambalam Krishnaswamy, 1906-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-4895"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000165"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901471"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000113-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100113"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200164"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000113-B"
+          ],
+          "uniformTitle": [
+            "Nālāyirat tivviyap pirapantam. Selections."
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Kaṭalūr : Nārāyaṇacāmi Nāyaṭu, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000165",
+            "urn:lccn:76901471",
+            "urn:oclc:NYPG001000113-B",
+            "urn:undefined:NNSZ00100113",
+            "urn:undefined:(WaOLN)nyp0200164"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vaishnavism -- Prayer books and devotions -- Tamil."
+          ],
+          "titleDisplay": [
+            "Āḻv̲arkaḷ Tamiḻil akkārak kaṉikaḷ / [Tokuppāciriyar Ti. Ki. Nārāyaṇacāmi Nāyaṭu]."
+          ],
+          "uri": "b10000165",
+          "lccClassification": [
+            "BL1245.V3 N28 1975"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kaṭalūr"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000165"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783808",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-4895"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-4895",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060419649"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-4895"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060419649"
+                    ],
+                    "idBarcode": [
+                      "33433060419649"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-004895"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000166",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "328, 8 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sufism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dānishgāh-i Tihrān, Dānishkadah-ʼi ʻUlūm-i Maʻqūl va Manqūl"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1962
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Laṭāʼif al-irfān : az durūs-i dawrah-ʼi dukturā-yi Dānishkadah-ʼi ʻUlūm-i Maʻqūl va Manqūl"
+          ],
+          "shelfMark": [
+            "*OMQ 84-154"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ḥakīm, Muḥammad ʻAlī."
+          ],
+          "createdString": [
+            "1962"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1962
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMQ 84-154"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000166"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000114-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100114"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200165"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000114-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Tihrān : Dānishgāh-i Tihrān, Dānishkadah-ʼi ʻUlūm-i Maʻqūl va Manqūl, 1340 [1962]"
+          ],
+          "identifier": [
+            "urn:bnum:10000166",
+            "urn:oclc:NYPG001000114-B",
+            "urn:undefined:NNSZ00100114",
+            "urn:undefined:(WaOLN)nyp0200165"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1962"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sufism."
+          ],
+          "titleDisplay": [
+            "Laṭāʼif al-irfān : az durūs-i dawrah-ʼi dukturā-yi Dānishkadah-ʼi ʻUlūm-i Maʻqūl va Manqūl / taʼlīf-i Muḥammad ʻAlī Ḥakīm."
+          ],
+          "uri": "b10000166",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000166"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000090",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMQ 84-154 "
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMQ 84-154 ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013145390"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMQ 84-154 "
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013145390"
+                    ],
+                    "idBarcode": [
+                      "33433013145390"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMQ 84-154 "
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000167",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 261 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islamic civilization"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Nashr-i Chakāmah"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʻUlūm-i Islāmī dar qarn-i avval-i Hijrī"
+          ],
+          "shelfMark": [
+            "*OGC 84-151"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Manṣūrī, Ẕabīḥ Allāh."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-151"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000167"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000115-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100115"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200166"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000115-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Tihrān : Nashr-i Chakāmah, 1362 [1983]"
+          ],
+          "identifier": [
+            "urn:bnum:10000167",
+            "urn:oclc:NYPG001000115-B",
+            "urn:undefined:NNSZ00100115",
+            "urn:undefined:(WaOLN)nyp0200166"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islamic civilization."
+          ],
+          "titleDisplay": [
+            "ʻUlūm-i Islāmī dar qarn-i avval-i Hijrī / nivishtah-ʼi Ẕabīḥ Allāh Manṣūrī."
+          ],
+          "uri": "b10000167",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000167"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-151"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-151",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-151"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691053"
+                    ],
+                    "idBarcode": [
+                      "33433022691053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-000151"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000168",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "83 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "In Malayalam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Title on p. facing t.p.: Kerala Panineeyam, chila anubandhachinthakal.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Rajaraja Varma, A. R., 1863-1918",
+            "Malayalam language",
+            "Malayalam language -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Mīrākkuṭṭi ; vitaraṇaṃ, Nāṣanal Bukksṯāḷ"
+          ],
+          "language": [
+            {
+              "id": "lang:mal",
+              "label": "Malayalam"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kēraḷapāṇinīyaṃ, cila anubandhacintakaḷ : paṭhanaṃ"
+          ],
+          "shelfMark": [
+            "*OLD 84-110"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Mīrākkuṭṭi, Pi., 1930-"
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "idLccn": [
+            "82906730"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLD 84-110"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000168"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82906730"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000116-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100116"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200167"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000116-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "[S.l.] : Mīrākkuṭṭi ; Kōṭṭayaṃ : vitaraṇaṃ, Nāṣanal Bukksṯāḷ, 1982."
+          ],
+          "identifier": [
+            "urn:bnum:10000168",
+            "urn:lccn:82906730",
+            "urn:oclc:NYPG001000116-B",
+            "urn:undefined:NNSZ00100116",
+            "urn:undefined:(WaOLN)nyp0200167"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rajaraja Varma, A. R., 1863-1918.",
+            "Malayalam language -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Kēraḷapāṇinīyaṃ, cila anubandhacintakaḷ : paṭhanaṃ / Pi. Mīrākkuṭṭi."
+          ],
+          "uri": "b10000168",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l.] : Kōṭṭayaṃ"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000168"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000091",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLD 84-110"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLD 84-110",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011098963"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLD 84-110"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011098963"
+                    ],
+                    "idBarcode": [
+                      "33433011098963"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLD 84-000110"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000169",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xii, 639 p. : ill., fold. map. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [635]-639.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamils",
+            "Tamils -- Social life and customs",
+            "South Arcot (India)",
+            "South Arcot (India) -- Social life and customs"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "viṟpaṉai urimai, Tirunelvēli Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Keṭilakkarai nākarikam"
+          ],
+          "shelfMark": [
+            "*OLB 84-112"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Cuntara Caṇmukaṉār, 1922-"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900317"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-112"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000169"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900317"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000117-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100117"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200168"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000117-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Ceṉṉai : viṟpaṉai urimai, Tirunelvēli Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000169",
+            "urn:lccn:76900317",
+            "urn:oclc:NYPG001000117-B",
+            "urn:undefined:NNSZ00100117",
+            "urn:undefined:(WaOLN)nyp0200168"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamils -- Social life and customs.",
+            "South Arcot (India) -- Social life and customs."
+          ],
+          "titleDisplay": [
+            "Keṭilakkarai nākarikam / Āciriyar Cuntara Caṇmukaṉār."
+          ],
+          "uri": "b10000169",
+          "lccClassification": [
+            "DS432.T3 S95"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000169"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783809",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-112"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-112",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061299735"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-112"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061299735"
+                    ],
+                    "idBarcode": [
+                      "33433061299735"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-000112"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000170",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 488 p., [6] leaves of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Perunthamizh: the third ten days' seminar papers.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Organized by the Dept. of Tamil, Madras University.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil philology",
+            "Tamil philology -- Congresses"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ceṉṉai Palkalaik Kaḻaka Veḷiyīṭu"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Peruṅkāppiyac ciṟṟilakkiyap peruntamiḻ : mūṉṟām Potunilaip Pattunāḷ Karuttāyvaraṅkak kaṭṭuraikaḷ"
+          ],
+          "shelfMark": [
+            "*OLB 84-105"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Potunilaip Pattunāḷ Karuttaraṅku (3rd : 1974 : University of Madras, India)"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76901454"
+          ],
+          "seriesStatement": [
+            "Ceṉṉaip Palkalaik Kaḻakat Tamiḻt Tuṟai veḷiyīṭu ; 37"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Cañcīvi, Na., 1927-",
+            "University of Madras. Tamil Department."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-105"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000170"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901454"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000118-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200169"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000118-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "[Ceṉṉai] : Ceṉṉai Palkalaik Kaḻaka Veḷiyīṭu, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000170",
+            "urn:lccn:76901454",
+            "urn:oclc:NYPG001000118-B",
+            "urn:undefined:NNSZ00100118",
+            "urn:undefined:(WaOLN)nyp0200169"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil philology -- Congresses."
+          ],
+          "titleDisplay": [
+            "Peruṅkāppiyac ciṟṟilakkiyap peruntamiḻ : mūṉṟām Potunilaip Pattunāḷ Karuttāyvaraṅkak kaṭṭuraikaḷ / Potup patippāciriyar, Na. Cañcīvi ; utavi, Tamiḻttuṟai āciriyarkaḷum māṇavarkaḷum."
+          ],
+          "uri": "b10000170",
+          "lccClassification": [
+            "PL4751 .P73 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Ceṉṉai]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000170"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783810",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-105"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-105",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061299719"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-105"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061299719"
+                    ],
+                    "idBarcode": [
+                      "33433061299719"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-000105"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000171",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "261p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At the head of title: Haykakan SSH Gitutʻyunneri Akademia Patmutʻian Institut.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added title page : Dvizhenie dzhelaliev i polozhenie arm︠i︡anskogo naroda v Osmanskoĭ imperii (XVI-XVII veka).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 221-226.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Armenian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Summary in  Russian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jellali Insurrections",
+            "Turkey",
+            "Turkey -- History",
+            "Turkey -- History -- 1453-1683",
+            "Armenia",
+            "Armenia -- History",
+            "Armenia -- History -- 1522-1800"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Haykakan SSH GA Hratarakchʻutʻyun"
+          ],
+          "language": [
+            {
+              "id": "lang:arm",
+              "label": "Armenian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Jalalineri sharzhumě ev Hay zhoghovrdi vichake Osmanian Kaysrutʻian mej (XVI-XVII darer)"
+          ],
+          "shelfMark": [
+            "*ONQ 84-119"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Zulalyan, M. K. (Manvel Karapeti)"
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ONQ 84-119"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000171"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000119-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100119"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200170"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000119-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Erevan : Haykakan SSH GA Hratarakchʻutʻyun"
+          ],
+          "identifier": [
+            "urn:bnum:10000171",
+            "urn:oclc:NYPG001000119-B",
+            "urn:undefined:NNSZ00100119",
+            "urn:undefined:(WaOLN)nyp0200170"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jellali Insurrections.",
+            "Turkey -- History -- 1453-1683.",
+            "Armenia -- History -- 1522-1800."
+          ],
+          "titleDisplay": [
+            "Jalalineri sharzhumě ev Hay zhoghovrdi vichake Osmanian Kaysrutʻian mej (XVI-XVII darer) / M.K. Zulalian."
+          ],
+          "uri": "b10000171",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Erevan"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Dvizhenie dzhelaliev i polozhenie arm︠i︡anskogo naroda v Osmanskoĭ imperii (XVI-XVII veka)."
+          ],
+          "dimensions": [
+            "22cm."
+          ]
+        },
+        "sort": [
+          "b10000171"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000092",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ONQ 84-119"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ONQ 84-119",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001889223"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ONQ 84-119"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001889223"
+                    ],
+                    "idBarcode": [
+                      "33433001889223"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ONQ 84-000119"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000172",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "225p. : [2] facsims. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p. in Russian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Head of title: \"Matenadaran\" Haykakan SSH Ministrneri Sovetin aṛĕntʻer Mashtotsʻi anvan hin dzeṛagreri institut.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Armenian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Armenian language, Classical",
+            "Armenian language, Classical -- Grammar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Haykakan SSH GA Hratarakchutʻyun"
+          ],
+          "language": [
+            {
+              "id": "lang:arm",
+              "label": "Armenian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Haghags ḳerakani"
+          ],
+          "shelfMark": [
+            "*ONL 84-118"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hovhannes, Ḳṛnetsʻi, active 14th century."
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Khachʻikyan, L. S. (Levon Stepʻani), 1918-1982.",
+            "Avagian, S. A."
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ONL 84-118"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000172"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000120-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100120"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200171"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000120-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Erevan : Haykakan SSH GA Hratarakchutʻyun, 1977."
+          ],
+          "identifier": [
+            "urn:bnum:10000172",
+            "urn:oclc:NYPG001000120-B",
+            "urn:undefined:NNSZ00100120",
+            "urn:undefined:(WaOLN)nyp0200171"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Armenian language, Classical -- Grammar."
+          ],
+          "titleDisplay": [
+            "Haghags ḳerakani / Hovhannes Ḳṛnetsʻi. Bnagire hratarakutʻian patrastetsʻ L.S. Khachʻikianĕ. Neratsutʻyunĕ L.S. Khachʻikiani ev S.A. Avagiani."
+          ],
+          "uri": "b10000172",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Erevan"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10000172"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000093",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ONL 84-118"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ONL 84-118",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013020924"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ONL 84-118"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013020924"
+                    ],
+                    "idBarcode": [
+                      "33433013020924"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ONL 84-000118"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000173",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "520 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "In Malayalam.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Navadhāra"
+          ],
+          "language": [
+            {
+              "id": "lang:mal",
+              "label": "Malayalam"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kāṭṭāḷan"
+          ],
+          "shelfMark": [
+            "*OLD 84-113"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Manōj."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82903306"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLD 84-113"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000173"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82903306"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000121-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100121"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200172"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000121-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Tiruvanantapuram : Navadhāra, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000173",
+            "urn:lccn:82903306",
+            "urn:oclc:NYPG001000121-B",
+            "urn:undefined:NNSZ00100121",
+            "urn:undefined:(WaOLN)nyp0200172"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Kāṭṭāḷan / Manoj."
+          ],
+          "uri": "b10000173",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tiruvanantapuram"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000173"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000094",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLD 84-113"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLD 84-113",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011098971"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLD 84-113"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011098971"
+                    ],
+                    "idBarcode": [
+                      "33433011098971"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLD 84-000113"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000174",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 232 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Dictionary of dialectal usages, courtesy-language and culture of Kerala Brahmins.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Malayalam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Title on page facing t.p.. :Namboodiribhasha sabdakosham.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Malayalam language",
+            "Malayalam language -- Terms and phrases"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Visnunampūtiri ; Nāṣanal Bukksṯāḷ"
+          ],
+          "language": [
+            {
+              "id": "lang:mal",
+              "label": "Malayalam"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nampūtiribhāṣā śabdakōśaṃ"
+          ],
+          "shelfMark": [
+            "*OLD 84-116"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Viṣṇunampūtiri, Eṃ. Vi."
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "idLccn": [
+            "83900738"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLD 84-116"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000174"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83900738"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000122-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100122"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200173"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000122-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "[Rāmantaḷi] : Visnunampūtiri ; Kōṭṭayaṃ : Nāṣanal Bukksṯāḷ 1982."
+          ],
+          "identifier": [
+            "urn:bnum:10000174",
+            "urn:lccn:83900738",
+            "urn:oclc:NYPG001000122-B",
+            "urn:undefined:NNSZ00100122",
+            "urn:undefined:(WaOLN)nyp0200173"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Malayalam language -- Terms and phrases."
+          ],
+          "titleDisplay": [
+            "Nampūtiribhāṣā śabdakōśaṃ / Eṃ. Vi. Viṣṇunampūtiri."
+          ],
+          "uri": "b10000174",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Rāmantaḷi] : Kōṭṭayaṃ"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000174"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000095",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLD 84-116"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLD 84-116",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011098989"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLD 84-116"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011098989"
+                    ],
+                    "idBarcode": [
+                      "33433011098989"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLD 84-000116"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000175",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15,111 p. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Persian and Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Self-instruction"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Shirkat-i Dānish"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1983"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Khud'āmūz-i zabān-i Sanskrīt"
+          ],
+          "shelfMark": [
+            "*OKE 84-115"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ḥasanī Dāʻī al-Islāmī, Muḥammad ʻAlī."
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKE 84-115"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000175"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000123-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100123"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200174"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000123-B"
+          ],
+          "dateEndYear": [
+            1983
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Tihrān : Shirkat-i Dānish, 1361 [1982 or 1983]"
+          ],
+          "identifier": [
+            "urn:bnum:10000175",
+            "urn:oclc:NYPG001000123-B",
+            "urn:undefined:NNSZ00100123",
+            "urn:undefined:(WaOLN)nyp0200174"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Self-instruction."
+          ],
+          "titleDisplay": [
+            "Khud'āmūz-i zabān-i Sanskrīt / taʼlīf-i Muḥammad ʻAlī Ḥasanī Dāʻī al-Islāmī."
+          ],
+          "uri": "b10000175",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000175"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858035",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKE 84-115"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKE 84-115",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058552856"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKE 84-115"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058552856"
+                    ],
+                    "idBarcode": [
+                      "33433058552856"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKE 84-000115"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000176",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "44, 286 p., [4] leaves of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p. in English.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; introductory matter and paraphrase in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Raj Singh, Maharana of Mewar, 1629-1680",
+            "Raj Singh, Maharana of Mewar, 1629-1680 -- Poetry"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sāhitya saṃsthāna, Rājasthāna Vidyāpīṭha"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rājapraśastiḥ mahākāvyam"
+          ],
+          "shelfMark": [
+            "*OKP 84-84"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Raṇachoḍabhaṭṭa, active 1661-1681."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75902395"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Menaria, Moti Lal, 1905-"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 84-84"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000176"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902395"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000124-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100124"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200175"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000124-B"
+          ],
+          "uniformTitle": [
+            "Rājapraśasti"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Udayapura : Sāhitya saṃsthāna, Rājasthāna Vidyāpīṭha, 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000176",
+            "urn:lccn:75902395",
+            "urn:oclc:NYPG001000124-B",
+            "urn:undefined:NNSZ00100124",
+            "urn:undefined:(WaOLN)nyp0200175"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Raj Singh, Maharana of Mewar, 1629-1680 -- Poetry."
+          ],
+          "titleDisplay": [
+            "Rājapraśastiḥ mahākāvyam / Raṇachoṛabhaṭṭa praṇītam ; sampādaka Motilāla Menāriyā."
+          ],
+          "uri": "b10000176",
+          "lccClassification": [
+            "PK3798.R2872 R3"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Udayapura"
+          ],
+          "titleAlt": [
+            "Rājapraśasti",
+            "Rājapraśasti."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000176"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783811",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 84-84"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 84-84",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153408"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 84-84"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153408"
+                    ],
+                    "idBarcode": [
+                      "33433058153408"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKP 84-000084"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000177",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 4, 354 p. col. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [349]-354.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Rām Sanehīs"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Rāmasnehī Sāhitya Śodha Saṃsthāna"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rāmasnehī-sampradāya kī dārśanika prshṭhabhūmi."
+          ],
+          "shelfMark": [
+            "*OLY 84-85"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Pāṇḍeya, Śivāśaṅkara, 1935-"
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "74901467"
+          ],
+          "seriesStatement": [
+            "Rāmasnehī sāhitya śodha saṃsthāna, pushpa 1"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 84-85"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000177"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74901467"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000125-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100125"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200176"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000125-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Dillī, Rāmasnehī Sāhitya Śodha Saṃsthāna [1973]"
+          ],
+          "identifier": [
+            "urn:bnum:10000177",
+            "urn:lccn:74901467",
+            "urn:oclc:NYPG001000125-B",
+            "urn:undefined:NNSZ00100125",
+            "urn:undefined:(WaOLN)nyp0200176"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rām Sanehīs."
+          ],
+          "titleDisplay": [
+            "Rāmasnehī-sampradāya kī dārśanika prshṭhabhūmi. Lekhaka Śivāśaṅkara Pāṇḍeya."
+          ],
+          "uri": "b10000177",
+          "lccClassification": [
+            "BL1245.R35 P36"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dillī"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000177"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783812",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 84-85"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 84-85",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060419680"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 84-85"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060419680"
+                    ],
+                    "idBarcode": [
+                      "33433060419680"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 84-000085"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000178",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16, 440 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Kāśī Hindū Viśvavidyālaya kī Pī. ech. Ḍī. upādhi ke lie svīkrta śodha prabandha.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [436]-440.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindi poetry",
+            "Hindi poetry -- History and criticism",
+            "Bhakti in literature"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Abhinava Bhārati Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Hindī Krshṇabhakti sāhitya meṃ madhurabhāva kī upāsanā."
+          ],
+          "shelfMark": [
+            "*OKTM 84-81"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rai, Purnamasi, 1928-"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74901757"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-81"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000178"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74901757"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000126-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100126"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200177"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000126-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Ilāhābāda, Abhinava Bhārati Prakāśana [1974]"
+          ],
+          "identifier": [
+            "urn:bnum:10000178",
+            "urn:lccn:74901757",
+            "urn:oclc:NYPG001000126-B",
+            "urn:undefined:NNSZ00100126",
+            "urn:undefined:(WaOLN)nyp0200177"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindi poetry -- History and criticism.",
+            "Bhakti in literature."
+          ],
+          "titleDisplay": [
+            "Hindī Krshṇabhakti sāhitya meṃ madhurabhāva kī upāsanā. [Lekhaka] Pūrṇamāsī Rāya."
+          ],
+          "uri": "b10000178",
+          "lccClassification": [
+            "PK2040 .R33"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ilāhābāda"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000178"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942053",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-81"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-81",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011093949"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-81"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011093949"
+                    ],
+                    "idBarcode": [
+                      "33433011093949"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-000081"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000179",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "126 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Series romanized: Śrīrāmavarmma granthāvali.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added t.p. in English: Kalakeyavadham.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Libretto for thullal, a variation of the kathakali dance drama of Kerala.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Malayalam.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ottanthullal",
+            "Dance",
+            "Dance -- Kerala",
+            "Kathakali"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Malayāḷasāhityanidhi, Kēraḷa Sāhitya Akkādami ; vitaraṇaṃ, Nāṣanal Buksṯṯāḷ"
+          ],
+          "language": [
+            {
+              "id": "lang:mal",
+              "label": "Malayalam"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kālakēyavadhaṃ : śītaṅkantuḷḷal"
+          ],
+          "shelfMark": [
+            "*MGS (Hindu) 84-117"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Dāmōdaran Nampūtiri, Pūntōttattu, 1815-1865."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "78900937"
+          ],
+          "seriesStatement": [
+            "Sṟīrāmavarmma granthāvali"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*MGS (Hindu) 84-117"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000179"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78900937"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000127-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100127"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200178"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000127-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "[Trśśūr] : Malayāḷasāhityanidhi, Kēraḷa Sāhitya Akkādami ; Kōṭṭayaṃ : vitaraṇaṃ, Nāṣanal Buksṯṯāḷ, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000179",
+            "urn:lccn:78900937",
+            "urn:oclc:NYPG001000127-B",
+            "urn:undefined:NNSZ00100127",
+            "urn:undefined:(WaOLN)nyp0200178"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ottanthullal",
+            "Dance -- Kerala.",
+            "Kathakali."
+          ],
+          "titleDisplay": [
+            "Kālakēyavadhaṃ : śītaṅkantuḷḷal / Granthakarttā Puntōṭṭattu Dāmōdaran Nampūtiri."
+          ],
+          "uri": "b10000179",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Trśśūr] : Kōṭṭayaṃ"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000179"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746410",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1121",
+                        "label": "Jerome Robbins Dance Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1121||Jerome Robbins Dance Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myd32",
+                        "label": "Performing Arts Research Collections - Dance"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myd32||Performing Arts Research Collections - Dance"
+                    ],
+                    "shelfMark": [
+                      "*MGS (Hindu) 84-117"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*MGS (Hindu) 84-117",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093040370"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*MGS (Hindu) 84-117"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093040370"
+                    ],
+                    "idBarcode": [
+                      "33433093040370"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*MGS (Hindu) 84-000117"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000180",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "95 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Putumaip Piracuram"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vitiyō? Vīṇaiyō?"
+          ],
+          "shelfMark": [
+            "*OLB 84-102"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Tamiḻoḷi."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72908855"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Iḷaṅkōvaṭikaḷ."
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-102"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000180"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72908855"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000128-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100128"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200179"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000128-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Ceṉṉai : Putumaip Piracuram, [1971]"
+          ],
+          "identifier": [
+            "urn:bnum:10000180",
+            "urn:lccn:72908855",
+            "urn:oclc:NYPG001000128-B",
+            "urn:undefined:NNSZ00100128",
+            "urn:undefined:(WaOLN)nyp0200179"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Vitiyō? Vīṇaiyō? / Kaviñar Tamiḻoḷi ; muṉṉurai : A. Citamparanātaṉ."
+          ],
+          "uri": "b10000180",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000180"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783813",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-102"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-102",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061299701"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-102"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061299701"
+                    ],
+                    "idBarcode": [
+                      "33433061299701"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-000102"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000181",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "104 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "In Malayalam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Title on p. facing t.p.: Inside Singhbhum of Bihar.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Mēri Jōsna",
+            "Social workers",
+            "Social workers -- Kerala",
+            "Social workers -- Kerala -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kaṟanṯ Buks"
+          ],
+          "language": [
+            {
+              "id": "lang:mal",
+              "label": "Malayalam"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Simhabhūmiyil : yātṟāvivaraṇaṃ"
+          ],
+          "shelfMark": [
+            "*OLD 84-103"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kuryan Pāmpāṭi, 1941-"
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "idLccn": [
+            "82904779"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLD 84-103"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000181"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82904779"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000129-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100129"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200180"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000129-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Kōṭṭayaṃ : Kaṟanṯ Buks, 1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000181",
+            "urn:lccn:82904779",
+            "urn:oclc:NYPG001000129-B",
+            "urn:undefined:NNSZ00100129",
+            "urn:undefined:(WaOLN)nyp0200180"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Mēri Jōsna.",
+            "Social workers -- Kerala -- Biography."
+          ],
+          "titleDisplay": [
+            "Simhabhūmiyil : yātṟāvivaraṇaṃ / Kuryan Pāmpāṭi."
+          ],
+          "uri": "b10000181",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kōṭṭayaṃ"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Inside Singhbhum of Bihar."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000181"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000096",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLD 84-103"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLD 84-103",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011098955"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLD 84-103"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011098955"
+                    ],
+                    "idBarcode": [
+                      "33433011098955"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLD 84-000103"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000182",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "5, v, 281 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Viśvavidyālaya-starīya grantha-nirmāṇa-yojanā ke antargata ... prakāśita.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [275]-281.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindi poetry",
+            "Hindi poetry -- 1947-",
+            "Hindi poetry -- 1947- -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Bihāra Hindī Grantha Akādamī"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Naī kavitā, udbhava aura vikāsa"
+          ],
+          "shelfMark": [
+            "*OKTM 84-86"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rāya, Rāma Vacana."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902264"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-86"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000182"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902264"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000130-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100130"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200181"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000130-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Patanā : Bihāra Hindī Grantha Akādamī, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000182",
+            "urn:lccn:75902264",
+            "urn:oclc:NYPG001000130-B",
+            "urn:undefined:NNSZ00100130",
+            "urn:undefined:(WaOLN)nyp0200181"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindi poetry -- 1947- -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Naī kavitā, udbhava aura vikāsa / lekhaka Rāmavacana Rāya."
+          ],
+          "uri": "b10000182",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Patanā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000182"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942054",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-86"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-86",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011093956"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-86"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011093956"
+                    ],
+                    "idBarcode": [
+                      "33433011093956"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-000086"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000183",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "680, [1] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "In Malayalam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: P. 681.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Malayalam language",
+            "Malayalam language -- Idioms"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sāhityapṟavarttaka Sahakaraṇasaṅghaṃ : Nāṣanal Bukksṯāḷ"
+          ],
+          "language": [
+            {
+              "id": "lang:mal",
+              "label": "Malayalam"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Apaśabdabodhini"
+          ],
+          "shelfMark": [
+            "*OLD 84-90"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Damodaran Nair, P., 1913-"
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "idLccn": [
+            "83901968"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLD 84-90"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000183"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83901968"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000131-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100131"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200182"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000131-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Kōṭṭayaṃ : Sāhityapṟavarttaka Sahakaraṇasaṅghaṃ : Nāṣanal Bukksṯāḷ, 1982."
+          ],
+          "identifier": [
+            "urn:bnum:10000183",
+            "urn:lccn:83901968",
+            "urn:oclc:NYPG001000131-B",
+            "urn:undefined:NNSZ00100131",
+            "urn:undefined:(WaOLN)nyp0200182"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Malayalam language -- Idioms."
+          ],
+          "titleDisplay": [
+            "Apaśabdabodhini / Pi. Dāmōdarannāyar."
+          ],
+          "uri": "b10000183",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kōṭṭayaṃ"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000183"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000097",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLD 84-90"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLD 84-90",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011098930"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLD 84-90"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011098930"
+                    ],
+                    "idBarcode": [
+                      "33433011098930"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLD 84-000090"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000184",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "18, 343 p. facsims., ports."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reviews of the author's works: p. 16-18.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Singh, Bhagat"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Bhāratīya Jñānapīṭha Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Yugadrashṭā Bhagata Siṃha aura una ke mrtyuñjaya purakhe."
+          ],
+          "shelfMark": [
+            "*OKTO 84-164"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Sindhu, Virendra, 1940-"
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75901954"
+          ],
+          "seriesStatement": [
+            "Lokodaya granthamālā, granthaṅka 268"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTO 84-164"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000184"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75901954"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000132-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100132"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200183"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000132-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "[Vārāṇasī] Bhāratīya Jñānapīṭha Prakāśana [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000184",
+            "urn:lccn:75901954",
+            "urn:oclc:NYPG001000132-B",
+            "urn:undefined:NNSZ00100132",
+            "urn:undefined:(WaOLN)nyp0200183"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Singh, Bhagat."
+          ],
+          "titleDisplay": [
+            "Yugadrashṭā Bhagata Siṃha aura una ke mrtyuñjaya purakhe. Lekhikā Vīrendra Sindhu. Bhūmikā: Yaśavantarāva Cahvāṇa."
+          ],
+          "uri": "b10000184",
+          "lccClassification": [
+            "DS481.S55 S5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Vārāṇasī]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000184"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000098",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTO 84-164"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTO 84-164",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011049917"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTO 84-164"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011049917"
+                    ],
+                    "idBarcode": [
+                      "33433011049917"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTO 84-000164"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000185",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xiv, 259 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"'Periya Purāṇattil uvamaikaḷʼ eṉṉum āyvuk kaṭṭuraiyiṉai mutukalaippaṭṭat tērviṉ oru pakutiyākat tantuḷḷār. Avvārāyccik kaṭṭuraiyē ... āyvu nūlāka ippoḻutu veḷivarukiṉṟatu.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 255-259.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cēkkiḻār, active 12th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sankari ; viṟpaṉai urimai, Jeyakumāri Sṭōrs"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Periya purāṇattil uvamaikaḷ"
+          ],
+          "shelfMark": [
+            "*OLB 84-92"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Sankari, A., 1950-"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900433"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-92"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000185"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900433"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000133-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100133"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200184"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000133-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Ayinkamam : Sankari ; Nākarkōvil : viṟpaṉai urimai, Jeyakumāri Sṭōrs, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000185",
+            "urn:lccn:76900433",
+            "urn:oclc:NYPG001000133-B",
+            "urn:undefined:NNSZ00100133",
+            "urn:undefined:(WaOLN)nyp0200184"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cēkkiḻār, active 12th century."
+          ],
+          "titleDisplay": [
+            "Periya purāṇattil uvamaikaḷ / A. Caṅkari."
+          ],
+          "uri": "b10000185",
+          "lccClassification": [
+            "PL4758.9.C385 P479"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ayinkamam : Nākarkōvil"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000185"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783814",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-92"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-92",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061299693"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-92"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061299693"
+                    ],
+                    "idBarcode": [
+                      "33433061299693"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-000092"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000186",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15, 146 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vedic language",
+            "Vedic language -- Pronunciation",
+            "Vedic language -- Accents and accentuation"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Vaidika Sāhitya Sadana"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vaidika-svara-bodha."
+          ],
+          "shelfMark": [
+            "*OKTH 84-163"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Caube, Vrajabihārī, 1940-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "72902691"
+          ],
+          "seriesStatement": [
+            "Vaidika sāhitya sadana granthamālā, pushpa 2"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTH 84-163"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000186"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902691"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000134-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100134"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200185"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000134-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Hośiyārapura, Vaidika Sāhitya Sadana, 1972."
+          ],
+          "identifier": [
+            "urn:bnum:10000186",
+            "urn:lccn:72902691",
+            "urn:oclc:NYPG001000134-B",
+            "urn:undefined:NNSZ00100134",
+            "urn:undefined:(WaOLN)nyp0200185"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vedic language -- Pronunciation.",
+            "Vedic language -- Accents and accentuation."
+          ],
+          "titleDisplay": [
+            "Vaidika-svara-bodha. Lekhaka Vrajabihārī Caube."
+          ],
+          "uri": "b10000186",
+          "lccClassification": [
+            "PK243 .C5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Hośiyārapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000186"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000099",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTH 84-163"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTH 84-163",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010762189"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTH 84-163"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010762189"
+                    ],
+                    "idBarcode": [
+                      "33433010762189"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTH 84-000163"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000187",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "535 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Azărbaĭjanja-Farsja lüghăt [by] Măhămmăd Peĭfun.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "p.[375]-381: Jughrāfī ādlār-nāmhā-yi jughrāfiyāʼī.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "p. [383]-535: Fihrist-i vāzhigān bā āvā'nivīsī-i Āẕarbāyjānī.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian and Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Dictionaries",
+            "Azerbaijani language -- Dictionaries -- Persian"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Nashr-i Dānishpāyah"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Farhang-i Āẕarbāyjānī-Fārsi : dārā-yi bīsh az 30 hizār vāzhah, iṣtilāḥ, tarkīb, ʻibārat bā muʻādil-i Fārsī"
+          ],
+          "shelfMark": [
+            "*OOX 84-178"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Payfun, Muḥammad."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OOX 84-178"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000187"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000135-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100135"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200186"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000135-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "Tihrān : Nashr-i Dānishpāyah, 1361 [1983]"
+          ],
+          "identifier": [
+            "urn:bnum:10000187",
+            "urn:oclc:NYPG001000135-B",
+            "urn:undefined:NNSZ00100135",
+            "urn:undefined:(WaOLN)nyp0200186"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Dictionaries -- Persian."
+          ],
+          "titleDisplay": [
+            "Farhang-i Āẕarbāyjānī-Fārsi : dārā-yi bīsh az 30 hizār vāzhah, iṣtilāḥ, tarkīb, ʻibārat bā muʻādil-i Fārsī / Muḥammad Payfun."
+          ],
+          "uri": "b10000187",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Azărbaĭjanja-Farsja lüghăt."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000187"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000100",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OOX 84-178"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OOX 84-178",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001718323"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OOX 84-178"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001718323"
+                    ],
+                    "idBarcode": [
+                      "33433001718323"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OOX 84-000178"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000188",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "160 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Urdu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Bahār Urdū Ākādimī"
+          ],
+          "language": [
+            {
+              "id": "lang:urd",
+              "label": "Urdu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Intikhāb-i kalām-i kulliyyāt-i Muntaẓar, (nuskhah-yi Nadvat al-ʻUlamāʼ Lakhav)"
+          ],
+          "shelfMark": [
+            "*OKTX 84-150"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Muntaẓar Lakhnavī, Nūrulislām, 1769?-1806?"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903706"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Kutub Ḵẖȧnah Nadvat al Ulamaʻ."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTX 84-150"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000188"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903706"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000136-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100136"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200187"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000136-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Paṭnah, Bahār Urdū Ākādimī [1974]"
+          ],
+          "identifier": [
+            "urn:bnum:10000188",
+            "urn:lccn:74903706",
+            "urn:oclc:NYPG001000136-B",
+            "urn:undefined:NNSZ00100136",
+            "urn:undefined:(WaOLN)nyp0200187"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Intikhāb-i kalām-i kulliyyāt-i Muntaẓar, (nuskhah-yi Nadvat al-ʻUlamāʼ Lakhav) [Shāʻir] Nūrulislām Muntaẓar Lakhnav̄. Murattabah-yi Shamsī Nadvī."
+          ],
+          "uri": "b10000188",
+          "lccClassification": [
+            "PK2198.M874 I58"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paṭnah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000188"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942055",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTX 84-150"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTX 84-150",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015458726"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTX 84-150"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015458726"
+                    ],
+                    "idBarcode": [
+                      "33433015458726"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTX 84-000150"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000189",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "5, 227 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Dillī Viśvavidyālaya se Pīeca. Ḍī kī upādhi ke lie svīkrta śodha prabandha kā parivartita tathā parivardhita rūpa.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p.[220]-227.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindi language",
+            "Hindi language -- Vocabulary",
+            "Hindi language -- Etymology"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Neśanala Pabḷiśiṅga Hāusa"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Hindī meṃ deśaja śabda."
+          ],
+          "shelfMark": [
+            "*OKTH 84-155"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Daḅāsa, Pūrṇasiṃha, 1938-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "73903281"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTH 84-155"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000189"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73903281"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000137-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100137"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200188"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000137-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Dillī, Neśanala Pabḷiśiṅga Hāusa [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000189",
+            "urn:lccn:73903281",
+            "urn:oclc:NYPG001000137-B",
+            "urn:undefined:NNSZ00100137",
+            "urn:undefined:(WaOLN)nyp0200188"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindi language -- Vocabulary.",
+            "Hindi language -- Etymology."
+          ],
+          "titleDisplay": [
+            "Hindī meṃ deśaja śabda. [Lekhaka] Pūrṇasiṃha Ḍabāsa. Bhūmikā Bholānātha Tivārī."
+          ],
+          "uri": "b10000189",
+          "lccClassification": [
+            "PK1939 .D24"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dillī"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000189"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000101",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTH 84-155"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTH 84-155",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010762171"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTH 84-155"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010762171"
+                    ],
+                    "idBarcode": [
+                      "33433010762171"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTH 84-000155"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000190",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "168 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit; introductory matter in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Gītā Presa"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1967"
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vidura nīti; Mahābhārata Udyogaparva se."
+          ],
+          "shelfMark": [
+            "*OKOC 84-137"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "idLccn": [
+            "sa 68014141"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKOC 84-137"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000190"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68014141"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000138-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100138"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200189"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000138-B"
+          ],
+          "uniformTitle": [
+            "Mahābhārata. Udyogaparva Viduranīti."
+          ],
+          "dateEndYear": [
+            1967
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Gorakhapura, Gītā Presa [1966 or 7]"
+          ],
+          "identifier": [
+            "urn:bnum:10000190",
+            "urn:lccn:sa 68014141",
+            "urn:oclc:NYPG001000138-B",
+            "urn:undefined:NNSZ00100138",
+            "urn:undefined:(WaOLN)nyp0200189"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Vidura nīti; Mahābhārata Udyogaparva se."
+          ],
+          "uri": "b10000190",
+          "lccClassification": [
+            "PK3631 .U32 1966"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Gorakhapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000190"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783815",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKOC 84-137"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKOC 84-137",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058630249"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKOC 84-137"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058630249"
+                    ],
+                    "idBarcode": [
+                      "33433058630249"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKOC 84-000137"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000191",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "482 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Hindī Krshṇa kāvya.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally presented as the author's thesis, University of Lucknow.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p.[478]-482.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Krishna (Hindu deity) in literature",
+            "Hindi poetry",
+            "Hindi poetry -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aśoka Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dvārakālīlāparaka Hindī Krshṇa kāvya."
+          ],
+          "shelfMark": [
+            "*OKTM 84-130"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Caturvedī, Sudhā, 1944-"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74902459"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-130"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000191"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74902459"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000139-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100139"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200190"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000139-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Lakhanaū, Aśoka Prakāśana [1974]"
+          ],
+          "identifier": [
+            "urn:bnum:10000191",
+            "urn:lccn:74902459",
+            "urn:oclc:NYPG001000139-B",
+            "urn:undefined:NNSZ00100139",
+            "urn:undefined:(WaOLN)nyp0200190"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Krishna (Hindu deity) in literature.",
+            "Hindi poetry -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Dvārakālīlāparaka Hindī Krshṇa kāvya. Lekhikā Sudhā Caturvedī."
+          ],
+          "uri": "b10000191",
+          "lccClassification": [
+            "PK2040 .C313 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Lakhanaū"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000191"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942056",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-130"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-130",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011093998"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-130"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011093998"
+                    ],
+                    "idBarcode": [
+                      "33433011093998"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-000130"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000192",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "636 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [634]-636.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Indic literature",
+            "Indic literature -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Granthama"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bhāratīya sāhitya darśana."
+          ],
+          "shelfMark": [
+            "*OKTM 84-136"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Krishnalal."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "73902642"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-136"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000192"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73902642"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000140-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100140"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200191"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000140-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Kānapura, Granthama [1973]"
+          ],
+          "identifier": [
+            "urn:bnum:10000192",
+            "urn:lccn:73902642",
+            "urn:oclc:NYPG001000140-B",
+            "urn:undefined:NNSZ00100140",
+            "urn:undefined:(WaOLN)nyp0200191"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Indic literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Bhāratīya sāhitya darśana. [Lekhaka] Krshṇalāla Haṃsa."
+          ],
+          "uri": "b10000192",
+          "lccClassification": [
+            "PK2903 .K675"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kānapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000192"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942057",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-136"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-136",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011094004"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-136"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011094004"
+                    ],
+                    "idBarcode": [
+                      "33433011094004"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-000136"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000193",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "8, 242, 5 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "No more published.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit poetry",
+            "Sanskrit poetry -- History and criticism",
+            "Poetics"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Vyāsabandhu ; prāptisthānam Caukhambā Vidyābhawana]"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Abhinava-kāvya-prakāśaḥ"
+          ],
+          "shelfMark": [
+            "*OKP 84-162"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "creatorLiteral": [
+            "Vyāsa, Giridharalāla, 1894-"
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "idLccn": [
+            "76902375"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 84-162"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000193"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76902375"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000141-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100141"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200192"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000141-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Udayapura : Vyāsabandhu ; [Vāṛāṇasī : prāptisthānam Caukhambā Vidyābhawana], 1966."
+          ],
+          "identifier": [
+            "urn:bnum:10000193",
+            "urn:lccn:76902375",
+            "urn:oclc:NYPG001000141-B",
+            "urn:undefined:NNSZ00100141",
+            "urn:undefined:(WaOLN)nyp0200192"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit poetry -- History and criticism.",
+            "Poetics."
+          ],
+          "titleDisplay": [
+            "Abhinava-kāvya-prakāśaḥ / Vyāsopāhṇena Paṇḍitaśrīgovardhanatanujanuṣā Giridharalālena saṃkalitaḥ."
+          ],
+          "uri": "b10000193",
+          "lccClassification": [
+            "PK2916 .V93 1966"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Udayapura : [Vāṛāṇasī"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm"
+          ]
+        },
+        "sort": [
+          "b10000193"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783816",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 84-162 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 84-162 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153416"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OKP 84-162"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153416"
+                    ],
+                    "idBarcode": [
+                      "33433058153416"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKP 84-162 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000194",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "147 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Telugu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Yam. Śēṣācalaṃ; [distributors: Andhra Pradesh Book Distributors, Secunderabad"
+          ],
+          "language": [
+            {
+              "id": "lang:tel",
+              "label": "Telugu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Hampīkanyalu."
+          ],
+          "shelfMark": [
+            "*OLC 83-2593"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Calaṃ, 1894-1979."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "77908094"
+          ],
+          "seriesStatement": [
+            "EMESCO pocket books, 86"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLC 83-2593"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000194"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77908094"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000142-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100142"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200193"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000142-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Macilīpaṭnaṃ, Yam. Śēṣācalaṃ; [distributors: Andhra Pradesh Book Distributors, Secunderabad, 1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000194",
+            "urn:lccn:77908094",
+            "urn:oclc:NYPG001000142-B",
+            "urn:undefined:NNSZ00100142",
+            "urn:undefined:(WaOLN)nyp0200193"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Hampīkanyalu. [Racana] Calaṃ."
+          ],
+          "uri": "b10000194",
+          "lccClassification": [
+            "PL4780.9.V4 H3"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Macilīpaṭnaṃ"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000194"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000102",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-2593"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-2593",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004689018"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-2593"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004689018"
+                    ],
+                    "idBarcode": [
+                      "33433004689018"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-002593"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000195",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "116 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vālmīki"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Periyār Cuyamariyātaip Piracāra Niṟuvaṉa Veḷiyīṭu"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Irāmāyaṇap pāttiraṅkaḷ; ātāraṅkaḷil uḷḷapaṭi tokuttatu."
+          ],
+          "shelfMark": [
+            "*OLY 83-2592"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rāmacāmi, Ī. Ve., Tantai Periyār, 1878-1973."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "73903633"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 83-2592"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000195"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73903633"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000143-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100143"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200194"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000143-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Tirucci, Periyār Cuyamariyātaip Piracāra Niṟuvaṉa Veḷiyīṭu [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000195",
+            "urn:lccn:73903633",
+            "urn:oclc:NYPG001000143-B",
+            "urn:undefined:NNSZ00100143",
+            "urn:undefined:(WaOLN)nyp0200194"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vālmīki."
+          ],
+          "titleDisplay": [
+            "Irāmāyaṇap pāttiraṅkaḷ; ātāraṅkaḷil uḷḷapaṭi tokuttatu. [Eḻutiyavar] Periyār Ī. Ve. Rā."
+          ],
+          "uri": "b10000195",
+          "lccClassification": [
+            "PK3659 .R34 1972"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirucci"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000195"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783817",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 83-2592"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 83-2592",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060418526"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 83-2592"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060418526"
+                    ],
+                    "idBarcode": [
+                      "33433060418526"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 83-002592"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000196",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "96 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "India",
+            "India -- Politics and government",
+            "India -- Politics and government -- 1947-"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirāviṭappaṇṇai"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Paṇattōṭṭam."
+          ],
+          "shelfMark": [
+            "*OLB 83-2591"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Annadurai, C. N., 1909-1969."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "79909527"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 83-2591"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000196"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79909527"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000144-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100144"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200195"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000144-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Tiruccirāppaḷḷi, Tirāviṭappaṇṇai [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000196",
+            "urn:lccn:79909527",
+            "urn:oclc:NYPG001000144-B",
+            "urn:undefined:NNSZ00100144",
+            "urn:undefined:(WaOLN)nyp0200195"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "India -- Politics and government -- 1947-"
+          ],
+          "titleDisplay": [
+            "Paṇattōṭṭam. [Eḻutiyavar] C. N. Aṇṇāturai."
+          ],
+          "uri": "b10000196",
+          "lccClassification": [
+            "DS480.84 .A76 1969"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tiruccirāppaḷḷi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000196"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783818",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 83-2591"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 83-2591",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061296400"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 83-2591"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061296400"
+                    ],
+                    "idBarcode": [
+                      "33433061296400"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 83-002591"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000197",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "159 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Cilampuc celvar Ma. Po. Ci. avarkaḷatu 69 - vatu piṟanta nāḷ veḷiyīṭu.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Pūṅkoṭi Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tirukkuṟaḷilē kalaipaṟṟik kūṟātatēṉ?"
+          ],
+          "shelfMark": [
+            "*OLB 83-2587"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Civañāṉam, Ma. Po., 1906-"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903607"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 83-2587"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000197"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903607"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000145-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100145"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200196"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000145-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Ceṉṉai, Pūṅkoṭi Patippakam [1974]"
+          ],
+          "identifier": [
+            "urn:bnum:10000197",
+            "urn:lccn:74903607",
+            "urn:oclc:NYPG001000145-B",
+            "urn:undefined:NNSZ00100145",
+            "urn:undefined:(WaOLN)nyp0200196"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Tirukkuṟaḷilē kalaipaṟṟik kūṟātatēṉ? [Eḻutiyavar] Ma. Po. Civañāṉam."
+          ],
+          "uri": "b10000197",
+          "lccClassification": [
+            "PL4758.9.T5 S54"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000197"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783819",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 83-2587"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 83-2587",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061296392"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 83-2587"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061296392"
+                    ],
+                    "idBarcode": [
+                      "33433061296392"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 83-002587"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000198",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "96 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Telugu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Si. Vi. Krṣṇā Bukḍipō"
+          ],
+          "language": [
+            {
+              "id": "lang:tel",
+              "label": "Telugu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vēmanapadyaratnamulu."
+          ],
+          "shelfMark": [
+            "*OLC 83-2645"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Vēmana."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "73907881"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLC 83-2645"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000198"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73907881"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000146-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100146"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200197"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000146-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Madarāsu, Si. Vi. Krṣṇā Bukḍipō [1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000198",
+            "urn:lccn:73907881",
+            "urn:oclc:NYPG001000146-B",
+            "urn:undefined:NNSZ00100146",
+            "urn:undefined:(WaOLN)nyp0200197"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Vēmanapadyaratnamulu."
+          ],
+          "uri": "b10000198",
+          "lccClassification": [
+            "PL4780.9.V38 V5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Madarāsu"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000198"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000103",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLC 83-2645"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLC 83-2645",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004689042"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-2645"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004689042"
+                    ],
+                    "idBarcode": [
+                      "33433004689042"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-002645"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000199",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "32 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Bengali.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sāhitya"
+          ],
+          "language": [
+            {
+              "id": "lang:ben",
+              "label": "Bengali"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nijera bipakshe."
+          ],
+          "shelfMark": [
+            "*OKV 83-2643"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Haque, Samsul, 1937-"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "sa 65006162"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKV 83-2643"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000199"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 65006162"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000147-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100147"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200198"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000147-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "Kalakātā, Sāhitya [1965]"
+          ],
+          "identifier": [
+            "urn:bnum:10000199",
+            "urn:lccn:sa 65006162",
+            "urn:oclc:NYPG001000147-B",
+            "urn:undefined:NNSZ00100147",
+            "urn:undefined:(WaOLN)nyp0200198"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Nijera bipakshe. [Lekhaka] Sāmasula Haka."
+          ],
+          "uri": "b10000199",
+          "lccClassification": [
+            "PK1718"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kalakātā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000199"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000104",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKV 83-2643"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKV 83-2643",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011439092"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKV 83-2643"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011439092"
+                    ],
+                    "idBarcode": [
+                      "33433011439092"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKV 83-002643"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000200",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "102 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Assamese.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Laẏārcha Buka Shṭala"
+          ],
+          "language": [
+            {
+              "id": "lang:asm",
+              "label": "Assamese"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1963
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nirupāya, nirupāya."
+          ],
+          "shelfMark": [
+            "*OYE 83-2641"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Dāsa, Yogeśa, 1927-"
+          ],
+          "createdString": [
+            "1963"
+          ],
+          "idLccn": [
+            "sa 64006442"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1963
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OYE 83-2641"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000200"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 64006442"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000148-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100148"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200199"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000148-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Guwāhāṭī, Laẏārcha Buka Shṭala [1963]"
+          ],
+          "identifier": [
+            "urn:bnum:10000200",
+            "urn:lccn:sa 64006442",
+            "urn:oclc:NYPG001000148-B",
+            "urn:undefined:NNSZ00100148",
+            "urn:undefined:(WaOLN)nyp0200199"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1963"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Nirupāya, nirupāya. [Likhaka] Yogeśa Dāsa."
+          ],
+          "uri": "b10000200",
+          "lccClassification": [
+            "PK1569.D2 N5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Guwāhāṭī"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000200"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000105",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OYE 83-2641"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OYE 83-2641",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011486549"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OYE 83-2641"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011486549"
+                    ],
+                    "idBarcode": [
+                      "33433011486549"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OYE 83-002641"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000201",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "58 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Plays.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Assamese.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:asm",
+              "label": "Assamese"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nimātīra māta."
+          ],
+          "shelfMark": [
+            "*OYE 83-2642"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Das, Kandarpa, 1941-"
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 66006179"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OYE 83-2642"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000201"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 66006179"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000149-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100149"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200200"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000149-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "[Barapeṭā, 1964]"
+          ],
+          "identifier": [
+            "urn:bnum:10000201",
+            "urn:lccn:sa 66006179",
+            "urn:oclc:NYPG001000149-B",
+            "urn:undefined:NNSZ00100149",
+            "urn:undefined:(WaOLN)nyp0200200"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Nimātīra māta. [Likhaka] Kandarpa Dāsa."
+          ],
+          "uri": "b10000201",
+          "lccClassification": [
+            "PK1569.D223 N5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Barapeṭā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000201"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000106",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OYE 83-2642"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OYE 83-2642",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010171373"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OYE 83-2642"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010171373"
+                    ],
+                    "idBarcode": [
+                      "33433010171373"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OYE 83-002642"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000202",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title page of v.2 bears subtitle only.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Arabic literature",
+            "Arabic literature -- Iraq",
+            "Arabic literature -- Iraq -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Maktabat al-Andalus"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Fann al-Qaṣaṣī fī al-adab al-ʻIrāqī al-ḥadīth"
+          ],
+          "shelfMark": [
+            "*OEM 83-2834"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ṭālib, ʻUmar."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72218369"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OEM 83-2834"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000202"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72218369"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000150-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100150"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200201"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000150-B"
+          ],
+          "updatedAt": 1674870754295,
+          "publicationStatement": [
+            "Baghdād, Maktabat al-Andalus, 1971."
+          ],
+          "identifier": [
+            "urn:bnum:10000202",
+            "urn:lccn:72218369",
+            "urn:oclc:NYPG001000150-B",
+            "urn:undefined:NNSZ00100150",
+            "urn:undefined:(WaOLN)nyp0200201"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Arabic literature -- Iraq -- History and criticism."
+          ],
+          "titleDisplay": [
+            "al-Fann al-Qaṣaṣī fī al-adab al-ʻIrāqī al-ḥadīth [taʼlīf]ʻUmar al-Ṭālib."
+          ],
+          "uri": "b10000202",
+          "lccClassification": [
+            "PJ8038 .T35"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Baghdād"
+          ],
+          "titleAlt": [
+            "Masraḥīyah al-ʻArabīyah fī al-ʻIrāq."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Juzʼ 1. al-Riwāyah al-ʻArabīyah fī al-Irāq.-- Juzʼ 2. al-Masraḥīyah al-ʻArabīyah fī al-ʻIrāq."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000202"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000107",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OEM 83-2834"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OEM 83-2834",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002039166"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OEM 83-2834"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002039166"
+                    ],
+                    "idBarcode": [
+                      "33433002039166"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OEM 83-002834"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-62a95dfbc4a44574ada5718b7181b2bb.json
+++ b/test/fixtures/query-62a95dfbc4a44574ada5718b7181b2bb.json
@@ -1,0 +1,286 @@
+{
+  "took": 515,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 18415692,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000103",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "11, 602 p.: port.;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Sharikah al-Waṭanīyah lil-Nashr wa-al-Tawzīʻ"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dīwān Muḥammad al-ʻĪd Muḥammad ʻAlī Khalīfah."
+          ],
+          "shelfMark": [
+            "*OFA 82-5137"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Khalīfah, Muḥammad al-ʻĪd, 1904-1979."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "75960366"
+          ],
+          "seriesStatement": [
+            "Manshūrāt Wizārat al-Tarbiyah al-Waṭanīyah bi-al-Jazāʼir; 1"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFA 82-5137"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000103"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960366"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000051-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100051"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200102"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000051-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "[al-Jazāʼir]: al-Sharikah al-Waṭanīyah lil-Nashr wa-al-Tawzīʻ, 1967."
+          ],
+          "identifier": [
+            "urn:bnum:10000103",
+            "urn:lccn:75960366",
+            "urn:oclc:NYPG001000051-B",
+            "urn:undefined:NNSZ00100051",
+            "urn:undefined:(WaOLN)nyp0200102"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Dīwān Muḥammad al-ʻĪd Muḥammad ʻAlī Khalīfah."
+          ],
+          "uri": "b10000103",
+          "lccClassification": [
+            "PJ7842.H2937 A17 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[al-Jazāʼir]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000103"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFA 82-5137"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFA 82-5137",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002000671"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFA 82-5137"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002000671"
+                    ],
+                    "idBarcode": [
+                      "33433002000671"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFA 82-005137"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-65f476f3796f33546015d7ac450f1381.json
+++ b/test/fixtures/query-65f476f3796f33546015d7ac450f1381.json
@@ -1,0 +1,3227 @@
+{
+  "took": 131,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 13.630238,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10833141",
+        "_score": 13.630238,
+        "_source": {
+          "extent": [
+            "volumes : illustrations ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Some issues bear also thematic titles.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Editors: Harold Ross, 1925-1951; William Shawn, 1951-1987; Robert Gotllieb, 1987-1992, Tina Brown, 1992-1998; David Remnick, 1998-",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Vol. 73, no. 1 never published.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Has occasional supplements.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Vol. 90, no. 24 (Aug. 25, 2014).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Began with issue for Feb. 21, 1925."
+          ],
+          "subjectLiteral_exploded": [
+            "Literature",
+            "Literature -- Periodicals",
+            "Intellectual life",
+            "Electronic journals",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- Intellectual life",
+            "New York (N.Y.) -- Intellectual life -- Directories",
+            "New York (State)",
+            "New York (State) -- New York"
+          ],
+          "numItemDatesParsed": [
+            892
+          ],
+          "publisherLiteral": [
+            "F-R Pub. Corp.",
+            "D. Carey",
+            "Condé Nast Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            898
+          ],
+          "createdYear": [
+            1925
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The New Yorker."
+          ],
+          "shelfMark": [
+            "*DA+ (New Yorker)"
+          ],
+          "numItemVolumesParsed": [
+            828
+          ],
+          "createdString": [
+            "1925"
+          ],
+          "idLccn": [
+            "   28005329"
+          ],
+          "idIssn": [
+            "0028-792X"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ross, Harold Wallace, 1892-1951",
+            "Shawn, William",
+            "Brown, Tina",
+            "Remnick, David",
+            "White, Katharine Sergeant Angell",
+            "White, E. B. (Elwyn Brooks), 1899-1985",
+            "Irvin, Rea, 1881-1972",
+            "Angell, Roger"
+          ],
+          "dateStartYear": [
+            1925
+          ],
+          "donor": [
+            "Gift of the DeWitt Wallace Endowment Fund, named in honor of the founder of Reader's Digest (copy held in Per. Sect.)"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*DA+ (New Yorker)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10833141"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0028-792X"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   28005329"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1760231"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1760231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1760231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)228666271 (OCoLC)315923316 (OCoLC)813435753 (OCoLC)972367546 (OCoLC)973902298 (OCoLC)1032835230 (OCoLC)1038943160 (OCoLC)1041661831 (OCoLC)1054975031 (OCoLC)1058338019 (OCoLC)1065410087 (OCoLC)1078551167 (OCoLC)1081045337 (OCoLC)1082980679 (OCoLC)1114402509 (OCoLC)1134878896 (OCoLC)1134879337 (OCoLC)1144737766 (OCoLC)1167086187 (OCoLC)1294152325 (OCoLC)1302429095 (OCoLC)1319602865 (OCoLC)1322139476 (OCoLC)1332666305"
+            }
+          ],
+          "idOclc": [
+            "1760231"
+          ],
+          "uniformTitle": [
+            "New Yorker (New York, N.Y. : 1925)"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "97(2021)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 97 No. 25 (Aug. 23, 2021)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 26 (Aug. 30, 2021)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 27 (Sep. 6, 2021)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 28 (Sep. 13, 2021)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 29 (Sep. 20, 2021)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 30 (Sep. 27, 2021)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 31 (Oct. 4, 2021)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 32 (Oct. 11, 2021)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 33 (Oct. 18, 2021)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 34 (Oct. 25, 2021)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 35 (Nov. 1, 2021)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 36 (Nov. 8, 2021)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 37 (Nov. 15, 2021)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 38 (Nov. 22, 2021)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 39 (Nov. 29, 2021)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 40 (Dec. 6, 2021)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 41 (Dec. 13, 2021)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 42 (Dec. 20, 2021)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 97 No. 43 (Dec. 27, 2021)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 44 (Jan. 3, 2022 - Jan. 10, 2022)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 45 (Jan. 10, 2022)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 46 (Jan. 24, 2022)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 47 (Jan. 31, 2022)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 48 (Feb. 7, 2022)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 1 (Feb. 14, 2022)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 2 (Feb. 28, 2022)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 3 (Mar. 7, 2022)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 4 (Mar. 14, 2022)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 5 (Mar. 21, 2022)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 6 (Mar. 28, 2022)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 7 (Apr. 4, 2022)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 8 (Apr. 11, 2022)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 9 (Apr. 18, 2022)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 10 (Apr. 25, 2022)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 11 (May. 9, 2022)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 12 (May. 16, 2022)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 13 (May. 23, 2022)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 14 (May. 30, 2022)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 15 (Jun. 6, 2022)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 16 (Jun. 13, 2022)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 17 (Jun. 20, 2022)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 18 (Jun. 27, 2022)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 19 (Jul. 4, 2022)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 20 (Jul. 11, 2022)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 21 (Jul. 25, 2022)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 22 (Aug. 1, 2022)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 23 (Aug. 8, 2022)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 24 (Aug. 15, 2022)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 25 (Aug. 22, 2022)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 26 (Aug. 29, 2022)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 27 (Sep. 5, 2022)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 28 (Sep. 12, 2022)",
+                  "position": "52",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 29 (Sep. 19, 2022)",
+                  "position": "53",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 30 (Sep. 26, 2022)",
+                  "position": "54",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 31 (Oct. 3, 2022)",
+                  "position": "55",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 32 (Oct. 10, 2022)",
+                  "position": "56",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 33 (Oct. 17, 2022)",
+                  "position": "57",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 34 (Oct. 24, 2022)",
+                  "position": "58",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 35 (Oct. 31, 2022)",
+                  "position": "59",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 36 (Nov. 7, 2022)",
+                  "position": "60",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 37 (Nov. 14, 2022)",
+                  "position": "61",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 38 (Nov. 21, 2022)",
+                  "position": "62",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 39 (Nov. 28, 2022)",
+                  "position": "63",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 40 (Dec. 5, 2022)",
+                  "position": "64",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 41 (Dec. 12, 2022)",
+                  "position": "65",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 98 No. 42 (Dec. 19, 2022)",
+                  "position": "66",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 43 (Dec. 26, 2022)",
+                  "position": "67",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 44 (Jan. 2, 2023)",
+                  "position": "68",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 45 (Jan. 16, 2023)",
+                  "position": "69",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 47 (Jan. 23, 2023)",
+                  "position": "70",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 48 (Jan. 30, 2023)",
+                  "position": "71",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 98 No. 49 (Feb. 6, 2023)",
+                  "position": "72",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 99 No. 01 (Feb. 13, 2023 - Feb. 20, 2023)",
+                  "position": "73",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 99 No. 2 (Feb. 27, 2023)",
+                  "position": "74",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 99 No. 3 (Mar. 6, 2023)",
+                  "position": "75",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 99 No. 4 (Mar. 13, 2023)",
+                  "position": "76",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 99 No. 5 (Mar. 20, 2023)",
+                  "position": "77",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 99 No. 6 (Mar. 27, 2023)",
+                  "position": "78",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 99 No. 7 (Apr. 3, 2023)",
+                  "position": "79",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 99 No. 8 (Apr. 10, 2023)",
+                  "position": "80",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 99 No. 9 (Apr. 17, 2023)",
+                  "position": "81",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 99 No. 10 (Apr. 24, 2023)",
+                  "position": "82",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 99 No. 11 (May. 1, 2023)",
+                  "position": "83",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*DA+ (New Yorker)"
+                }
+              ],
+              "notes": [
+                "Room 108"
+              ],
+              "physicalLocation": [
+                "*DA+ (New Yorker)"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:makk3",
+                  "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                }
+              ],
+              "uri": "h1144777",
+              "shelfMark": [
+                "*DA+ (New Yorker)"
+              ]
+            },
+            {
+              "holdingStatement": [
+                "[Bound vols.] 1(1925)-June, Sept.1951-68:9(1992), 68:11(1992)-69:4(1993), 69:6(1993)-72:25(1996), 72:27(1996)-75:25(1999), 75:27(1999)-76:45(2001), 77:1(2001)-77:27(2001), 77:29(2001)-81:15(2005), 81:18(2005)-83:13(2007), 83:17(2007)-85:22(2009), 85:24(2009)-86:11(2010), 86:13(2010)-88:12(2012), 88:14(2012)-88:20(2012), 88:39(2012)-90:38(2014), 91:5(2015), 91:9(2015), 91:14(2015)-92:36(2016), 92:38(2016)-94(2018/19)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 95 No. 1 (Feb. 18, 2019)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 2 (Mar. 4, 2019)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 3 (Mar. 11, 2019)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 4 (Mar. 18, 2019)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 5 (Mar. 25, 2019)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 6 (Apr. 1, 2019)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 7 (Apr. 8, 2019)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 8 (Apr. 15, 2019)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 9 (Apr. 22, 2019)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 10 (Apr. 29, 2019)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 11 (May. 6, 2019)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 12 (May. 13, 2019)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 13 (May. 20, 2019)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 14 (May. 27, 2019)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 15 (Jun. 3, 2019)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 16 (Jun. 10, 2019)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 17 (Jun. 24, 2019)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 18 (Jul. 1, 2019)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 19 (Jul. 8, 2019)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 20 (Jul. 22, 2019)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 21 (Jul. 29, 2019)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 22 (Aug. 5, 2019)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 23 (Aug. 19, 2019)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 24 (Aug. 26, 2019)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 25 (Sep. 2, 2019)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 26 (Sep. 9, 2019)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 27 (Sep. 16, 2019)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 28 (Sep. 23, 2019)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 29 (Sep. 30, 2019)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 30 (Oct. 7, 2019)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 31 (Oct. 14, 2019)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 32 (Oct. 21, 2019)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 33 (Oct. 28, 2019)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 34 (Nov. 4, 2019)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 35 (Nov. 11, 2019)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 36 (Nov. 18, 2019)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 37 (Nov. 25, 2019)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 38 (Dec. 2, 2019)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 39 (Dec. 9, 2019)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 40 (Dec. 16, 2019)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 41 (Dec. 23, 2019)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 42 (Dec. 30, 2019)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 43 (Jan. 6, 2020)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 44 (Jan. 13, 2020)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 45 (Jan. 20, 2020)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 46 (Jan. 27, 2020)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 47 (Feb. 3, 2020)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 95 No. 48 (Feb. 10, 2020)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "To Bind"
+                },
+                {
+                  "coverage": "Vol. 96 No. 1 (Feb. 17, 2020 - Feb. 24, 2020)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 2 (Mar. 2, 2020)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 3 (Mar. 9, 2020)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 4 (Mar. 16, 2020)",
+                  "position": "52",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 5 (Mar. 23, 2020)",
+                  "position": "53",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 6 (Mar. 30, 2020)",
+                  "position": "54",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 7 (Apr. 6, 2020)",
+                  "position": "55",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 8 (Apr. 13, 2020)",
+                  "position": "56",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 09 (Apr. 20, 2020)",
+                  "position": "57",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 10 (Apr. 27, 2020)",
+                  "position": "58",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 11 (May. 4, 2020)",
+                  "position": "59",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 12 (May. 11, 2020)",
+                  "position": "60",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 13 (May. 18, 2020)",
+                  "position": "61",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 14 (May. 23, 2020)",
+                  "position": "62",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 15 (Jun. 1, 2020)",
+                  "position": "63",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 16 (Jun. 8, 2020)",
+                  "position": "64",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 18 (Jun. 15, 2020)",
+                  "position": "65",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 96 No. 17 (Jun. 22, 2020)",
+                  "position": "66",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 18 (Jun. 29, 2020)",
+                  "position": "67",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 19 (Jul. 6, 2020 - Jul. 13, 2020)",
+                  "position": "68",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 20 (Jul. 20, 2020)",
+                  "position": "69",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 21 (Jul. 27, 2020)",
+                  "position": "70",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 22 (Aug. 3, 2020)",
+                  "position": "71",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 23 (Aug. 17, 2020)",
+                  "position": "72",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 24 (Aug. 24, 2020)",
+                  "position": "73",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 25 (Aug. 31, 2020)",
+                  "position": "74",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 26 (Sep. 7, 2020)",
+                  "position": "75",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 27 (Sep. 14, 2020)",
+                  "position": "76",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 28 (Sep. 21, 2020)",
+                  "position": "77",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 29 (Sep. 28, 2020)",
+                  "position": "78",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 30 (Oct. 5, 2020)",
+                  "position": "79",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 31 (Oct. 12, 2020)",
+                  "position": "80",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 32 (Oct. 19, 2020)",
+                  "position": "81",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 33 (Oct. 26, 2020)",
+                  "position": "82",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 34 (Nov. 2, 2020)",
+                  "position": "83",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 35 (Nov. 9, 2020)",
+                  "position": "84",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 36 (Nov. 16, 2020)",
+                  "position": "85",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 37 (Nov. 23, 2020)",
+                  "position": "86",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 38 (Nov. 30, 2020)",
+                  "position": "87",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 39 (Dec. 7, 2020)",
+                  "position": "88",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 40 (Dec. 14, 2020)",
+                  "position": "89",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 41 (Dec. 21, 2020)",
+                  "position": "90",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 42 (Dec. 28, 2020)",
+                  "position": "91",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 43 (Jan. 4, 2021)",
+                  "position": "92",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 44 (Jan. 18, 2021)",
+                  "position": "93",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 45 (Jan. 25, 2021)",
+                  "position": "94",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 46 (Feb. 1, 2021)",
+                  "position": "95",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 96 No. 47 (Feb. 8, 2021)",
+                  "position": "96",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 1 (Feb. 15, 2021)",
+                  "position": "97",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 2 (Mar. 1, 2021)",
+                  "position": "98",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 3 (Mar. 8, 2021)",
+                  "position": "99",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 4 (Mar. 15, 2021)",
+                  "position": "100",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 5 (Mar. 22, 2021)",
+                  "position": "101",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 6 (Mar. 29, 2021)",
+                  "position": "102",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 7 (Apr. 5, 2021)",
+                  "position": "103",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 8 (Apr. 12, 2021)",
+                  "position": "104",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 9 (Apr. 19, 2021)",
+                  "position": "105",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 10 (Apr. 26, 2021 - May. 3, 2021)",
+                  "position": "106",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 11 (May. 10, 2021)",
+                  "position": "107",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 12 (May. 17, 2021)",
+                  "position": "108",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 13 (May. 24, 2021)",
+                  "position": "109",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 14 (May. 31, 2021)",
+                  "position": "110",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 15 (Jun. 7, 2021)",
+                  "position": "111",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 16 (Jun. 14, 2021)",
+                  "position": "112",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 17 (Jun. 21, 2021)",
+                  "position": "113",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 18 (Jun. 28, 2021)",
+                  "position": "114",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 19 (Jul. 5, 2021)",
+                  "position": "115",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 20 (Jul. 12, 2021)",
+                  "position": "116",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 21 (Jul. 26, 2021)",
+                  "position": "117",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 22 (Aug. 2, 2021)",
+                  "position": "118",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 23 (Aug. 9, 2021)",
+                  "position": "119",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 97 No. 24 (Aug. 16, 2021)",
+                  "position": "120",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*DA+ (New Yorker)"
+                  ],
+                  "status": "Arrived"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*DA+ (New Yorker)"
+                }
+              ],
+              "notes": [
+                "ROOM 108"
+              ],
+              "physicalLocation": [
+                "*DA+ (New Yorker)"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:makk3",
+                  "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                }
+              ],
+              "uri": "h1059671",
+              "shelfMark": [
+                "*DA+ (New Yorker)"
+              ]
+            }
+          ],
+          "updatedAt": 1679333246338,
+          "publicationStatement": [
+            "New York : F-R Pub. Corp., 1925-",
+            "[New York] : D. Carey",
+            "[New York] : Condé Nast Publications"
+          ],
+          "identifier": [
+            "urn:bnum:10833141",
+            "urn:issn:0028-792X",
+            "urn:lccn:   28005329",
+            "urn:oclc:1760231",
+            "urn:undefined:(OCoLC)1760231",
+            "urn:undefined:(OCoLC)228666271 (OCoLC)315923316 (OCoLC)813435753 (OCoLC)972367546 (OCoLC)973902298 (OCoLC)1032835230 (OCoLC)1038943160 (OCoLC)1041661831 (OCoLC)1054975031 (OCoLC)1058338019 (OCoLC)1065410087 (OCoLC)1078551167 (OCoLC)1081045337 (OCoLC)1082980679 (OCoLC)1114402509 (OCoLC)1134878896 (OCoLC)1134879337 (OCoLC)1144737766 (OCoLC)1167086187 (OCoLC)1294152325 (OCoLC)1302429095 (OCoLC)1319602865 (OCoLC)1322139476 (OCoLC)1332666305"
+          ],
+          "genreForm": [
+            "Electronic journals.",
+            "Collections.",
+            "Directories.",
+            "Periodicals."
+          ],
+          "numCheckinCardItems": [
+            203
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1925"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Literature -- Periodicals.",
+            "Intellectual life.",
+            "Literature.",
+            "Electronic journals.",
+            "New York (N.Y.) -- Intellectual life -- Directories.",
+            "New York (State) -- New York."
+          ],
+          "titleDisplay": [
+            "The New Yorker."
+          ],
+          "uri": "b10833141",
+          "lccClassification": [
+            "AP2 .N6763"
+          ],
+          "numItems": [
+            695
+          ],
+          "numAvailable": [
+            841
+          ],
+          "placeOfPublication": [
+            "New York",
+            "[New York]"
+          ],
+          "titleAlt": [
+            "New Yorker",
+            "The New Yorker"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "28-31 cm"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "allItems": {
+            "hits": {
+              "total": 898,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 897
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i37530724",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 94 (Oct.-Nov. 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 94 (Oct.-Nov. 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128201161"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 94 (Oct.-Nov. 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128201161"
+                    ],
+                    "idBarcode": [
+                      "33433128201161"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 94,
+                        "lte": 94
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        94-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000094 (Oct.-Nov. 2018)"
+                  }
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 896
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i37539307",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 94 (May-June 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 94 (May-June 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128201310"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 94 (May-June 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128201310"
+                    ],
+                    "idBarcode": [
+                      "33433128201310"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 94,
+                        "lte": 94
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        94-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000094 (May-June 2018)"
+                  }
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 895
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i37539308",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker) v. 94 (July-Sept. 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker) v. 94 (July-Sept. 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128201302"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 94 (July-Sept. 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128201302"
+                    ],
+                    "idBarcode": [
+                      "33433128201302"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 94,
+                        "lte": 94
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        94-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker) v. 000094 (July-Sept. 2018)"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 9,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 200
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-2",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 99 No. 11 (May. 1, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 99 No. 11"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 99,
+                        "lte": 99
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-05-01",
+                        "lte": "2023-05-01"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        99-2023-05-01"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        99-2023-05-01"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 199
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-3",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 99 No. 10 (Apr. 24, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 99 No. 10"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 99,
+                        "lte": 99
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-04-24",
+                        "lte": "2023-04-24"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        99-2023-04-24"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        99-2023-04-24"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 198
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-4",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 99 No. 9 (Apr. 17, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 99 No. 9"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 99,
+                        "lte": 99
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-04-17",
+                        "lte": "2023-04-17"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        99-2023-04-17"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        99-2023-04-17"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 197
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-5",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 99 No. 8 (Apr. 10, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 99 No. 8"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 99,
+                        "lte": 99
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-04-10",
+                        "lte": "2023-04-10"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        99-2023-04-10"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        99-2023-04-10"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 196
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-6",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 99 No. 7 (Apr. 3, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 99 No. 7"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 99,
+                        "lte": 99
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-04-03",
+                        "lte": "2023-04-03"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        99-2023-04-03"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        99-2023-04-03"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 195
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-7",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 99 No. 6 (Mar. 27, 2023)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 99 No. 6"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 99,
+                        "lte": 99
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2023-03-27",
+                        "lte": "2023-03-27"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        99-2023-03-27"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        99-2023-03-27"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 184
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-18",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 98 No. 41 (Dec. 12, 2022)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 98 No. 41"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 98,
+                        "lte": 98
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022-12-12",
+                        "lte": "2022-12-12"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        98-2022-12-12"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        98-2022-12-12"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 134
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1144777-68",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 97 No. 42 (Dec. 20, 2021)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 97 No. 42"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 97,
+                        "lte": 97
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021-12-20",
+                        "lte": "2021-12-20"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        97-2021-12-20"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        97-2021-12-20"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 54
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i-h1059671-65",
+                    "status": [
+                      {
+                        "id": "status:na",
+                        "label": "Not Available (ReCAP)"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:na||Not Available (ReCAP)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:makk3",
+                        "label": "Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108"
+                    ],
+                    "shelfMark": [
+                      "*DA+ (New Yorker)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DA+ (New Yorker)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Vol. 96 No. 18 (Jun. 15, 2020)"
+                    ],
+                    "volumeRaw": [
+                      "Vol. 96 No. 18"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 96,
+                        "lte": 96
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2020-06-15",
+                        "lte": "2020-06-15"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        96-2020-06-15"
+                    ],
+                    "type": [
+                      "nypl:CheckinCardItem"
+                    ],
+                    "shelfMark_sort": "a*DA+ (New Yorker)"
+                  },
+                  "sort": [
+                    "        96-2020-06-15"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 898,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "loc:mal82||Schwarzman Building - Main Reading Room 315",
+            "doc_count": 563
+          },
+          {
+            "key": "loc:makk3||Schwarzman Building - Dewitt Wallace Reference Desk Room 108",
+            "doc_count": 203
+          },
+          {
+            "key": "loc:rc2ma||Offsite",
+            "doc_count": 66
+          },
+          {
+            "key": "loc:rcma2||Offsite",
+            "doc_count": 66
+          }
+        ]
+      }
+    },
+    "item_format": {
+      "doc_count": 898,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 695
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 898,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 841
+          },
+          {
+            "key": "status:i||At bindery",
+            "doc_count": 48
+          },
+          {
+            "key": "status:na||Not Available (ReCAP)",
+            "doc_count": 9
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/query-70f97a0d65cdad852b1fd30dc04bddba.json
+++ b/test/fixtures/query-70f97a0d65cdad852b1fd30dc04bddba.json
@@ -1,0 +1,918 @@
+{
+  "took": 105,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.903906,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.903906,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-7ae74e0482f00e8bfd91dbd0b0a7332f.json
+++ b/test/fixtures/query-7ae74e0482f00e8bfd91dbd0b0a7332f.json
@@ -1,0 +1,40 @@
+{
+  "took": 4,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 0,
+    "max_score": null,
+    "hits": []
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 0,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": []
+      }
+    },
+    "item_format": {
+      "doc_count": 0,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": []
+      }
+    },
+    "item_status": {
+      "doc_count": 0,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": []
+      }
+    }
+  }
+}

--- a/test/fixtures/query-8dd8f0bcbec654739063825b7572a834.json
+++ b/test/fixtures/query-8dd8f0bcbec654739063825b7572a834.json
@@ -1,0 +1,698 @@
+{
+  "took": 10,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.362448,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b11984689",
+        "_score": 14.362448,
+        "_source": {
+          "extent": [
+            "v. ill."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Established 1900.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Most issues lack subtitle.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "v. 42, no. 1-v. 62, no. 7; Jan. 1942-July 1962."
+          ],
+          "subjectLiteral_exploded": [
+            "Woodwork",
+            "Woodwork -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            19
+          ],
+          "publisherLiteral": [
+            "Southam-Maclean Publications [etc.]"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            19
+          ],
+          "createdYear": [
+            1942
+          ],
+          "dateEndString": [
+            "1962"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Canadian woodworker; millwork, furniture, plywood."
+          ],
+          "shelfMark": [
+            "VMA (Canadian woodworker)"
+          ],
+          "numItemVolumesParsed": [
+            19
+          ],
+          "createdString": [
+            "1942"
+          ],
+          "idLccn": [
+            "cn 76300447"
+          ],
+          "idIssn": [
+            "0316-9669"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1942
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "VMA (Canadian woodworker)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11984689"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0316-9669"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "cn 76300447"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG94-S11794"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1974025"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "RCON-STC"
+            }
+          ],
+          "idOclc": [
+            "NYPG94-S11794"
+          ],
+          "dateEndYear": [
+            1962
+          ],
+          "updatedAt": 1675262897750,
+          "publicationStatement": [
+            "Don Mills, Ont. [etc.] Southam-Maclean Publications [etc.]"
+          ],
+          "identifier": [
+            "urn:bnum:11984689",
+            "urn:issn:0316-9669",
+            "urn:lccn:cn 76300447",
+            "urn:oclc:NYPG94-S11794",
+            "urn:undefined:(WaOLN)nyp1974025",
+            "urn:undefined:RCON-STC"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1942"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Woodwork -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Canadian woodworker; millwork, furniture, plywood."
+          ],
+          "uri": "b11984689",
+          "numItems": [
+            19
+          ],
+          "numAvailable": [
+            19
+          ],
+          "placeOfPublication": [
+            "Don Mills, Ont. [etc.]"
+          ],
+          "titleAlt": [
+            "Canadian woodworker (1942)",
+            "Canadian woodworker and furniture manufacturer Jan.-Mar. 1942"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29976055",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "VMA (Canadian woodworker) v. 44 (1944)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "VMA (Canadian woodworker) v. 44 (1944)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433102812199"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 44 (1944)"
+                    ],
+                    "physicalLocation": [
+                      "VMA (Canadian woodworker)"
+                    ],
+                    "recapCustomerCode": [
+                      "JS"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433102812199"
+                    ],
+                    "idBarcode": [
+                      "33433102812199"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 44,
+                        "lte": 44
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1944",
+                        "lte": "1944"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        44-1944"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aVMA (Canadian woodworker) v. 000044 (1944)"
+                  },
+                  "sort": [
+                    "        44-1944"
+                  ]
+                }
+              ]
+            }
+          },
+          "allItems": {
+            "hits": {
+              "total": 19,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 18
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i29978114",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "VMA (Canadian woodworker) v. 62 (Jan. -July 1962)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "VMA (Canadian woodworker) v. 62 (Jan. -July 1962)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433102813007"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 62 (Jan. -July 1962)"
+                    ],
+                    "physicalLocation": [
+                      "VMA (Canadian woodworker)"
+                    ],
+                    "recapCustomerCode": [
+                      "JS"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433102813007"
+                    ],
+                    "idBarcode": [
+                      "33433102813007"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 62,
+                        "lte": 62
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1962",
+                        "lte": "1962"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        62-1962"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aVMA (Canadian woodworker) v. 000062 (Jan. -July 1962)"
+                  }
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 17
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i29978115",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "VMA (Canadian woodworker) v. 61 (1961)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "VMA (Canadian woodworker) v. 61 (1961)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433102812850"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 61 (1961)"
+                    ],
+                    "physicalLocation": [
+                      "VMA (Canadian woodworker)"
+                    ],
+                    "recapCustomerCode": [
+                      "JS"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433102812850"
+                    ],
+                    "idBarcode": [
+                      "33433102812850"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 61,
+                        "lte": 61
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1961",
+                        "lte": "1961"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        61-1961"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aVMA (Canadian woodworker) v. 000061 (1961)"
+                  }
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i29978117",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "VMA (Canadian woodworker) v. 60 (1960)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "VMA (Canadian woodworker) v. 60 (1960)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433102812553"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 60 (1960)"
+                    ],
+                    "physicalLocation": [
+                      "VMA (Canadian woodworker)"
+                    ],
+                    "recapCustomerCode": [
+                      "JS"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433102812553"
+                    ],
+                    "idBarcode": [
+                      "33433102812553"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 60,
+                        "lte": 60
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1960",
+                        "lte": "1960"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        60-1960"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aVMA (Canadian woodworker) v. 000060 (1960)"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 19,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "loc:rc2ma||Offsite",
+            "doc_count": 19
+          }
+        ]
+      }
+    },
+    "item_format": {
+      "doc_count": 19,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 19
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 19,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 19
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/query-9860c2ad8409a132bad05b076789607b.json
+++ b/test/fixtures/query-9860c2ad8409a132bad05b076789607b.json
@@ -1,0 +1,979 @@
+{
+  "took": 18,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.334448,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b14937001",
+        "_score": 14.334448,
+        "_source": {
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "From 1807-June 1837 title reads: Morgenblatt für gebildete stände.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Kunst-blatt. Stuttgart, 1816-1849.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Includes the current supplements Literatur-blatt 1817-1849; Kunstblatt 1816-1849; Intelligenz-blatt 1817-1847.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "J. G. Cotta'sche buchhandlung."
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            4
+          ],
+          "dateEndString": [
+            "1"
+          ],
+          "createdYear": [
+            1855
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Morgenblatt für gebildete leser."
+          ],
+          "shelfMark": [
+            "*DF+ (Morgenblatt für gebildete Leser)"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1855"
+          ],
+          "idLccn": [
+            "cau08001961"
+          ],
+          "numElectronicResources": [
+            88
+          ],
+          "dateStartYear": [
+            1855
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*DF+ (Morgenblatt für gebildete Leser)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "14937001"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "cau08001961"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1608345"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "0494254"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)ret0001042"
+            }
+          ],
+          "idOclc": [
+            "1608345"
+          ],
+          "dateEndYear": [
+            1
+          ],
+          "updatedAt": 1671729582968,
+          "publicationStatement": [
+            "Stuttgart, Tübingen [etc.], J. G. Cotta'sche buchhandlung."
+          ],
+          "identifier": [
+            "urn:bnum:14937001",
+            "urn:lccn:cau08001961",
+            "urn:oclc:1608345",
+            "urn:undefined:0494254",
+            "urn:undefined:(WaOLN)ret0001042"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1855"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Morgenblatt für gebildete leser."
+          ],
+          "uri": "b14937001",
+          "numItems": [
+            4
+          ],
+          "numAvailable": [
+            4
+          ],
+          "placeOfPublication": [
+            "Stuttgart, Tübingen [etc.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i14937001-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899526k",
+                        "label": "Full text available via HathiTrust - jahrg.11:Jan.-June (1817)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899527i",
+                        "label": "Full text available via HathiTrust - jahrg.11:July-Dec. (1817)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899528g",
+                        "label": "Full text available via HathiTrust - jahrg.12:Jan.-June (1818)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899529e",
+                        "label": "Full text available via HathiTrust - jahrg.12:July-Dec. (1818)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899530t",
+                        "label": "Full text available via HathiTrust - jahrg.13:Jan.-June (1819)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899531r",
+                        "label": "Full text available via HathiTrust - jahrg.13:July-Dec. (1819)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899532p",
+                        "label": "Full text available via HathiTrust - jahrg.14:Jan.-June (1820)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899534l",
+                        "label": "Full text available via HathiTrust - jahrg.15:Jan.-June (1821)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899535j",
+                        "label": "Full text available via HathiTrust - jahrg.15:July-Dec. (1821)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899536h",
+                        "label": "Full text available via HathiTrust - jahrg.16:Jan.-June (1822)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899537f",
+                        "label": "Full text available via HathiTrust - jahrg.16:July-Dec. (1822)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899538d",
+                        "label": "Full text available via HathiTrust - jahrg.17:Jan.-June (1823)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899539b",
+                        "label": "Full text available via HathiTrust - jahrg.17:July-Dec. (1823)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899541o",
+                        "label": "Full text available via HathiTrust - jahrg.18:July-Dec. (1824)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899542m",
+                        "label": "Full text available via HathiTrust - jahrg.19:Jan.-June (1825)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899505s",
+                        "label": "Full text available via HathiTrust - jahrg.2:Jan.-June (1808)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899506q",
+                        "label": "Full text available via HathiTrust - jahrg.2:July-Dec. (1808)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899544i",
+                        "label": "Full text available via HathiTrust - jahrg.20:Jan.-June (1826)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899545g",
+                        "label": "Full text available via HathiTrust - jahrg.20:July-Dec. (1826)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899547c",
+                        "label": "Full text available via HathiTrust - jahrg.21:July-Dec. (1827)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899548a",
+                        "label": "Full text available via HathiTrust - jahrg.22 (1828)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899620s",
+                        "label": "Full text available via HathiTrust - jahrg.22:suppl.:art (1828)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899550n",
+                        "label": "Full text available via HathiTrust - jahrg.23:July-Dec. (1829)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899551l",
+                        "label": "Full text available via HathiTrust - jahrg.24:Jan.-June (1830)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899552j",
+                        "label": "Full text available via HathiTrust - jahrg.24:July-Dec. (1830)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899624k",
+                        "label": "Full text available via HathiTrust - jahrg.24:suppl.:lit. (1830)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899554f",
+                        "label": "Full text available via HathiTrust - jahrg.25:July-Dec. (1831)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899555d",
+                        "label": "Full text available via HathiTrust - jahrg.26:Jan.-June (1832)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899556b",
+                        "label": "Full text available via HathiTrust - jahrg.26:July-Dec. (1832)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995587",
+                        "label": "Full text available via HathiTrust - jahrg.28:Jan.-June (1834)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995595",
+                        "label": "Full text available via HathiTrust - jahrg.28:July-Dec. (1834)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899560k",
+                        "label": "Full text available via HathiTrust - jahrg.29:Jan.-June (1835)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899561i",
+                        "label": "Full text available via HathiTrust - jahrg.29:July-Dec. (1835)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899563e",
+                        "label": "Full text available via HathiTrust - jahrg.30:Oct.-Dec. (1836)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899641k",
+                        "label": "Full text available via HathiTrust - jahrg.32:suppl.:lit. (1838)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995668",
+                        "label": "Full text available via HathiTrust - jahrg.33 (1839)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899642i",
+                        "label": "Full text available via HathiTrust - jahrg.33:suppl.:art (1839)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899645c",
+                        "label": "Full text available via HathiTrust - jahrg.35:suppl.:art (1841)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899646a",
+                        "label": "Full text available via HathiTrust - jahrg.35:suppl.:lit. (1841)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995692",
+                        "label": "Full text available via HathiTrust - jahrg.36:Jan.-Apr. (1842)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899571f",
+                        "label": "Full text available via HathiTrust - jahrg.36:Sept.-Dec. (1842)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899572d",
+                        "label": "Full text available via HathiTrust - jahrg.37:Jan.-Apr. (1843)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899573b",
+                        "label": "Full text available via HathiTrust - jahrg.37:May-Aug. (1843)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995749",
+                        "label": "Full text available via HathiTrust - jahrg.37:Sept.-Dec. (1843)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951p01107664f",
+                        "label": "Full text available via HathiTrust - jahrg.38:Jan.-Apr. (1844)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995765",
+                        "label": "Full text available via HathiTrust - jahrg.38:May-Aug. (1844)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995781",
+                        "label": "Full text available via HathiTrust - jahrg.39:Jan.-June (1845)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899509k",
+                        "label": "Full text available via HathiTrust - jahrg.4:Jan.-June (1810)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899582a",
+                        "label": "Full text available via HathiTrust - jahrg.41:Jan.-June (1847)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.319510018995838",
+                        "label": "Full text available via HathiTrust - jahrg.41:July-Dec. (1847)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899589w",
+                        "label": "Full text available via HathiTrust - jahrg.44:July-Dec. (1850)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899590b",
+                        "label": "Full text available via HathiTrust - jahrg.45:Jan.-June (1851)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899599t",
+                        "label": "Full text available via HathiTrust - jahrg.49:July-Dec. (1855)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899512v",
+                        "label": "Full text available via HathiTrust - jahrg.5:July-Dec. (1811)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899600y",
+                        "label": "Full text available via HathiTrust - jahrg.50:Jan.-June (1856)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899601w",
+                        "label": "Full text available via HathiTrust - jahrg.50:July-Dec. (1856)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899602u",
+                        "label": "Full text available via HathiTrust - jahrg.51:Jan.-June (1857)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899603s",
+                        "label": "Full text available via HathiTrust - jahrg.51:July-Dec. (1857)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899605o",
+                        "label": "Full text available via HathiTrust - jahrg.52:July-Dec. (1858)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899606m",
+                        "label": "Full text available via HathiTrust - jahrg.53:Jan.-June (1859)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899607k",
+                        "label": "Full text available via HathiTrust - jahrg.53:July-Dec. (1859)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899608i",
+                        "label": "Full text available via HathiTrust - jahrg.54:Jan.-June (1860)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899609g",
+                        "label": "Full text available via HathiTrust - jahrg.54:July-Dec. (1860)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899610v",
+                        "label": "Full text available via HathiTrust - jahrg.55:Jan.-June (1861)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899611t",
+                        "label": "Full text available via HathiTrust - jahrg.55:July-Dec. (1861)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899612r",
+                        "label": "Full text available via HathiTrust - jahrg.56:Jan.-June (1862)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899613p",
+                        "label": "Full text available via HathiTrust - jahrg.56:July-Dec. (1862)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899614n",
+                        "label": "Full text available via HathiTrust - jahrg.57:Jan.-June (1863)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899615l",
+                        "label": "Full text available via HathiTrust - jahrg.57:July-Dec. (1863)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899616j",
+                        "label": "Full text available via HathiTrust - jahrg.58:Jan.-June (1864)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899617h",
+                        "label": "Full text available via HathiTrust - jahrg.58:July-Dec. (1864)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899619d",
+                        "label": "Full text available via HathiTrust - jahrg.59:July-Dec. (1865)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899513t",
+                        "label": "Full text available via HathiTrust - jahrg.6:Jan.-June (1812)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899514r",
+                        "label": "Full text available via HathiTrust - jahrg.6:July-Dec. (1812)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899516n",
+                        "label": "Full text available via HathiTrust - jahrg.7:July-Dec. (1813)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/umn.31951001899521u",
+                        "label": "Full text available via HathiTrust - jahrg.9:Jan.-June (1815)"
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054677",
+                        "label": "Full text available via HathiTrust - vol.13, pt.2 (1819)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054701",
+                        "label": "Full text available via HathiTrust - vol.15, pt.1 (1821)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054743",
+                        "label": "Full text available via HathiTrust - vol.28, pt.1 (1834)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054768",
+                        "label": "Full text available via HathiTrust - vol.28, pt.2 (1834)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054776",
+                        "label": "Full text available via HathiTrust - vol.28, pt.3 (1834)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054800",
+                        "label": "Full text available via HathiTrust - vol.30, pt.1 (1836)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054818",
+                        "label": "Full text available via HathiTrust - vol.30, pt.2 (1836)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054826",
+                        "label": "Full text available via HathiTrust - vol.31, pt.1 (1837)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054834",
+                        "label": "Full text available via HathiTrust - vol.31, pt.2 (1837)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054842",
+                        "label": "Full text available via HathiTrust - vol.33, pt.1 (1839)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064054859",
+                        "label": "Full text available via HathiTrust - vol.33, pt.2 (1839)\"\"\""
+                      },
+                      {
+                        "url": "http://hdl.handle.net/2027/njp.32101064488156",
+                        "label": "Full text available via HathiTrust - vol.40 (1846)"
+                      }
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "bi14937001-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28543800",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1860"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1860",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433097964930"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 1860"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433097964930"
+                    ],
+                    "idBarcode": [
+                      "33433097964930"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 001860"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          },
+          "allItems": {
+            "hits": {
+              "total": 4,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i28309666",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 1933"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 1933",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088646033"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. Mar.-May 1933"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088646033"
+                    ],
+                    "idBarcode": [
+                      "33433088646033"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. Mar.-May 001933"
+                  }
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i28309648",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433096425198"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 49 (1855)"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433096425198"
+                    ],
+                    "idBarcode": [
+                      "33433096425198"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 49 (1855)"
+                  }
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i28309668",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1861"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*DF+ (Morgenblatt für gebildete Leser) Jahrg. 1861",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088646041"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Jahrg. 1861"
+                    ],
+                    "physicalLocation": [
+                      "*DF+ (Morgenblatt für gebildete Leser)"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088646041"
+                    ],
+                    "idBarcode": [
+                      "33433088646041"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*DF+ (Morgenblatt für gebildete Leser) Jahrg. 001861"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 5,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "loc:rc2ma||Offsite",
+            "doc_count": 3
+          },
+          {
+            "key": "loc:mal92||Schwarzman Building M2 - General Research Room 315",
+            "doc_count": 1
+          }
+        ]
+      }
+    },
+    "item_format": {
+      "doc_count": 5,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 5
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 5,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 4
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/fixtures/query-9b80844bc3095d88ef6a43506d81eb91.json
+++ b/test/fixtures/query-9b80844bc3095d88ef6a43506d81eb91.json
@@ -1,0 +1,918 @@
+{
+  "took": 66,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.903906,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.903906,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-9c91b5f16b98836b71337ad3f0087fd1.json
+++ b/test/fixtures/query-9c91b5f16b98836b71337ad3f0087fd1.json
@@ -1,0 +1,20106 @@
+{
+  "took": 578,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 755919,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001080",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "577 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"The first printed book in Malayalam\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Facsimile reproduction of old Malayalam and transcription, paraphrase, and notes in modern Malayalam, on opposite pages.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Original t.p. reads: Nasṟāṇikaḷ okkakkuṃ aṟiyeṇṭunna saṅkṣepavedārtthaṃ=Compendiosa legis explanatio omnibus Christianis scitu necessaria. Malabarico idiomate. Romāyilninn Miśihā pirṟannīṭṭ 1772 śṟȧṣṭa melpaṭṭakkāraruṭe anuvādattāl=Romae An. A nativit. Christi 1772, praisidum facultate\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Catholic Church. Syro-Malabar rite",
+            "Christianity",
+            "Christianity -- Philosophy"
+          ],
+          "publisherLiteral": [
+            "Ḍi. Ṣi. Buks ; Kārmel Pabḷiṣiṅg Senṟar,"
+          ],
+          "language": [
+            {
+              "id": "lang:mal",
+              "label": "Malayalam"
+            }
+          ],
+          "dateEndString": [
+            "1772"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Saṅkṣēpavēdartthaṃ : tṟānsliṯṯaṟēṣanuṃ parāvarttanavuṃ vyākhayānavuṃ ataṅṅiya putiya patipp"
+          ],
+          "shelfMark": [
+            "*OLD 84-299"
+          ],
+          "creatorLiteral": [
+            "Piyāniyas, Kḷemanṟ, 1731-1782."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82904075"
+          ],
+          "contributorLiteral": [
+            "Choondal, Chummar, 1940-",
+            "Mathew, Ulakamthara."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLD 84-299"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001080"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82904075"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201091"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201079"
+            }
+          ],
+          "dateEndYear": [
+            1772
+          ],
+          "updatedAt": 1636128328325,
+          "publicationStatement": [
+            "Kōṭṭayaṃ : Ḍi. Ṣi. Buks ; Tiruvanantapuraṃ : Kārmel Pabḷiṣiṅg Senṟar, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10001080",
+            "urn:lccn:82904075",
+            "urn:undefined:NNSZ00201091",
+            "urn:undefined:(WaOLN)nyp0201079"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Catholic Church. Syro-Malabar rite.",
+            "Christianity -- Philosophy."
+          ],
+          "titleDisplay": [
+            "Saṅkṣēpavēdartthaṃ : tṟānsliṯṯaṟēṣanuṃ parāvarttanavuṃ vyākhayānavuṃ ataṅṅiya putiya patipp / Kḷemanṟ Piyāniyas = Samkshepa vedartham / by Clement Pianius ; introduction by Chummar Choondel ; commentary by Mathew Ulakamthara."
+          ],
+          "uri": "b10001080",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kōṭṭayaṃ : Tiruvanantapuraṃ :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10001080"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011099029"
+                    ],
+                    "physicalLocation": [
+                      "*OLD 84-299"
+                    ],
+                    "shelfMark_sort": "a*OLD 84-000299",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10000682",
+                    "shelfMark": [
+                      "*OLD 84-299"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLD 84-299"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011099029"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433011099029"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003158",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "608 p. in various pagings ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Reprint ed.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Chinese.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Medicine, Chinese"
+          ],
+          "publisherLiteral": [
+            "Xuan feng chu ban she ; Taipei : Zong jing xiao da zhong tu shu Gong si,"
+          ],
+          "language": [
+            {
+              "id": "lang:chi",
+              "label": "Chinese"
+            }
+          ],
+          "dateEndString": [
+            "1670"
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zheng yin mo zhi : [4 juan]"
+          ],
+          "shelfMark": [
+            "*OVL 84-1330"
+          ],
+          "creatorLiteral": [
+            "Qin, Changyu, active 17th century."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "77839836"
+          ],
+          "seriesStatement": [
+            "zhongguo yi yao zong shu."
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OVL 84-1330"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003158"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77839836"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303509"
+            }
+          ],
+          "dateEndYear": [
+            1670
+          ],
+          "updatedAt": 1641391919318,
+          "publicationStatement": [
+            "Taipei xian yonghe zhen : Xuan feng chu ban she ; Taipei : Zong jing xiao da zhong tu shu Gong si, Min'Guo 61[1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10003158",
+            "urn:lccn:77839836",
+            "urn:undefined:NNSZ00303509"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Medicine, Chinese."
+          ],
+          "titleDisplay": [
+            "Zheng yin mo zhi : [4 juan] / Qin Jingming [Changyu] zhu ; Qin Zhizheng ji ; [Cao Binzhang quan dian]."
+          ],
+          "uri": "b10003158",
+          "lccClassification": [
+            "R128.7 .C545"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Taipei xian yonghe zhen :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10003158"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001746852"
+                    ],
+                    "physicalLocation": [
+                      "*OVL 84-1330"
+                    ],
+                    "shelfMark_sort": "a*OVL 84-001330",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002193",
+                    "shelfMark": [
+                      "*OVL 84-1330"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OVL 84-1330"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001746852"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001746852"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003190",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "606 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Basavapurāṇavu.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Kannaḍa sāhitya caritre.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Basava, active 1160",
+            "Basava, active 1160 -- Poetry",
+            "Lingayats",
+            "Lingayats -- Poetry"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "1899"
+          ],
+          "createdYear": [
+            1800
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Basavapurāṇavu"
+          ],
+          "shelfMark": [
+            "*OLA+ 82-1360"
+          ],
+          "creatorLiteral": [
+            "Palakuriki Somanatha, active 13th century."
+          ],
+          "createdString": [
+            "1800"
+          ],
+          "contributorLiteral": [
+            "Bhīmakavi, active 1369."
+          ],
+          "dateStartYear": [
+            1800
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA+ 82-1360"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003190"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303541"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203183"
+            }
+          ],
+          "uniformTitle": [
+            "Basavapurāṇamu. Kannada"
+          ],
+          "dateEndYear": [
+            1899
+          ],
+          "updatedAt": 1636076831370,
+          "publicationStatement": [
+            "[S.1. : s.n., 18--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10003190",
+            "urn:undefined:NNSZ00303541",
+            "urn:undefined:(WaOLN)nyp0203183"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1800"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Basava, active 1160 -- Poetry.",
+            "Lingayats -- Poetry."
+          ],
+          "titleDisplay": [
+            "Basavapurāṇavu / [Bhīmakavi viracita ; Sōmanātha kaviya Telugu Basavapurāṇamuvina Kannaḍa anuvāda]."
+          ],
+          "uri": "b10003190",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.1. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Basavapurāṇamu."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10003190"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433069579674"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 82-001360",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784381",
+                    "shelfMark": [
+                      "*OLA+ 82-1360"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433069579674"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433069579674"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003301",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., map, facsims. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kurds",
+            "Kurds -- Iran",
+            "Kurds -- Iran -- History"
+          ],
+          "publisherLiteral": [
+            "Chāpkhānah-ʼi Kūshish,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ḥarikat-i tārikhī-i Kurd bih Khurāsān dar difāʻ az istiqlāl-i Īrān"
+          ],
+          "shelfMark": [
+            "*OMR 84-1145"
+          ],
+          "creatorLiteral": [
+            "Tavaḥḥudī Awghāzī, Kalīm Allāh."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMR 84-1145"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003301"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303655"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0000007"
+            }
+          ],
+          "dateEndYear": [
+            999
+          ],
+          "updatedAt": 1636103985760,
+          "publicationStatement": [
+            "Mashhad : Chāpkhānah-ʼi Kūshish, 1359-  [1981-  ]"
+          ],
+          "identifier": [
+            "urn:bnum:10003301",
+            "urn:undefined:NNSZ00303655",
+            "urn:undefined:(WaOLN)nyp0000007"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kurds -- Iran -- History."
+          ],
+          "titleDisplay": [
+            "Ḥarikat-i tārikhī-i Kurd bih Khurāsān dar difāʻ az istiqlāl-i Īrān / taʼlīf-i Kalīm Allāh Tavaḥḥudī (Awghāzi)"
+          ],
+          "uri": "b10003301",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Mashhad :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003301"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013135854"
+                    ],
+                    "physicalLocation": [
+                      "*OMR 84-1145"
+                    ],
+                    "shelfMark_sort": "a*OMR 84-1145 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002283",
+                    "shelfMark": [
+                      "*OMR 84-1145 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMR 84-1145 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013135854"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433013135854"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013135847"
+                    ],
+                    "physicalLocation": [
+                      "*OMR 84-1145"
+                    ],
+                    "shelfMark_sort": "a*OMR 84-1145 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002282",
+                    "shelfMark": [
+                      "*OMR 84-1145 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMR 84-1145 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013135847"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433013135847"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013136530"
+                    ],
+                    "physicalLocation": [
+                      "*OMR 84-1145"
+                    ],
+                    "shelfMark_sort": "a*OMR 84-1145 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002281",
+                    "shelfMark": [
+                      "*OMR 84-1145 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMR 84-1145 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013136530"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433013136530"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003857",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "319 p. : ill., plates, maps ;"
+          ],
+          "parallelDisplayField": [
+            {
+              "fieldName": "publicationStatement",
+              "index": 0,
+              "value": "‏بيروت : دار مكتبة الحياة, [196-؟]"
+            },
+            {
+              "fieldName": "placeOfPublication",
+              "index": 0,
+              "value": "‏بيروت :"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Yemen (Republic)"
+          ],
+          "publisherLiteral": [
+            "Dār Maktabat al-Ḥayāh,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "createdYear": [
+            196
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Yaman wa-ḥaḍārat al-ʻArab, maʻa dirāsah jughrāfīyah kāmilah /"
+          ],
+          "parallelTitle": [
+            "‏اليمن وحضارة العرب, مع دراسة جغرافية كاملة /"
+          ],
+          "shelfMark": [
+            "*OFI 82-4419"
+          ],
+          "creatorLiteral": [
+            "Tarsīsī, ʻAdnān."
+          ],
+          "createdString": [
+            "196"
+          ],
+          "parallelPublisher": [
+            "‏دار مكتبة الحياة,"
+          ],
+          "idLccn": [
+            "ne 64003290"
+          ],
+          "dateStartYear": [
+            196
+          ],
+          "parallelCreatorLiteral": [
+            "‏ترسيسي, عدنان."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFI 82-4419"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003857"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ne 64003290"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11272192"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11272192"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)221366702"
+            }
+          ],
+          "idOclc": [
+            "11272192"
+          ],
+          "updatedAt": 1649121307527,
+          "publicationStatement": [
+            "Bayrūt : Dār Maktabat al-Ḥayāh, [196-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10003857",
+            "urn:lccn:ne 64003290",
+            "urn:oclc:11272192",
+            "urn:undefined:(OCoLC)11272192",
+            "urn:undefined:(OCoLC)221366702"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "196"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Yemen (Republic)"
+          ],
+          "titleDisplay": [
+            "al-Yaman wa-ḥaḍārat al-ʻArab, maʻa dirāsah jughrāfīyah kāmilah / [taʼlīf] ʻAdnān Tarsīsī."
+          ],
+          "uri": "b10003857",
+          "lccClassification": [
+            "DS247.Y4 T3"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏اليمن وحضارة العرب, مع دراسة جغرافية كاملة / [تاليف] عدنان ترسيسي."
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Includes musical score of national anthem of Yemen Arab Republic."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003857"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101143836"
+                    ],
+                    "physicalLocation": [
+                      "*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                    ],
+                    "shelfMark_sort": "a*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i29202258",
+                    "shelfMark": [
+                      "*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFK (Tarsīsī. Yaman wa-ḥaḍārat al-ʻArab)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101143836"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "idBarcode": [
+                      "33433101143836"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002023293"
+                    ],
+                    "physicalLocation": [
+                      "*OFI 82-4419"
+                    ],
+                    "shelfMark_sort": "a*OFI 82-004419",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002714",
+                    "shelfMark": [
+                      "*OFI 82-4419"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFI 82-4419"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002023293"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433002023293"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004080",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Bengali.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Esosiẏeṭeḍa Pābaliśārsa"
+          ],
+          "language": [
+            {
+              "id": "lang:ben",
+              "label": "Bengali"
+            }
+          ],
+          "dateEndString": [
+            "62"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Junāpura Sṭīla."
+          ],
+          "shelfMark": [
+            "*OKV 82-3891"
+          ],
+          "creatorLiteral": [
+            "Mānnā, Guṇamaẏa, 1925-2010."
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "sa 63003864"
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKV 82-3891"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004080"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 63003864"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304442"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204072"
+            }
+          ],
+          "dateEndYear": [
+            62
+          ],
+          "updatedAt": 1636108800927,
+          "publicationStatement": [
+            "[Kalakātā] Esosiẏeṭeḍa Pābaliśārsa [1960-1962]"
+          ],
+          "identifier": [
+            "urn:bnum:10004080",
+            "urn:lccn:sa 63003864",
+            "urn:undefined:NNSZ00304442",
+            "urn:undefined:(WaOLN)nyp0204072"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Junāpura Sṭīla. [Lekhaka] Guṇamaẏa Mānnā."
+          ],
+          "uri": "b10004080",
+          "lccClassification": [
+            "PK1718.M253 53"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Kalakātā]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10004080"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011168402"
+                    ],
+                    "physicalLocation": [
+                      "*OKV 82-3891"
+                    ],
+                    "shelfMark_sort": "a*OKV 82-3891 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002917",
+                    "shelfMark": [
+                      "*OKV 82-3891 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKV 82-3891 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011168402"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433011168402"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011168394"
+                    ],
+                    "physicalLocation": [
+                      "*OKV 82-3891"
+                    ],
+                    "shelfMark_sort": "a*OKV 82-3891 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002916",
+                    "shelfMark": [
+                      "*OKV 82-3891 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKV 82-3891 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011168394"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433011168394"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004504",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "34 p.;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Pronunciation"
+          ],
+          "publisherLiteral": [
+            "Naṭarācaṉ,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "createdYear": [
+            197
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tamiḻ valliṉa eḻuttukkaḷ: olikaḷum vitikaḷum"
+          ],
+          "shelfMark": [
+            "*OLB 83-2757"
+          ],
+          "creatorLiteral": [
+            "Natarajan, Subbiah, 1911-"
+          ],
+          "createdString": [
+            "197"
+          ],
+          "idLccn": [
+            "75906338"
+          ],
+          "dateStartYear": [
+            197
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 83-2757"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004504"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75906338"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304869"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204496"
+            }
+          ],
+          "updatedAt": 1636132308475,
+          "publicationStatement": [
+            "[Tūttukkuṭi]: Naṭarācaṉ, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10004504",
+            "urn:lccn:75906338",
+            "urn:undefined:NNSZ00304869",
+            "urn:undefined:(WaOLN)nyp0204496"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "197"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Pronunciation."
+          ],
+          "titleDisplay": [
+            "Tamiḻ valliṉa eḻuttukkaḷ: olikaḷum vitikaḷum/ Cu. Naṭarājaṉ."
+          ],
+          "uri": "b10004504",
+          "lccClassification": [
+            "PL4754 .N33 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Tūttukkuṭi]:"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10004504"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061296681"
+                    ],
+                    "physicalLocation": [
+                      "*OLB 83-2757"
+                    ],
+                    "shelfMark_sort": "a*OLB 83-002757",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784546",
+                    "shelfMark": [
+                      "*OLB 83-2757"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLB 83-2757"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061296681"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433061296681"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004672",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "106 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "P. Vaillant,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1775
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "All in the wrong [microform] : a comedy, as it is acted at the Theatre-Royal in Drury-Lane"
+          ],
+          "shelfMark": [
+            "*ZC-177"
+          ],
+          "creatorLiteral": [
+            "Murphy, Arthur, 1727-1805."
+          ],
+          "createdString": [
+            "1775"
+          ],
+          "dateStartYear": [
+            1775
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZC-177"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004672"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405783"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204664"
+            }
+          ],
+          "updatedAt": 1636073146019,
+          "publicationStatement": [
+            "London : P. Vaillant, 1775."
+          ],
+          "identifier": [
+            "urn:bnum:10004672",
+            "urn:undefined:NNSZ00405783",
+            "urn:undefined:(WaOLN)nyp0204664"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1775"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "All in the wrong [microform] : a comedy, as it is acted at the Theatre-Royal in Drury-Lane / by Mr. Murphy."
+          ],
+          "uri": "b10004672",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "12⁰."
+          ]
+        },
+        "sort": [
+          "b10004672"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004849",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[8], 48 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Samaritans"
+          ],
+          "publisherLiteral": [
+            "Sumtu Io. Bielckii,"
+          ],
+          "language": [
+            {
+              "id": "lang:lat",
+              "label": "Latin"
+            }
+          ],
+          "createdYear": [
+            1688
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Christophori Cellarii Collectanea historiae Samaritanae : quibus praeter res geographicas, tam politia huius gentis, quam religio et res litteraria explicantur."
+          ],
+          "shelfMark": [
+            "**P 07-283"
+          ],
+          "creatorLiteral": [
+            "Cellarius, Christoph, 1638-1707."
+          ],
+          "createdString": [
+            "1688"
+          ],
+          "dateStartYear": [
+            1688
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "**P 07-283"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004849"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405962"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204839"
+            }
+          ],
+          "updatedAt": 1636081486226,
+          "publicationStatement": [
+            "Cizae : Sumtu Io. Bielckii, 1688."
+          ],
+          "identifier": [
+            "urn:bnum:10004849",
+            "urn:undefined:NNSZ00405962",
+            "urn:undefined:(WaOLN)nyp0204839"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1688"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Samaritans."
+          ],
+          "titleDisplay": [
+            "Christophori Cellarii Collectanea historiae Samaritanae : quibus praeter res geographicas, tam politia huius gentis, quam religio et res litteraria explicantur."
+          ],
+          "uri": "b10004849",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Cizae :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Collectanea historiae Samaritanae."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10004849"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746564",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:maf88",
+                        "label": "Schwarzman Building - Dorot Jewish Division Room 111"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:maf88||Schwarzman Building - Dorot Jewish Division Room 111"
+                    ],
+                    "shelfMark": [
+                      "**P 07-283"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "**P 07-283",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433075470579"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "**P 07-283"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433075470579"
+                    ],
+                    "idBarcode": [
+                      "33433075470579"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:a",
+                        "label": "By appointment only"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:a||By appointment only"
+                    ],
+                    "shelfMark_sort": "a**P 07-000283"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005935",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[12] leaves : col. ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "J. Vlieger"
+          ],
+          "language": [
+            {
+              "id": "lang:dut",
+              "label": "Dutch"
+            }
+          ],
+          "dateEndString": [
+            "1899"
+          ],
+          "createdYear": [
+            1800
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "De 10 kleine nikkertjes."
+          ],
+          "shelfMark": [
+            "Sc Rare F 83-57"
+          ],
+          "createdString": [
+            "1800"
+          ],
+          "dateStartYear": [
+            1800
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare F 83-57"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005935"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507149"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205924"
+            }
+          ],
+          "dateEndYear": [
+            1899
+          ],
+          "updatedAt": 1654777212731,
+          "publicationStatement": [
+            "Amsterdam : J. Vlieger, [18--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10005935",
+            "urn:undefined:NNSZ00507149",
+            "urn:undefined:(WaOLN)nyp0205924"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1800"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "De 10 kleine nikkertjes."
+          ],
+          "uri": "b10005935",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Tien Kleine nikkertjes."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10005935"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10005935-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=De+10+kleine+nikkertjes.&Site=SCHRB&CallNumber=Sc+Rare+F+83-57&ItemPlace=Amsterdam+:&ItemPublisher=J.+Vlieger,&Date=[18--?]&ItemInfo3=https://catalog.nypl.org/record=b10005935&ReferenceNumber=b100059351&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036926669&ItemISxN=i119005189&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10005935-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900518",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare F 83-57"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare F 83-57",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036926669"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare F 83-57"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036926669"
+                    ],
+                    "idBarcode": [
+                      "33433036926669"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=De+10+kleine+nikkertjes.&Site=SCHRB&CallNumber=Sc+Rare+F+83-57&ItemPlace=Amsterdam+:&ItemPublisher=J.+Vlieger,&Date=[18--?]&ItemInfo3=https://catalog.nypl.org/record=b10005935&ReferenceNumber=b100059351&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036926669&ItemISxN=i119005189&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare F 83-000057"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005945",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[4], iv, 5-62 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Indexed In",
+              "label": "Sabin",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "of Sidney Lapidus; ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Copy in Sc Rare E 16-46 (Lapidus Collection) disbound.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Slave-trade",
+            "Slave-trade -- West Indies, British.",
+            "Slave-trade -- West Indies, British. -- Early works to 1800",
+            "Slavery",
+            "Slavery -- West Indies, British.",
+            "Slavery -- West Indies, British. -- Early works to 1800",
+            "Slavery -- Law and legislation",
+            "Slavery -- Law and legislation -- Jamaica",
+            "Slavery -- Law and legislation -- Jamaica -- Early works to 1800"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Printed and sold by James Philips"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            4
+          ],
+          "createdYear": [
+            1789
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Notes on the two reports from the Committee of the Honourable House of Assembly of Jamaica: appointed to examine into, and to report to the House, the allegations and charges contained in the several petitions which have been presented to the British House of Commons, on the subject of the slave-trade, and the treatment of the Negroes,&c.&c.&c."
+          ],
+          "shelfMark": [
+            "Sc Rare F 83-78"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Fuller, Stephen, 1716-1808."
+          ],
+          "createdString": [
+            "1789"
+          ],
+          "numElectronicResources": [
+            2
+          ],
+          "contributorLiteral": [
+            "Jamaica. Assembly."
+          ],
+          "dateStartYear": [
+            1789
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare F 83-78"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005945"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG005000087-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507159"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205933"
+            }
+          ],
+          "idOclc": [
+            "NYPG005000087-B"
+          ],
+          "updatedAt": 1675264202226,
+          "publicationStatement": [
+            "London : Printed and sold by James Philips, 1789."
+          ],
+          "identifier": [
+            "urn:bnum:10005945",
+            "urn:oclc:NYPG005000087-B",
+            "urn:undefined:NNSZ00507159",
+            "urn:undefined:(WaOLN)nyp0205933"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1789"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Slave-trade -- West Indies, British. -- Early works to 1800.",
+            "Slavery -- West Indies, British. -- Early works to 1800.",
+            "Slavery -- Law and legislation -- Jamaica -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "Notes on the two reports from the Committee of the Honourable House of Assembly of Jamaica: appointed to examine into, and to report to the House, the allegations and charges contained in the several petitions which have been presented to the British House of Commons, on the subject of the slave-trade, and the treatment of the Negroes,&c.&c.&c. / by a Jamaica planter."
+          ],
+          "uri": "b10005945",
+          "numItems": [
+            4
+          ],
+          "numAvailable": [
+            4
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10005945"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10005945-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Notes+on+the+two+reports+from+the+Committee+of+the+Honourable+House+of+Assembly+of+Jamaica:+appointed+to+examine+into,+and+to+report+to+the+House,+the+allegations+and+charges+contained+in+the+several+petitions+which+have+been+presented+to+the+British+House+of+Commons,+on+the+subject+of+the+slave-trade,+and+the+treatment+of+the+Negroes,andc.andc.andc.+/&Site=SASRB&CallNumber=8-*KF+1789+(Notes+on+the+two+reports)+*KF+1789+(Notes+on+the+two+reports)&Author=Fuller,+Stephen,&ItemPlace=London+:&ItemPublisher=Printed+and+sold+by+James+Philips,&Date=1789.&ItemInfo3=https://catalog.nypl.org/record=b10005945&ReferenceNumber=b100059454&Genre=Book-text&Location=Schwarzman+Rare+Book+Division",
+                        "label": "Request access to this item in the Schwarzman Rare Books Collection"
+                      },
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Notes+on+the+two+reports+from+the+Committee+of+the+Honourable+House+of+Assembly+of+Jamaica:+appointed+to+examine+into,+and+to+report+to+the+House,+the+allegations+and+charges+contained+in+the+several+petitions+which+have+been+presented+to+the+British+House+of+Commons,+on+the+subject+of+the+slave-trade,+and+the+treatment+of+the+Negroes,andc.andc.andc.+/&Site=SCHRB&CallNumber=Sc+Rare+F+83-78&Author=Fuller,+Stephen,&ItemPlace=London+:&ItemPublisher=Printed+and+sold+by+James+Philips,&Date=1789.&ItemInfo3=https://catalog.nypl.org/record=b10005945&ReferenceNumber=b100059454&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "bi10005945-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 4,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003913",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare F 83-78"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare F 83-78",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076159494"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare F 83-78"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076159494"
+                    ],
+                    "idBarcode": [
+                      "33433076159494"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Notes+on+the+two+reports+from+the+Committee+of+the+Honourable+House+of+Assembly+of+Jamaica:+appointed+to+examine+into,+and+to+report+to+the+House,+the+allegations+and+charges+contained+in+the+several+petitions+which+have+been+presented+to+the+British+House+of+Commons,+on+the+subject+of+the+slave-trade,+and+the+treatment+of+the+Negroes,andc.andc.andc.+/&Site=SCHRB&CallNumber=8-*KF+1789+(Notes+on+the+two+reports)+*KF+1789+(Notes+on+the+two+reports)&Author=Fuller,+Stephen,&ItemPlace=London+:&ItemPublisher=Printed+and+sold+by+James+Philips,&Date=1789.&ItemInfo3=https://catalog.nypl.org/record=b10005945&ReferenceNumber=b100059454&Genre=Book-text&Location=Schwarzman+Rare+Book+Division"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aSc Rare F 83-000078"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34051315",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare E 16-46 (Lapidus Collection)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare E 16-46 (Lapidus Collection)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433117263263"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare E 16-46 (Lapidus Collection)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433117263263"
+                    ],
+                    "idBarcode": [
+                      "33433117263263"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Notes+on+the+two+reports+from+the+Committee+of+the+Honourable+House+of+Assembly+of+Jamaica:+appointed+to+examine+into,+and+to+report+to+the+House,+the+allegations+and+charges+contained+in+the+several+petitions+which+have+been+presented+to+the+British+House+of+Commons,+on+the+subject+of+the+slave-trade,+and+the+treatment+of+the+Negroes,andc.andc.andc.+/&Site=SCHRB&CallNumber=8-*KF+1789+(Notes+on+the+two+reports)+*KF+1789+(Notes+on+the+two+reports)&Author=Fuller,+Stephen,&ItemPlace=London+:&ItemPublisher=Printed+and+sold+by+James+Philips,&Date=1789.&ItemInfo3=https://catalog.nypl.org/record=b10005945&ReferenceNumber=b100059454&Genre=Book-text&Location=Schwarzman+Rare+Book+Division"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aSc Rare E 16-46 (Lapidus Collection)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003915",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1108",
+                        "label": "Rare Book Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1108||Rare Book Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:marr2",
+                        "label": "Schwarzman Building - Rare Book Collection Room 328"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:marr2||Schwarzman Building - Rare Book Collection Room 328"
+                    ],
+                    "shelfMark": [
+                      "8-*KF 1789 (Notes on the two reports)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "8-*KF 1789 (Notes on the two reports)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "8-*KF 1789 (Notes on the two reports)"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:4",
+                        "label": "Restricted use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:4||Restricted use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Notes+on+the+two+reports+from+the+Committee+of+the+Honourable+House+of+Assembly+of+Jamaica:+appointed+to+examine+into,+and+to+report+to+the+House,+the+allegations+and+charges+contained+in+the+several+petitions+which+have+been+presented+to+the+British+House+of+Commons,+on+the+subject+of+the+slave-trade,+and+the+treatment+of+the+Negroes,andc.andc.andc.+/&Site=SASRB&CallNumber=8-*KF+1789+(Notes+on+the+two+reports)+*KF+1789+(Notes+on+the+two+reports)&Author=Fuller,+Stephen,&ItemPlace=London+:&ItemPublisher=Printed+and+sold+by+James+Philips,&Date=1789.&ItemInfo3=https://catalog.nypl.org/record=b10005945&ReferenceNumber=b100059454&Genre=Book-text&Location=Schwarzman+Rare+Book+Division"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a8-*KF 1789 (Notes on the two reports)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003914",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1108",
+                        "label": "Rare Book Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1108||Rare Book Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:marr2",
+                        "label": "Schwarzman Building - Rare Book Collection Room 328"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:marr2||Schwarzman Building - Rare Book Collection Room 328"
+                    ],
+                    "shelfMark": [
+                      "*KF 1789 (Notes on the two reports)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*KF 1789 (Notes on the two reports)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*KF 1789 (Notes on the two reports)"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:4",
+                        "label": "Restricted use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:4||Restricted use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Notes+on+the+two+reports+from+the+Committee+of+the+Honourable+House+of+Assembly+of+Jamaica:+appointed+to+examine+into,+and+to+report+to+the+House,+the+allegations+and+charges+contained+in+the+several+petitions+which+have+been+presented+to+the+British+House+of+Commons,+on+the+subject+of+the+slave-trade,+and+the+treatment+of+the+Negroes,andc.andc.andc.+/&Site=SASRB&CallNumber=8-*KF+1789+(Notes+on+the+two+reports)+*KF+1789+(Notes+on+the+two+reports)&Author=Fuller,+Stephen,&ItemPlace=London+:&ItemPublisher=Printed+and+sold+by+James+Philips,&Date=1789.&ItemInfo3=https://catalog.nypl.org/record=b10005945&ReferenceNumber=b100059454&Genre=Book-text&Location=Schwarzman+Rare+Book+Division"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*KF 1789 (Notes on the two reports)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005951",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "150, [10] p. : folded col. map ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Bound in leather.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Almanacs, Jamaican",
+            "Jamaica",
+            "Jamaica -- Registers"
+          ],
+          "publisherLiteral": [
+            "Printed by David Dickson for Thomas Stevenson"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1794
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The New Jamaica almanack, and register ... for the year of Our Lord 1795 ... ."
+          ],
+          "shelfMark": [
+            "Sc Rare B 83-2"
+          ],
+          "createdString": [
+            "1794"
+          ],
+          "dateStartYear": [
+            1794
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare B 83-2"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005951"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507166"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205940"
+            }
+          ],
+          "updatedAt": 1654777211068,
+          "publicationStatement": [
+            "Kingston : Printed by David Dickson for Thomas Stevenson, [1794?]"
+          ],
+          "identifier": [
+            "urn:bnum:10005951",
+            "urn:undefined:NNSZ00507166",
+            "urn:undefined:(WaOLN)nyp0205940"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1794"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Almanacs, Jamaican.",
+            "Jamaica -- Registers."
+          ],
+          "titleDisplay": [
+            "The New Jamaica almanack, and register ... for the year of Our Lord 1795 ... ."
+          ],
+          "uri": "b10005951",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kingston"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "15 cm."
+          ]
+        },
+        "sort": [
+          "b10005951"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10005951-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=The+New+Jamaica+almanack,+and+register+...+for+the+year+of+Our+Lord+1795+...+.&Site=SCHRB&CallNumber=Sc+Rare+B+83-2&ItemPlace=Kingston+:&ItemPublisher=Printed+by+David+Dickson+for+Thomas+Stevenson,&Date=[1794?]&ItemInfo3=https://catalog.nypl.org/record=b10005951&ReferenceNumber=b10005951x&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036926776&ItemISxN=i119005281&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10005951-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900528",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare B 83-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare B 83-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036926776"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare B 83-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036926776"
+                    ],
+                    "idBarcode": [
+                      "33433036926776"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=The+New+Jamaica+almanack,+and+register+...+for+the+year+of+Our+Lord+1795+...+.&Site=SCHRB&CallNumber=Sc+Rare+B+83-2&ItemPlace=Kingston+:&ItemPublisher=Printed+by+David+Dickson+for+Thomas+Stevenson,&Date=[1794?]&ItemInfo3=https://catalog.nypl.org/record=b10005951&ReferenceNumber=b10005951x&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036926776&ItemISxN=i119005281&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare B 83-000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005958",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "66 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Indexed In",
+              "label": "Sabin",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Garran de Coulon, Jean Philippe, 1748-1816",
+            "Haiti",
+            "Haiti -- History",
+            "Haiti -- History -- Revolution, 1791-1804"
+          ],
+          "publisherLiteral": [
+            "Se vend chez Maret, Desenne, et chez tous les marchands de nouveautés"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1797
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lettre de Michel-Pascal Creuzé à Jean-Philippe Garan sur son rapport des troubles de St-Domingue : distribué au Corps législatif en ventôse, an V, dix-huit mois apres la clôture des débats."
+          ],
+          "shelfMark": [
+            "*KF 1797 (Creuzé-Dufresne, M. P. Lettre de Michel Pascal Creuzé)"
+          ],
+          "creatorLiteral": [
+            "Creuzé-Dufresne, Michel Pascal."
+          ],
+          "createdString": [
+            "1797"
+          ],
+          "dateStartYear": [
+            1797
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*KF 1797 (Creuzé-Dufresne, M. P. Lettre de Michel Pascal Creuzé)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005958"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507175"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205949"
+            }
+          ],
+          "updatedAt": 1654780361497,
+          "publicationStatement": [
+            "Paris : Se vend chez Maret, Desenne, et chez tous les marchands de nouveautés, an 5 [1797]"
+          ],
+          "identifier": [
+            "urn:bnum:10005958",
+            "urn:undefined:NNSZ00507175",
+            "urn:undefined:(WaOLN)nyp0205949"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1797"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Garran de Coulon, Jean Philippe, 1748-1816.",
+            "Haiti -- History -- Revolution, 1791-1804."
+          ],
+          "titleDisplay": [
+            "Lettre de Michel-Pascal Creuzé à Jean-Philippe Garan sur son rapport des troubles de St-Domingue : distribué au Corps législatif en ventôse, an V, dix-huit mois apres la clôture des débats."
+          ],
+          "uri": "b10005958",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10005958"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10005958-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Lettre+de+Michel-Pascal+Creuzé+à+Jean-Philippe+Garan+sur+son+rapport+des+troubles+de+St-Domingue+:+distribué+au+Corps+législatif+en+ventôse,+an+V,+dix-huit+mois+apres+la+clôture+des+débats.&Site=SASRB&CallNumber=*KF+1797+(Creuzé,+M.+P.+Lettre+de+Michel+Pascal+Creuzé)&Author=Creuzé-Dufresne,+Michel+Pascal.&ItemPlace=Paris+:&ItemPublisher=Se+vend+chez+Maret,+Desenne,+et+chez+tous+les+marchands+de+nouveautés,&Date=an+5+[1797]&ItemInfo3=https://catalog.nypl.org/record=b10005958&ReferenceNumber=b100059582&ItemISxN=i100039182&Genre=Book-text&Location=Schwarzman+Rare+Book+Division",
+                        "label": "Request access to this item in the Schwarzman Rare Books Collection"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10005958-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003918",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1108",
+                        "label": "Rare Book Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1108||Rare Book Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:marr2",
+                        "label": "Schwarzman Building - Rare Book Collection Room 328"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:marr2||Schwarzman Building - Rare Book Collection Room 328"
+                    ],
+                    "shelfMark": [
+                      "*KF 1797 (Creuzé, M. P. Lettre de Michel Pascal Creuzé)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*KF 1797 (Creuzé, M. P. Lettre de Michel Pascal Creuzé)",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*KF 1797 (Creuzé, M. P. Lettre de Michel Pascal Creuzé)"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:4",
+                        "label": "Restricted use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:4||Restricted use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Lettre+de+Michel-Pascal+Creuzé+à+Jean-Philippe+Garan+sur+son+rapport+des+troubles+de+St-Domingue+:+distribué+au+Corps+législatif+en+ventôse,+an+V,+dix-huit+mois+apres+la+clôture+des+débats.&Site=SASRB&CallNumber=*KF+1797+(Creuzé,+M.+P.+Lettre+de+Michel+Pascal+Creuzé)&Author=Creuzé-Dufresne,+Michel+Pascal.&ItemPlace=Paris+:&ItemPublisher=Se+vend+chez+Maret,+Desenne,+et+chez+tous+les+marchands+de+nouveautés,&Date=an+5+[1797]&ItemInfo3=https://catalog.nypl.org/record=b10005958&ReferenceNumber=b100059582&ItemISxN=i100039182&Genre=Book-text&Location=Schwarzman+Rare+Book+Division"
+                    ],
+                    "shelfMark_sort": "a*KF 1797 (Creuzé, M. P. Lettre de Michel Pascal Creuzé)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006047",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[12] p. of plates : all col. ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ethiopia",
+            "Ethiopia -- Pictorial works",
+            "Ethiopia -- Social life and customs"
+          ],
+          "publisherLiteral": [
+            "A. Vallardi"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "dateEndString": [
+            "1899"
+          ],
+          "createdYear": [
+            1800
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Usi e costumi dell' Abissinia e dei dintorni di Massaua"
+          ],
+          "shelfMark": [
+            "Sc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)"
+          ],
+          "createdString": [
+            "1800"
+          ],
+          "contributorLiteral": [
+            "Pasini, Lazzaro."
+          ],
+          "dateStartYear": [
+            1800
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006047"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507270"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206040"
+            }
+          ],
+          "dateEndYear": [
+            1899
+          ],
+          "updatedAt": 1654777378164,
+          "publicationStatement": [
+            "Milano : A. Vallardi, [18--]"
+          ],
+          "identifier": [
+            "urn:bnum:10006047",
+            "urn:undefined:NNSZ00507270",
+            "urn:undefined:(WaOLN)nyp0206040"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1800"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ethiopia -- Pictorial works.",
+            "Ethiopia -- Social life and customs."
+          ],
+          "titleDisplay": [
+            "Usi e costumi dell' Abissinia e dei dintorni di Massaua / da originali acquarelli di un indigeno, riprodotti da Laz. Pasini."
+          ],
+          "uri": "b10006047",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Milano"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 x 21 cm."
+          ]
+        },
+        "sort": [
+          "b10006047"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10006047-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Usi+e+costumi+dell'+Abissinia+e+dei+dintorni+di+Massaua+/&Site=SCHRB&CallNumber=Sc+Rare+C+84-8&ItemPlace=Milano+:&ItemPublisher=A.+Vallardi,&Date=[18--]&ItemInfo3=https://catalog.nypl.org/record=b10006047&ReferenceNumber=b10006047x&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433076137185&ItemISxN=i10003925x&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10006047-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003925",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 84-8"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 84-8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076137185"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 84-8"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076137185"
+                    ],
+                    "idBarcode": [
+                      "33433076137185"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Usi+e+costumi+dell'+Abissinia+e+dei+dintorni+di+Massaua+/&Site=SCHRB&CallNumber=Sc+Rare+C+84-8&ItemPlace=Milano+:&ItemPublisher=A.+Vallardi,&Date=[18--]&ItemInfo3=https://catalog.nypl.org/record=b10006047&ReferenceNumber=b10006047x&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433076137185&ItemISxN=i10003925x&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 84-000008"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003926",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019684897"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019684897"
+                    ],
+                    "idBarcode": [
+                      "33433019684897"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc 916.3-P (Pasini, L. Usi e costumi dell'Abissinia)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006816",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[11], 144 p."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Nella stamperia di Gennaro Muzio,"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "createdYear": [
+            1725
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "La somiglianza [microform] : commedia"
+          ],
+          "shelfMark": [
+            "*Z-3500"
+          ],
+          "creatorLiteral": [
+            "Amenta, Niccolò, 1659-1719."
+          ],
+          "createdString": [
+            "1725"
+          ],
+          "dateStartYear": [
+            1725
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3500"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006816"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00508052"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206802"
+            }
+          ],
+          "updatedAt": 1636111583127,
+          "publicationStatement": [
+            "In Napoli : Nella stamperia di Gennaro Muzio, 1725."
+          ],
+          "identifier": [
+            "urn:bnum:10006816",
+            "urn:undefined:NNSZ00508052",
+            "urn:undefined:(WaOLN)nyp0206802"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1725"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "La somiglianza [microform] : commedia / del dottor ... Niccolò Amenta ..."
+          ],
+          "uri": "b10006816",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "In Napoli :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ]
+        },
+        "sort": [
+          "b10006816"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107660718"
+                    ],
+                    "physicalLocation": [
+                      "*Z-3500"
+                    ],
+                    "shelfMark_sort": "a*Z-003500",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003967",
+                    "shelfMark": [
+                      "*Z-3500"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*Z-3500"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107660718"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433107660718"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10007423",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "184 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Muʼassisah-ʼi Khāvar"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1334"
+          ],
+          "createdYear": [
+            1333
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʻĀlam va Ādam"
+          ],
+          "shelfMark": [
+            "*OMO 84-2676"
+          ],
+          "creatorLiteral": [
+            "Vafā ʻAlī Shāh."
+          ],
+          "createdString": [
+            "1333"
+          ],
+          "dateStartYear": [
+            1333
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMO 84-2676"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10007423"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00508668"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0207407"
+            }
+          ],
+          "dateEndYear": [
+            1334
+          ],
+          "updatedAt": 1653404639396,
+          "publicationStatement": [
+            "Tihrān : Muʼassisah-ʼi Khāvar, 1312 [1933 or 1934]"
+          ],
+          "identifier": [
+            "urn:bnum:10007423",
+            "urn:undefined:NNSZ00508668",
+            "urn:undefined:(WaOLN)nyp0207407"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1333"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "ʻĀlam va Ādam / a̲sar-i khāmah-ʼi Mīrzā Hādī Mawlavī Rash̄tī ; bi-himmat-i Muḥammad Ramazānī."
+          ],
+          "uri": "b10007423",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10007423"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001898570"
+                    ],
+                    "physicalLocation": [
+                      "*OMO 84-2676"
+                    ],
+                    "shelfMark_sort": "a*OMO 84-002676",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10004294",
+                    "shelfMark": [
+                      "*OMO 84-2676"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMO 84-2676"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001898570"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001898570"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10007812",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "176 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "French wit and humor",
+            "French wit and humor -- France"
+          ],
+          "publisherLiteral": [
+            "A. Pierret,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1899"
+          ],
+          "createdYear": [
+            1800
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sac à juifs [microform] : recueil de scènes et récits satiriques et humoristiques"
+          ],
+          "shelfMark": [
+            "*ZP-687 no. 9"
+          ],
+          "creatorLiteral": [
+            "La Badine, C. de."
+          ],
+          "createdString": [
+            "1800"
+          ],
+          "dateStartYear": [
+            1800
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZP-687 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10007812"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00609209"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0207795"
+            }
+          ],
+          "dateEndYear": [
+            1899
+          ],
+          "updatedAt": 1637634877781,
+          "publicationStatement": [
+            "Paris : A. Pierret, [18--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10007812",
+            "urn:undefined:NNSZ00609209",
+            "urn:undefined:(WaOLN)nyp0207795"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1800"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "French wit and humor -- France."
+          ],
+          "titleDisplay": [
+            "Sac à juifs [microform] : recueil de scènes et récits satiriques et humoristiques / par C. de La Badine ; illus. de Bocardho."
+          ],
+          "uri": "b10007812",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "12⁰."
+          ]
+        },
+        "sort": [
+          "b10007812"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008934",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "536 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Aristotle",
+            "Porphyry, approximately 234-approximately 305"
+          ],
+          "publisherLiteral": [
+            "G. Olms,"
+          ],
+          "language": [
+            {
+              "id": "lang:lat",
+              "label": "Latin"
+            }
+          ],
+          "dateEndString": [
+            "1597"
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "In Porphyrii Isagogen et Aristotelis Organum : commentarius analyticus"
+          ],
+          "shelfMark": [
+            "JFD 85-2807"
+          ],
+          "creatorLiteral": [
+            "Pace, Giulio, 1550-1635."
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFD 85-2807"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008934"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00810450"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0208909"
+            }
+          ],
+          "dateEndYear": [
+            1597
+          ],
+          "updatedAt": 1636105378000,
+          "publicationStatement": [
+            "Hildesheim : G. Olms, 1966."
+          ],
+          "identifier": [
+            "urn:bnum:10008934",
+            "urn:undefined:NNSZ00810450",
+            "urn:undefined:(WaOLN)nyp0208909"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Aristotle.",
+            "Porphyry, approximately 234-approximately 305."
+          ],
+          "titleDisplay": [
+            "In Porphyrii Isagogen et Aristotelis Organum : commentarius analyticus / Julius Pacius."
+          ],
+          "uri": "b10008934",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Hildesheim :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10008934"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858678",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFD 85-2807"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFD 85-2807",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433038876987"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFD 85-2807"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433038876987"
+                    ],
+                    "idBarcode": [
+                      "33433038876987"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFD 85-002807"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009127",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "84 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "God (Islam)",
+            "God (Islam) -- Attributes"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1268"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Fatwá al-Ḥamawīyah al-kubrá,"
+          ],
+          "shelfMark": [
+            "*OGM 85-1727"
+          ],
+          "creatorLiteral": [
+            "Ibn Taymīyah, Aḥmad ibn ʻAbd al-Ḥalīm, 1263-1328."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "76961126"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGM 85-1727"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009127"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76961126"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00810649"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209102"
+            }
+          ],
+          "dateEndYear": [
+            1268
+          ],
+          "updatedAt": 1636072369613,
+          "publicationStatement": [
+            "[al-Qāhirah, al-Maṭbaʻah al-Salafīyah wa-Maktabatuhā, 1967 or 8]"
+          ],
+          "identifier": [
+            "urn:bnum:10009127",
+            "urn:lccn:76961126",
+            "urn:undefined:NNSZ00810649",
+            "urn:undefined:(WaOLN)nyp0209102"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "God (Islam) -- Attributes."
+          ],
+          "titleDisplay": [
+            "al-Fatwá al-Ḥamawīyah al-kubrá, taʼlīf Taqī al-Dīn Aḥmad ibn Taymīyah. Nasharahā Quṣay Muḥibb al-Dīn al-Khaṭīb."
+          ],
+          "uri": "b10009127",
+          "lccClassification": [
+            "BP166.2 .I24 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[al-Qāhirah, al-Maṭbaʻah al-Salafīyah wa-Maktabatuhā, 1967 or 8]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10009127"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001945694"
+                    ],
+                    "physicalLocation": [
+                      "*OGM 85-1727"
+                    ],
+                    "shelfMark_sort": "a*OGM 85-001727",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10004965",
+                    "shelfMark": [
+                      "*OGM 85-1727"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OGM 85-1727"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001945694"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001945694"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009912",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[4] p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Alva, Juan de"
+          ],
+          "publisherLiteral": [
+            "Imprenta de Alonso del Riego"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "1799"
+          ],
+          "createdYear": [
+            1700
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Romance famoso : en que se refieren las grandes hazañas del valiente negro en Flandes, llamado Juan de Alva, y la mucho que el Rey nuestro Señor premio sus hechos."
+          ],
+          "shelfMark": [
+            "Sc Rare+ F 82-61"
+          ],
+          "createdString": [
+            "1700"
+          ],
+          "dateStartYear": [
+            1700
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare+ F 82-61"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009912"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00911389"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209888"
+            }
+          ],
+          "dateEndYear": [
+            1799
+          ],
+          "updatedAt": 1654777211068,
+          "publicationStatement": [
+            "Valladolid : Imprenta de Alonso del Riego, [17--?]"
+          ],
+          "identifier": [
+            "urn:bnum:10009912",
+            "urn:undefined:NNSZ00911389",
+            "urn:undefined:(WaOLN)nyp0209888"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1700"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Alva, Juan de."
+          ],
+          "titleDisplay": [
+            "Romance famoso : en que se refieren las grandes hazañas del valiente negro en Flandes, llamado Juan de Alva, y la mucho que el Rey nuestro Señor premio sus hechos."
+          ],
+          "uri": "b10009912",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Valladolid"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10009912"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10009912-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Romance+famoso+:+en+que+se+refieren+las+grandes+hazañas+del+valiente+negro+en+Flandes,+llamado+Juan+de+Alva,+y+la+mucho+que+el+Rey+nuestro+Señor+premio+sus+hechos.&Site=SCHRB&CallNumber=Sc+Rare%2b+F+82-61&ItemPlace=Valladolid+:&ItemPublisher=Imprenta+de+Alonso+del+Riego,&Date=[17--?]&ItemInfo3=https://catalog.nypl.org/record=b10009912&ReferenceNumber=b100099129&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036926867&ItemISxN=i11901001x&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10009912-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901001",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare+ F 82-61"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare+ F 82-61",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036926867"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare+ F 82-61"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036926867"
+                    ],
+                    "idBarcode": [
+                      "33433036926867"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Romance+famoso+:+en+que+se+refieren+las+grandes+hazañas+del+valiente+negro+en+Flandes,+llamado+Juan+de+Alva,+y+la+mucho+que+el+Rey+nuestro+Señor+premio+sus+hechos.&Site=SCHRB&CallNumber=Sc+Rare%2b+F+82-61&ItemPlace=Valladolid+:&ItemPublisher=Imprenta+de+Alonso+del+Riego,&Date=[17--?]&ItemInfo3=https://catalog.nypl.org/record=b10009912&ReferenceNumber=b100099129&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036926867&ItemISxN=i11901001x&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare+ F 82-000061"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009988",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "5 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Coutilien Coutard, Philippe-Jérome",
+            "Haiti",
+            "Haiti -- History",
+            "Haiti -- History -- 1804-1844",
+            "Haiti -- History -- Revolution, 1791-1804"
+          ],
+          "publisherLiteral": [
+            "Impr. du gouvernement,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1899"
+          ],
+          "createdYear": [
+            1800
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Discours aux Haïtiens, ou, Hommage au dévouement patriotique de Coutillien [microform]"
+          ],
+          "shelfMark": [
+            "Sc Micro F-10834"
+          ],
+          "creatorLiteral": [
+            "Marion, Ignace Despontreaux."
+          ],
+          "createdString": [
+            "1800"
+          ],
+          "dateStartYear": [
+            1800
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro F-10834"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009988"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209965"
+            }
+          ],
+          "dateEndYear": [
+            1899
+          ],
+          "updatedAt": 1643680852554,
+          "publicationStatement": [
+            "Aux Cayes : Impr. du gouvernement, [185-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10009988",
+            "urn:undefined:(WaOLN)nyp0209965"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1800"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Coutilien Coutard, Philippe-Jérome.",
+            "Haiti -- History -- 1804-1844.",
+            "Haiti -- History -- Revolution, 1791-1804."
+          ],
+          "titleDisplay": [
+            "Discours aux Haïtiens, ou, Hommage au dévouement patriotique de Coutillien [microform] / par A.J. Despontreau Marion."
+          ],
+          "uri": "b10009988",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Aux Cayes :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Hommage au dévouement patriotique de Coutillien"
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10009988"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13965122",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro F-10900 Library has: Vol. 3, no. 5-v. 3, no. 7 (June-Aug. 1919)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro F-10900 Library has: Vol. 3, no. 5-v. 3, no. 7 (June-Aug. 1919)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058298906"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro F-10900 Library has: Vol. 3, no. 5-v. 3, no. 7 (June-Aug. 1919)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058298906"
+                    ],
+                    "idBarcode": [
+                      "33433058298906"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro F-10900 Library has: Vol. 3, no. 000005-v. 3, no. 7 (June-Aug. 1919)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785539",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:26",
+                        "label": "microfiche"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:26||microfiche"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff3",
+                        "label": "Schomburg Center - Research & Reference - Desk"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff3||Schomburg Center - Research & Reference - Desk"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro F-10834"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro F-10834",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058299276"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro F-10834"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058299276"
+                    ],
+                    "idBarcode": [
+                      "33433058299276"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro F-010834"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010385",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 microfilm reel ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "On reel with: Jamaica 1871-1943 (except 1934), Panama Canal Zone 1912",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "United States Virgin Islands",
+            "United States Virgin Islands -- Census"
+          ],
+          "publisherLiteral": [
+            "Research Publications,"
+          ],
+          "language": [
+            {
+              "id": "lang:und",
+              "label": "Undetermined"
+            }
+          ],
+          "createdYear": [
+            198
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "U.S. Virgin Islands--Census 1901, pt. 1, 1911, pt. 1 [microform]."
+          ],
+          "shelfMark": [
+            "*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands"
+          ],
+          "createdString": [
+            "198"
+          ],
+          "seriesStatement": [
+            "International population census publications [pre-1945]. Latin America"
+          ],
+          "dateStartYear": [
+            198
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010385"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01012026"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210361"
+            }
+          ],
+          "updatedAt": 1636140635056,
+          "publicationStatement": [
+            "Woodbridge, Conn. : Research Publications, [1983]"
+          ],
+          "identifier": [
+            "urn:bnum:10010385",
+            "urn:undefined:NNSZ01012026",
+            "urn:undefined:(WaOLN)nyp0210361"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "198"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "United States Virgin Islands -- Census."
+          ],
+          "titleDisplay": [
+            "U.S. Virgin Islands--Census 1901, pt. 1, 1911, pt. 1 [microform]."
+          ],
+          "uri": "b10010385",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Woodbridge, Conn. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 mm."
+          ]
+        },
+        "sort": [
+          "b10010385"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433094813171"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i27849993",
+                    "shelfMark": [
+                      "*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZAN-T4817 Latin America & the Caribbean: Jamaica, Panama Canal Zone, U.S. Virgin Islands"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433094813171"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433094813171"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010607",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 broadside ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Facsimile reproduction (photoreproduction).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Alembert, Jean Le Rond d', 1717-1783",
+            "Diderot, Denis, 1713-1784",
+            "Encyclopédie"
+          ],
+          "publisherLiteral": [
+            "Ex Typographia Reverendae Camerae Apostolicae,"
+          ],
+          "language": [
+            {
+              "id": "lang:lat",
+              "label": "Latin"
+            }
+          ],
+          "createdYear": [
+            1759
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Damnatio, et prohibitio operis in plures tomos distributi, cujus est titulus Encyclopedie, ou Dictionaire raisonné des sciences, des arts, & des metiers, par une société de gens de lettres, mis en ordre, & publié par Mr. Diderot de l'Academie royale des sciences, & des belles lettres de Prusse, & quant a la partie mathematique, par Mr. d'Alembert de l'Academie royale de Sciences de Paris, de celle de Prusse, & de la Société royale de Londres [microform]"
+          ],
+          "shelfMark": [
+            "*Z-3852 no. 26"
+          ],
+          "creatorLiteral": [
+            "Catholic Church. Pope (1758-1769 : Clement XIII)"
+          ],
+          "createdString": [
+            "1759"
+          ],
+          "dateStartYear": [
+            1759
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3852 no. 26"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010607"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)13888170"
+            }
+          ],
+          "updatedAt": 1636086132775,
+          "publicationStatement": [
+            "Romae : Ex Typographia Reverendae Camerae Apostolicae, 1759."
+          ],
+          "identifier": [
+            "urn:bnum:10010607",
+            "urn:undefined:(OCoLC)13888170"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1759"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Alembert, Jean Le Rond d', 1717-1783.",
+            "Diderot, Denis, 1713-1784.",
+            "Encyclopédie."
+          ],
+          "titleDisplay": [
+            "Damnatio, et prohibitio operis in plures tomos distributi, cujus est titulus Encyclopedie, ou Dictionaire raisonné des sciences, des arts, & des metiers, par une société de gens de lettres, mis en ordre, & publié par Mr. Diderot de l'Academie royale des sciences, & des belles lettres de Prusse, & quant a la partie mathematique, par Mr. d'Alembert de l'Academie royale de Sciences de Paris, de celle de Prusse, & de la Société royale de Londres [microform] / Clemens Papa XIII ad futuram rei memoriam."
+          ],
+          "uri": "b10010607",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Romae :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "37 cm"
+          ]
+        },
+        "sort": [
+          "b10010607"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433107973277"
+                    ],
+                    "physicalLocation": [
+                      "*Z-3852"
+                    ],
+                    "shelfMark_sort": "a*Z-3852 no. 000001-27",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30458802",
+                    "shelfMark": [
+                      "*Z-3852 no. 1-27"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*Z-3852 no. 1-27"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433107973277"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-27"
+                    ],
+                    "idBarcode": [
+                      "33433107973277"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010675",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Description based on: No. 2 (1975).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "English or Spanish.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "American literature",
+            "American literature -- Mexican American authors",
+            "American literature -- Mexican American authors -- Periodicals",
+            "American poetry",
+            "American poetry -- Mexican American authors",
+            "American poetry -- Mexican American authors -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Pajarito Publications."
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "19"
+          ],
+          "createdYear": [
+            19
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Flor y canto."
+          ],
+          "shelfMark": [
+            "JFL 81-111"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "19"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            19
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 81-111"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010675"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG0110-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210651"
+            }
+          ],
+          "idOclc": [
+            "NYPG0110-S"
+          ],
+          "dateEndYear": [
+            19
+          ],
+          "updatedAt": 1669925867950,
+          "publicationStatement": [
+            "Albuquerque : Pajarito Publications."
+          ],
+          "identifier": [
+            "urn:bnum:10010675",
+            "urn:oclc:NYPG0110-S",
+            "urn:undefined:(WaOLN)nyp0210651"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "19"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "American literature -- Mexican American authors -- Periodicals.",
+            "American poetry -- Mexican American authors -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Flor y canto."
+          ],
+          "uri": "b10010675",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Albuquerque"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10010675"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10005340",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFL 81-111 v. 2-5 1975-78"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFL 81-111 v. 2-5 1975-78",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005304187"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2-5 1975-78"
+                    ],
+                    "physicalLocation": [
+                      "JFL 81-111"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005304187"
+                    ],
+                    "idBarcode": [
+                      "33433005304187"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 5
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFL 81-111 v. 000002-5 1975-78"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011031",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ill."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "State universities and colleges",
+            "State universities and colleges -- United States",
+            "State universities and colleges -- United States -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            999
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "AASCU studies."
+          ],
+          "shelfMark": [
+            "JLM 81-389"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "American Association of State Colleges and Universities."
+          ],
+          "createdString": [
+            "999"
+          ],
+          "idLccn": [
+            "72621307"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLM 81-389"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011031"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72621307"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "7994181"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "7994181"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG0111-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)7994181"
+            }
+          ],
+          "idOclc": [
+            "7994181",
+            "NYPG0111-S"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1669918566353,
+          "publicationStatement": [
+            "[Washington]"
+          ],
+          "identifier": [
+            "urn:bnum:10011031",
+            "urn:lccn:72621307",
+            "urn:oclc:7994181",
+            "urn:oclc:NYPG0111-S",
+            "urn:undefined:(WaOLN)nyp0211007",
+            "urn:undefined:(OCoLC)7994181"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "State universities and colleges -- United States -- Periodicals."
+          ],
+          "titleDisplay": [
+            "AASCU studies."
+          ],
+          "uri": "b10011031",
+          "lccClassification": [
+            "LB2329.5.A43"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Washington]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "A. A. S. C. U. studies."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10011031"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540542",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-389 1970-1974"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-389 1970-1974",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017529995"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1970-1974"
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-389"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017529995"
+                    ],
+                    "idBarcode": [
+                      "33433017529995"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJLM 81-389 1970-001974"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011036",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Numbering",
+              "label": "Vols. for 1980-   called 1st-   annual supplement.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Continues: Equal employment opportunity court cases, ISSN 0272-278x, issued by: United States. Civil Service Commission. Bureau of Intergovernmental Personnel Programs. (Earlier title cataloged as monograph. See entry under: United States. Civil Service Commission. Bureau of Intergovernmental Personnel Programs).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Discrimination in employment",
+            "Discrimination in employment -- Digests",
+            "Discrimination in employment -- Digests -- United States",
+            "Discrimination in employment -- Digests -- United States -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "U.S. Office of Personnel Management, Office of Intergovernmental Programs : For sale by the Supt. of Docs., U.S. G.P.O."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            999
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Equal employment opportunity court cases."
+          ],
+          "shelfMark": [
+            "JLM 81-385"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "999"
+          ],
+          "idLccn": [
+            "80647817"
+          ],
+          "seriesStatement": [
+            "OIPP"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "United States. Office of Intergovernmental Personnel Programs."
+          ],
+          "dateStartYear": [
+            999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLM 81-385"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011036"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80647817"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "6784164"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "6784164"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG0116-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0011050"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0000038"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)6784164"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "RCON-EPA"
+            }
+          ],
+          "idOclc": [
+            "6784164",
+            "NYPG0116-S"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1670012393617,
+          "publicationStatement": [
+            "Washington : U.S. Office of Personnel Management, Office of Intergovernmental Programs : For sale by the Supt. of Docs., U.S. G.P.O."
+          ],
+          "identifier": [
+            "urn:bnum:10011036",
+            "urn:lccn:80647817",
+            "urn:oclc:6784164",
+            "urn:oclc:NYPG0116-S",
+            "urn:undefined:(WaOLN)nyp0011050",
+            "urn:undefined:(WaOLN)nyp0000038",
+            "urn:undefined:(OCoLC)6784164",
+            "urn:undefined:RCON-EPA"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Discrimination in employment -- Digests -- United States -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Equal employment opportunity court cases."
+          ],
+          "uri": "b10011036",
+          "lccClassification": [
+            "PAR"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Washington"
+          ],
+          "titleAlt": [
+            "Equal employment opportunity court cases"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10011036"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540547",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-385 1980"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-385 1980",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017529912"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1980"
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-385"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017529912"
+                    ],
+                    "idBarcode": [
+                      "33433017529912"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJLM 81-385 001980"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011041",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ill., ports."
+          ],
+          "note": [
+            {
+              "noteType": "Supplement",
+              "label": "Supplement accompany some issues.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Journalism",
+            "Journalism -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            9
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            9
+          ],
+          "createdYear": [
+            999
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bulletin."
+          ],
+          "shelfMark": [
+            "M-10 3102"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "American Society of Newspaper Editors."
+          ],
+          "createdString": [
+            "999"
+          ],
+          "idLccn": [
+            "59037860 //r82"
+          ],
+          "idIssn": [
+            "0003-1178"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "M-10 3102"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011041"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0003-1178"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "59037860 //r82"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG0120-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0011055"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0000039"
+            }
+          ],
+          "idOclc": [
+            "NYPG0120-S"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1675264982433,
+          "publicationStatement": [
+            "Easton, Pa. [etc.]"
+          ],
+          "identifier": [
+            "urn:bnum:10011041",
+            "urn:issn:0003-1178",
+            "urn:lccn:59037860 //r82",
+            "urn:oclc:NYPG0120-S",
+            "urn:undefined:(WaOLN)nyp0011055",
+            "urn:undefined:(WaOLN)nyp0000039"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Journalism -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Bulletin."
+          ],
+          "uri": "b10011041",
+          "lccClassification": [
+            "PN4700 .A58"
+          ],
+          "numItems": [
+            9
+          ],
+          "numAvailable": [
+            9
+          ],
+          "placeOfPublication": [
+            "Easton, Pa. [etc.]"
+          ],
+          "titleAlt": [
+            "The Bulletin of the American Society of Newspaper Editors"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10011041"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 9,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901117",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 601-629 Jan. 1977-Jan. 1980"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 601-629 Jan. 1977-Jan. 1980",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676884"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "nos. 601-629 Jan. 1977-Jan. 1980"
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676884"
+                    ],
+                    "idBarcode": [
+                      "33433010676884"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1977",
+                        "lte": "1980"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1977"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 601-629 Jan. 1977-Jan. 001980"
+                  },
+                  "sort": [
+                    "          -1977"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901116",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 574-600 1974-76"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 574-600 1974-76",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676876"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "nos. 574-600 1974-76"
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676876"
+                    ],
+                    "idBarcode": [
+                      "33433010676876"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1974",
+                        "lte": "1976"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1974"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 574-600 1974-000076"
+                  },
+                  "sort": [
+                    "          -1974"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901115",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 547-57 1971-73"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 547-57 1971-73",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676868"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "nos. 547-57 1971-73"
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676868"
+                    ],
+                    "idBarcode": [
+                      "33433010676868"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1971",
+                        "lte": "1973"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1971"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 547-57 1971-000073"
+                  },
+                  "sort": [
+                    "          -1971"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901114",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 515-546 1968-70"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 515-546 1968-70",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676850"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "nos. 515-546 1968-70"
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676850"
+                    ],
+                    "idBarcode": [
+                      "33433010676850"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1968",
+                        "lte": "1970"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1968"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 515-546 1968-000070"
+                  },
+                  "sort": [
+                    "          -1968"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901113",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 482-514 1965-67"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 482-514 1965-67",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676843"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "nos. 482-514 1965-67"
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676843"
+                    ],
+                    "idBarcode": [
+                      "33433010676843"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1965",
+                        "lte": "1967"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1965"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 482-514 1965-000067"
+                  },
+                  "sort": [
+                    "          -1965"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901112",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 460-481 1963-64"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 460-481 1963-64",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676835"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "nos. 460-481 1963-64"
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676835"
+                    ],
+                    "idBarcode": [
+                      "33433010676835"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1963",
+                        "lte": "1964"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1963"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 460-481 1963-000064"
+                  },
+                  "sort": [
+                    "          -1963"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901111",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 438-459 1961-62"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 438-459 1961-62",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676827"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "nos. 438-459 1961-62"
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676827"
+                    ],
+                    "idBarcode": [
+                      "33433010676827"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1961",
+                        "lte": "1962"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1961"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 438-459 1961-000062"
+                  },
+                  "sort": [
+                    "          -1961"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901110",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 416-437 1959-60"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 416-437 1959-60",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676819"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "nos. 416-437 1959-60"
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676819"
+                    ],
+                    "idBarcode": [
+                      "33433010676819"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1959",
+                        "lte": "1960"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1959"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 416-437 1959-000060"
+                  },
+                  "sort": [
+                    "          -1959"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901109",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "M-10 3102 nos. 383-415 1956-58"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "M-10 3102 nos. 383-415 1956-58",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433010676801"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "nos. 383-415 1956-58"
+                    ],
+                    "physicalLocation": [
+                      "M-10 3102"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433010676801"
+                    ],
+                    "idBarcode": [
+                      "33433010676801"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1956",
+                        "lte": "1958"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1956"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aM-10 3102 nos. 383-415 1956-000058"
+                  },
+                  "sort": [
+                    "          -1956"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011321",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[6], 72 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "German and Hebrew.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrew language",
+            "Hebrew language -- Grammar",
+            "Aramaic language",
+            "Aramaic language -- Grammar"
+          ],
+          "publisherLiteral": [
+            "Wittwe Vandenhöck"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1770
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Johann Ernst Fabers Anmerkungen zur Erlernung des Talmudischen und Rabbinischen."
+          ],
+          "shelfMark": [
+            "*PCQ 85-1669"
+          ],
+          "creatorLiteral": [
+            "Faber, Johann Ernst, 1746-1774."
+          ],
+          "createdString": [
+            "1770"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1770
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*PCQ 85-1669"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011321"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01213287"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211293"
+            }
+          ],
+          "updatedAt": 1661953355475,
+          "publicationStatement": [
+            "Göttingen : Wittwe Vandenhöck, 1770."
+          ],
+          "identifier": [
+            "urn:bnum:10011321",
+            "urn:undefined:NNSZ01213287",
+            "urn:undefined:(WaOLN)nyp0211293"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1770"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrew language -- Grammar.",
+            "Aramaic language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Johann Ernst Fabers Anmerkungen zur Erlernung des Talmudischen und Rabbinischen."
+          ],
+          "uri": "b10011321",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Göttingen"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Anmerkungen zur Erlernung des Talmudischen und Rabbinischen."
+          ],
+          "dimensions": [
+            "19cm."
+          ]
+        },
+        "sort": [
+          "b10011321"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747226",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:maf98",
+                        "label": "Schwarzman Building M2 - Dorot Jewish Division Room 111"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:maf98||Schwarzman Building M2 - Dorot Jewish Division Room 111"
+                    ],
+                    "shelfMark": [
+                      "**P-*PCQ 85-1669"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "**P-*PCQ 85-1669",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433089858876"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "**P-*PCQ 85-1669"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433089858876"
+                    ],
+                    "idBarcode": [
+                      "33433089858876"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:a",
+                        "label": "By appointment only"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:a||By appointment only"
+                    ],
+                    "shelfMark_sort": "a**P-*PCQ 85-001669"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011751",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Results of a survey of RMA member banks.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "-1987."
+          ],
+          "subjectLiteral_exploded": [
+            "Robert Morris Associates",
+            "Robert Morris Associates -- Periodicals",
+            "Bank loans",
+            "Bank loans -- United States",
+            "Bank loans -- United States -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Robert Morris Associates."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            198
+          ],
+          "dateEndString": [
+            "1987"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Report on domestic and international loan charge-offs."
+          ],
+          "shelfMark": [
+            "JLM 81-449"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Robert Morris Associates."
+          ],
+          "createdString": [
+            "198"
+          ],
+          "idLccn": [
+            "80640293"
+          ],
+          "idIssn": [
+            "0196-724X"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            198
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLM 81-449"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011751"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0196-724X"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80640293"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG0129-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211718"
+            }
+          ],
+          "idOclc": [
+            "NYPG0129-S"
+          ],
+          "dateEndYear": [
+            1987
+          ],
+          "updatedAt": 1670259686970,
+          "publicationStatement": [
+            "Philadelphia, Robert Morris Associates."
+          ],
+          "identifier": [
+            "urn:bnum:10011751",
+            "urn:issn:0196-724X",
+            "urn:lccn:80640293",
+            "urn:oclc:NYPG0129-S",
+            "urn:undefined:(WaOLN)nyp0211718"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "198"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Robert Morris Associates -- Periodicals.",
+            "Bank loans -- United States -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Report on domestic and international loan charge-offs."
+          ],
+          "uri": "b10011751",
+          "lccClassification": [
+            "HG1642.U5 R58a"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Philadelphia"
+          ],
+          "titleAlt": [
+            "Report on domestic and international loan charge-offs"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10011751"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540558",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-449 1978-1983, 1987."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-449 1978-1983, 1987.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019908379"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1978-1983, 1987."
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-449"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019908379"
+                    ],
+                    "idBarcode": [
+                      "33433019908379"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJLM 81-449 1978-1983, 1987."
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10012379",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "712 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A service book of the Armenian church.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In classical Armenian (Grabar)",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Armenian Church",
+            "Armenian Church -- Liturgy"
+          ],
+          "publisherLiteral": [
+            "Tpeal hramanaw Teaṛn Zakʻariay azgasēr ev barekarg Patriargi"
+          ],
+          "language": [
+            {
+              "id": "lang:arm",
+              "label": "Armenian"
+            }
+          ],
+          "createdYear": [
+            1795
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kargavorutʻyun Hasarakatsʻ Aghotʻitsʻ Hayastaneaytsʻ Ekeghetsʻwoy."
+          ],
+          "shelfMark": [
+            "*ONN 86-1887"
+          ],
+          "creatorLiteral": [
+            "Armenian Church."
+          ],
+          "createdString": [
+            "1795"
+          ],
+          "dateStartYear": [
+            1795
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ONN 86-1887"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10012379"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01314364"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0212344"
+            }
+          ],
+          "updatedAt": 1654794066679,
+          "publicationStatement": [
+            "Kostandnupolis : Tpeal hramanaw Teaṛn Zakʻariay azgasēr ev barekarg Patriargi, 1795."
+          ],
+          "identifier": [
+            "urn:bnum:10012379",
+            "urn:undefined:NNSZ01314364",
+            "urn:undefined:(WaOLN)nyp0212344"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1795"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Armenian Church -- Liturgy."
+          ],
+          "titleDisplay": [
+            "Kargavorutʻyun Hasarakatsʻ Aghotʻitsʻ Hayastaneaytsʻ Ekeghetsʻwoy."
+          ],
+          "uri": "b10012379",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kostandnupolis"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "17 cm."
+          ]
+        },
+        "sort": [
+          "b10012379"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10012379-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Kargavorutʻyun+Hasarakatsʻ+Aghotʻitsʻ+Hayastaneaytsʻ+Ekeghetsʻwoy.&Site=SASRB&CallNumber=*ONN+86-1887+(Locked+cage)&Author=Armenian+Church.&ItemPlace=Kostandnupolis+:&ItemPublisher=Tpeal+hramanaw+Teaṛn+Zakʻariay+azgas&#x113;r+ev+barekarg+Patriargi,&Date=1795.&ItemInfo3=https://catalog.nypl.org/record=b10012379&ReferenceNumber=b10012379x&ItemNumber=33433057787578&ItemISxN=i125405972&Genre=Book-text&Location=Schwarzman+Rare+Book+Division",
+                        "label": "Request access to this item in the Schwarzman Rare Books Collection"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10012379-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540597",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1108",
+                        "label": "Rare Book Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1108||Rare Book Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:marr2",
+                        "label": "Schwarzman Building - Rare Book Collection Room 328"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:marr2||Schwarzman Building - Rare Book Collection Room 328"
+                    ],
+                    "shelfMark": [
+                      "*ONN 86-1887"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ONN 86-1887",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057787578"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ONN 86-1887"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057787578"
+                    ],
+                    "idBarcode": [
+                      "33433057787578"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:4",
+                        "label": "Restricted use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:4||Restricted use"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Kargavorutʻyun+Hasarakatsʻ+Aghotʻitsʻ+Hayastaneaytsʻ+Ekeghetsʻwoy.&Site=SASRB&CallNumber=*ONN+86-1887+(Locked+cage)&Author=Armenian+Church.&ItemPlace=Kostandnupolis+:&ItemPublisher=Tpeal+hramanaw+Teaṛn+Zakʻariay+azgas&#x113;r+ev+barekarg+Patriargi,&Date=1795.&ItemInfo3=https://catalog.nypl.org/record=b10012379&ReferenceNumber=b10012379x&ItemNumber=33433057787578&ItemISxN=i125405972&Genre=Book-text&Location=Schwarzman+Rare+Book+Division"
+                    ],
+                    "shelfMark_sort": "a*ONN 86-001887"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10012504",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Description based on: Sept. 1, 1933.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Issues for 1933-1957 called v. <16-39>.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Began in 1918"
+          ],
+          "subjectLiteral_exploded": [
+            "Labor unions",
+            "Labor unions -- Miners",
+            "Labor unions -- Miners -- United States",
+            "Labor unions -- Miners -- United States -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            16
+          ],
+          "publisherLiteral": [
+            "Districts No. 1, 7, and 9, United Mine Workers of America"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            16
+          ],
+          "dateEndString": [
+            "19"
+          ],
+          "createdYear": [
+            1918
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Anthracite tri-district news : official organ for Districts No. 1, 7, and 9, United Mine Workers of America."
+          ],
+          "shelfMark": [
+            "TDRA+++ (Anthracite tri-district news)"
+          ],
+          "numItemVolumesParsed": [
+            16
+          ],
+          "createdString": [
+            "1918"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "United Mine Workers of America. District No. 1.",
+            "United Mine Workers of America. District No. 7.",
+            "United Mine Workers of America. District No. 9."
+          ],
+          "dateStartYear": [
+            1918
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "TDRA+++ (Anthracite tri-district news)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10012504"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG0131-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0212468"
+            }
+          ],
+          "idOclc": [
+            "NYPG0131-S"
+          ],
+          "dateEndYear": [
+            19
+          ],
+          "updatedAt": 1675267526996,
+          "publicationStatement": [
+            "Hazelton, Pa. : Districts No. 1, 7, and 9, United Mine Workers of America"
+          ],
+          "identifier": [
+            "urn:bnum:10012504",
+            "urn:oclc:NYPG0131-S",
+            "urn:undefined:(WaOLN)nyp0212468"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1918"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Labor unions -- Miners -- United States -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Anthracite tri-district news : official organ for Districts No. 1, 7, and 9, United Mine Workers of America."
+          ],
+          "uri": "b10012504",
+          "numItems": [
+            16
+          ],
+          "numAvailable": [
+            16
+          ],
+          "placeOfPublication": [
+            "Hazelton, Pa."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "57 cm."
+          ]
+        },
+        "sort": [
+          "b10012504"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 16,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859081",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 33 (1950)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 33 (1950)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102232"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 33 (1950)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102232"
+                    ],
+                    "idBarcode": [
+                      "33433057102232"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 33,
+                        "lte": 33
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1950",
+                        "lte": "1950"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        33-1950"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000033 (1950)"
+                  },
+                  "sort": [
+                    "        33-1950"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859080",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 32 (1949)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 32 (1949)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102224"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 32 (1949)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102224"
+                    ],
+                    "idBarcode": [
+                      "33433057102224"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 32,
+                        "lte": 32
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1949",
+                        "lte": "1949"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        32-1949"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000032 (1949)"
+                  },
+                  "sort": [
+                    "        32-1949"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859079",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 30 (1947)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 30 (1947)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102216"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 30 (1947)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102216"
+                    ],
+                    "idBarcode": [
+                      "33433057102216"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 30,
+                        "lte": 30
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1947",
+                        "lte": "1947"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        30-1947"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000030 (1947)"
+                  },
+                  "sort": [
+                    "        30-1947"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 12
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859078",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 29 (1946)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 29 (1946)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102208"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 29 (1946)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102208"
+                    ],
+                    "idBarcode": [
+                      "33433057102208"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 29,
+                        "lte": 29
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1946",
+                        "lte": "1946"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        29-1946"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000029 (1946)"
+                  },
+                  "sort": [
+                    "        29-1946"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859077",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 28 (1945)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 28 (1945)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102190"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 28 (1945)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102190"
+                    ],
+                    "idBarcode": [
+                      "33433057102190"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 28,
+                        "lte": 28
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1945",
+                        "lte": "1945"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        28-1945"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000028 (1945)"
+                  },
+                  "sort": [
+                    "        28-1945"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859076",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 27 (1944)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 27 (1944)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102182"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 27 (1944)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102182"
+                    ],
+                    "idBarcode": [
+                      "33433057102182"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 27,
+                        "lte": 27
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1944",
+                        "lte": "1944"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        27-1944"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000027 (1944)"
+                  },
+                  "sort": [
+                    "        27-1944"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859075",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 26 (1943)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 26 (1943)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102174"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 26 (1943)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102174"
+                    ],
+                    "idBarcode": [
+                      "33433057102174"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 26,
+                        "lte": 26
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1943",
+                        "lte": "1943"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        26-1943"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000026 (1943)"
+                  },
+                  "sort": [
+                    "        26-1943"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859074",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 25 (1942)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 25 (1942)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102166"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 25 (1942)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102166"
+                    ],
+                    "idBarcode": [
+                      "33433057102166"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 25,
+                        "lte": 25
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1942",
+                        "lte": "1942"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        25-1942"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000025 (1942)"
+                  },
+                  "sort": [
+                    "        25-1942"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859073",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 24 (1941)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 24 (1941)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102158"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 24 (1941)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102158"
+                    ],
+                    "idBarcode": [
+                      "33433057102158"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 24,
+                        "lte": 24
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1941",
+                        "lte": "1941"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        24-1941"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000024 (1941)"
+                  },
+                  "sort": [
+                    "        24-1941"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859072",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 23 (1940)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 23 (1940)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057102141"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 23 (1940)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057102141"
+                    ],
+                    "idBarcode": [
+                      "33433057102141"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 23,
+                        "lte": 23
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1940",
+                        "lte": "1940"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        23-1940"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000023 (1940)"
+                  },
+                  "sort": [
+                    "        23-1940"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859071",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 22 (1939)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 22 (1939)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057100301"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 22 (1939)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057100301"
+                    ],
+                    "idBarcode": [
+                      "33433057100301"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 22,
+                        "lte": 22
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1939",
+                        "lte": "1939"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        22-1939"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000022 (1939)"
+                  },
+                  "sort": [
+                    "        22-1939"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859070",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 21 (1938)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 21 (1938)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057100293"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 21 (1938)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057100293"
+                    ],
+                    "idBarcode": [
+                      "33433057100293"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 21,
+                        "lte": 21
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1938",
+                        "lte": "1938"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        21-1938"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000021 (1938)"
+                  },
+                  "sort": [
+                    "        21-1938"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859069",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 20 (1937)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 20 (1937)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057100285"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 20 (1937)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057100285"
+                    ],
+                    "idBarcode": [
+                      "33433057100285"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 20,
+                        "lte": 20
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1937",
+                        "lte": "1937"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        20-1937"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000020 (1937)"
+                  },
+                  "sort": [
+                    "        20-1937"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859068",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 19 (1936)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 19 (1936)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057100277"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 19 (1936)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057100277"
+                    ],
+                    "idBarcode": [
+                      "33433057100277"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 19,
+                        "lte": 19
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1936",
+                        "lte": "1936"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        19-1936"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000019 (1936)"
+                  },
+                  "sort": [
+                    "        19-1936"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859067",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 18 (1935)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 18 (1935)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057100269"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 18 (1935)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057100269"
+                    ],
+                    "idBarcode": [
+                      "33433057100269"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 18,
+                        "lte": 18
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1935",
+                        "lte": "1935"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        18-1935"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000018 (1935)"
+                  },
+                  "sort": [
+                    "        18-1935"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12859066",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "TDRA+++ (Anthracite tri-district news) v. 17 (Jan. 5-Dec. 28, 1934)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "TDRA+++ (Anthracite tri-district news) v. 17 (Jan. 5-Dec. 28, 1934)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057100251"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 17 (Jan. 5-Dec. 28, 1934)"
+                    ],
+                    "physicalLocation": [
+                      "TDRA+++ (Anthracite tri-district news)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057100251"
+                    ],
+                    "idBarcode": [
+                      "33433057100251"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:o",
+                        "label": "Oversize"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:o||Oversize"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 17,
+                        "lte": 17
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1934",
+                        "lte": "1934"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        17-1934"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aTDRA+++ (Anthracite tri-district news) v. 000017 (Jan. 5-Dec. 28, 1934)"
+                  },
+                  "sort": [
+                    "        17-1934"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10012514",
+        "_score": null,
+        "_source": {
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Genealogy",
+            "Clark County (Wash.)",
+            "Clark County (Wash.) -- Genealogy",
+            "Clark County (Wash.) -- Genealogy -- Periodicals",
+            "Washington (State)",
+            "Washington (State) -- Clark County",
+            "United States, Washington",
+            "United States, Washington -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            25
+          ],
+          "publisherLiteral": [
+            "Clark County Genealogical Society."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            25
+          ],
+          "createdYear": [
+            999
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Trail breakers."
+          ],
+          "shelfMark": [
+            "APR (Clark Co., Wash.) 81-297"
+          ],
+          "numItemVolumesParsed": [
+            25
+          ],
+          "createdString": [
+            "999"
+          ],
+          "idLccn": [
+            "   76641407"
+          ],
+          "idIssn": [
+            "0362-0344"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Clark County Genealogical Society (Clark County, Wash.)"
+          ],
+          "dateStartYear": [
+            999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "APR (Clark Co., Wash.) 81-297"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10012514"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0362-0344"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   76641407"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "2441280"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "2441280"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)2441280"
+            }
+          ],
+          "idOclc": [
+            "2441280"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "2:1(Sep 1975)-33(Jun. 2006-Jun. 2007).",
+                "Directory (of society's officers and other sources)  1984/1985 bound with v.10 & v.11"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 27 No. 1 (Fall 2000)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 27 No. 2 (Winter 2001)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 27 No. 3 (Spring 2001)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 27 No. 4 (Summer 2001)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 28 No. 1-3 (Fall 2001)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 29 No. 1 (Fall 2002)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 29 No. 2 (Winter 2003)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 29 No. 3/4 (Spring 2003)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 30 No. 1 (Fall 2003)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Unavailable"
+                },
+                {
+                  "coverage": "Vol. 30 No. 2 (Winter 2004)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 30 No. 3/4 (Spring 2004)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                },
+                {
+                  "coverage": "Vol. 31-32 No. 1 (2004)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Out of Print"
+                },
+                {
+                  "coverage": "No. 33 (Jul. 2006 - Jun. 2007)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APR (Clark Co., Wash.) 81-297"
+                  ],
+                  "status": "Bind Prep"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "APR (Clark Co., Wash.) 81-297"
+                }
+              ],
+              "notes": [
+                "QUARTERLY",
+                "\"Directory\" of same society collected and bound separately under : APR (Clark Co., Wash.) 83-333.",
+                "ISSN number: 0362-0344"
+              ],
+              "physicalLocation": [
+                "APR (Clark Co., Wash.) 81-297"
+              ],
+              "format": [
+                "CURRENT IN U.S. HISTORY & GENEALOGY + HOLDINGS"
+              ],
+              "location": [
+                {
+                  "code": "loc:mag",
+                  "label": "Schwarzman Building - Milstein Division Room 121"
+                }
+              ],
+              "uri": "h1031662",
+              "shelfMark": [
+                "APR (Clark Co., Wash.) 81-297"
+              ]
+            }
+          ],
+          "updatedAt": 1675271833667,
+          "publicationStatement": [
+            "Vancouver, Wash., Clark County Genealogical Society."
+          ],
+          "identifier": [
+            "urn:bnum:10012514",
+            "urn:issn:0362-0344",
+            "urn:lccn:   76641407",
+            "urn:oclc:2441280",
+            "urn:undefined:(OCoLC)2441280"
+          ],
+          "genreForm": [
+            "Periodicals."
+          ],
+          "numCheckinCardItems": [
+            13
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Genealogy.",
+            "Clark County (Wash.) -- Genealogy -- Periodicals.",
+            "Washington (State) -- Clark County.",
+            "United States, Washington -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Trail breakers."
+          ],
+          "uri": "b10012514",
+          "lccClassification": [
+            "F897.C6 T7"
+          ],
+          "numItems": [
+            12
+          ],
+          "numAvailable": [
+            12
+          ],
+          "placeOfPublication": [
+            "Vancouver, Wash."
+          ],
+          "titleAlt": [
+            "Trail breakers"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "28 cm"
+          ]
+        },
+        "sort": [
+          "b10012514"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 12,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 24
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34246372",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 27-33, inc. (Fall 2000 - July 2006-June 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 27-33, inc. (Fall 2000 - July 2006-June 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433089464600"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 27-33, inc. (Fall 2000 - July 2006-June 2007)"
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433089464600"
+                    ],
+                    "idBarcode": [
+                      "33433089464600"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 27,
+                        "lte": 33
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        27-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000027-33, inc. (Fall 2000 - July 2006-June 2007)"
+                  },
+                  "sort": [
+                    "        27-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 23
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901144",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 25-26 (Fall. 1998-Sum. 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 25-26 (Fall. 1998-Sum. 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031851227"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 25-26 (Fall. 1998-Sum. 2000)"
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433031851227"
+                    ],
+                    "idBarcode": [
+                      "33433031851227"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 25,
+                        "lte": 26
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1998",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        25-1998"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000025-26 (Fall. 1998-Sum. 2000)"
+                  },
+                  "sort": [
+                    "        25-1998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 22
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901143",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 23-24 (Fall. 1996-Sum. 1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 23-24 (Fall. 1996-Sum. 1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031851219"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 23-24 (Fall. 1996-Sum. 1998)"
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433031851219"
+                    ],
+                    "idBarcode": [
+                      "33433031851219"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 23,
+                        "lte": 24
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1998"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        23-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000023-24 (Fall. 1996-Sum. 1998)"
+                  },
+                  "sort": [
+                    "        23-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 21
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747357",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 21-22 (Fall. 1994-Sum. 1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 21-22 (Fall. 1994-Sum. 1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480177"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 21-22 (Fall. 1994-Sum. 1996)"
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480177"
+                    ],
+                    "idBarcode": [
+                      "33433062480177"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 21,
+                        "lte": 22
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        21-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000021-22 (Fall. 1994-Sum. 1996)"
+                  },
+                  "sort": [
+                    "        21-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 20
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747356",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 18-20 (Fall. 1991-Sum. 1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 18-20 (Fall. 1991-Sum. 1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480169"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 18-20 (Fall. 1991-Sum. 1994)"
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480169"
+                    ],
+                    "idBarcode": [
+                      "33433062480169"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 18,
+                        "lte": 20
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1991",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        18-1991"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000018-20 (Fall. 1991-Sum. 1994)"
+                  },
+                  "sort": [
+                    "        18-1991"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 19
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747355",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 16-17 (1989-1991)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 16-17 (1989-1991)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480151"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 16-17 (1989-1991)"
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480151"
+                    ],
+                    "idBarcode": [
+                      "33433062480151"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 16,
+                        "lte": 17
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1989",
+                        "lte": "1991"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        16-1989"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000016-17 (1989-1991)"
+                  },
+                  "sort": [
+                    "        16-1989"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 18
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747354",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 14-15 (1987-1989)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 14-15 (1987-1989)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480144"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 14-15 (1987-1989)"
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480144"
+                    ],
+                    "idBarcode": [
+                      "33433062480144"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 14,
+                        "lte": 15
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1987",
+                        "lte": "1989"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        14-1987"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000014-15 (1987-1989)"
+                  },
+                  "sort": [
+                    "        14-1987"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 17
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747353",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 12-13 (Fall. 1985-Sum. 1987)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 12-13 (Fall. 1985-Sum. 1987)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480136"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 12-13 (Fall. 1985-Sum. 1987)"
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480136"
+                    ],
+                    "idBarcode": [
+                      "33433062480136"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 12,
+                        "lte": 13
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1985",
+                        "lte": "1987"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        12-1985"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000012-13 (Fall. 1985-Sum. 1987)"
+                  },
+                  "sort": [
+                    "        12-1985"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747352",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 10-11 (1983-1985)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 10-11 (1983-1985)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480128"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 10-11 (1983-1985)"
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480128"
+                    ],
+                    "idBarcode": [
+                      "33433062480128"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 10,
+                        "lte": 11
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1983",
+                        "lte": "1985"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        10-1983"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000010-11 (1983-1985)"
+                  },
+                  "sort": [
+                    "        10-1983"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747351",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 8-9 (1981-1983)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 8-9 (1981-1983)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480110"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 8-9 (1981-1983)"
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480110"
+                    ],
+                    "idBarcode": [
+                      "33433062480110"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 8,
+                        "lte": 9
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1981",
+                        "lte": "1983"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         8-1981"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000008-9 (1981-1983)"
+                  },
+                  "sort": [
+                    "         8-1981"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747350",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 5-7 (Sep. 1978-Sum. 1981)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 5-7 (Sep. 1978-Sum. 1981)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480102"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 5-7 (Sep. 1978-Sum. 1981)"
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480102"
+                    ],
+                    "idBarcode": [
+                      "33433062480102"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 7
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1978",
+                        "lte": "1981"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-1978"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000005-7 (Sep. 1978-Sum. 1981)"
+                  },
+                  "sort": [
+                    "         5-1978"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747349",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Clark Co., Wash.) 81-297 v. 2-4 (1975-1978)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Clark Co., Wash.) 81-297 v. 2-4 (1975-1978)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062480094"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2-4 (1975-1978)"
+                    ],
+                    "physicalLocation": [
+                      "APR (Clark Co., Wash.) 81-297"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062480094"
+                    ],
+                    "idBarcode": [
+                      "33433062480094"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 4
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1975",
+                        "lte": "1978"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-1975"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aAPR (Clark Co., Wash.) 81-297 v. 000002-4 (1975-1978)"
+                  },
+                  "sort": [
+                    "         2-1975"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10012515",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Numbering",
+              "label": "Feb.-June 1928 also called year 3.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "no.   -123;   -June 22, 1928"
+          ],
+          "subjectLiteral_exploded": [
+            "Jews",
+            "Jews -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Jewish Graphic, Ltd."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1928"
+          ],
+          "createdYear": [
+            192
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The Jewish graphic."
+          ],
+          "shelfMark": [
+            "*ZAN-*P519"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "192"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            192
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZAN-*P519"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10012515"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG0140-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0212479"
+            }
+          ],
+          "idOclc": [
+            "NYPG0140-S"
+          ],
+          "dateEndYear": [
+            1928
+          ],
+          "updatedAt": 1670010190628,
+          "publicationStatement": [
+            "London : Jewish Graphic, Ltd."
+          ],
+          "identifier": [
+            "urn:bnum:10012515",
+            "urn:oclc:NYPG0140-S",
+            "urn:undefined:(WaOLN)nyp0212479"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "192"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jews -- Periodicals."
+          ],
+          "titleDisplay": [
+            "The Jewish graphic."
+          ],
+          "uri": "b10012515",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "42 cm."
+          ]
+        },
+        "sort": [
+          "b10012515"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10006287",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:maf82",
+                        "label": "Schwarzman Building - Dorot Jewish Division Room 111"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:maf82||Schwarzman Building - Dorot Jewish Division Room 111"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-*P519 Sept. 23, 1927-Jun 22, 1928 (Inc.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-*P519 Sept. 23, 1927-Jun 22, 1928 (Inc.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433092672512"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Sept. 23, 1927-Jun 22, 1928 (Inc.)"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-*P519"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433092672512"
+                    ],
+                    "idBarcode": [
+                      "33433092672512"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-*P519 Sept. 23, 1927-Jun 22, 1928 (Inc.)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013199",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Volume 1 only. No more published.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Administrative agencies",
+            "Administrative agencies -- Argentina",
+            "Argentina",
+            "Argentina -- Politics and government",
+            "Argentina -- Politics and government -- 1983-"
+          ],
+          "publisherLiteral": [
+            "Asociación Argentina de Egresados en Ciencias Políticas,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "999"
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Estructura y organización de los ministerios de poder ejecutivo nacional : [aportes para el estudio de la estructura del poder durante el gobierno del Dr. Alfonsín]"
+          ],
+          "shelfMark": [
+            "JLK 86-206"
+          ],
+          "creatorLiteral": [
+            "Fardeso, José Horacio."
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLK 86-206"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013199"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415604"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213163"
+            }
+          ],
+          "dateEndYear": [
+            999
+          ],
+          "updatedAt": 1636094229907,
+          "publicationStatement": [
+            "Buenos Aires : Asociación Argentina de Egresados en Ciencias Políticas, 1985."
+          ],
+          "identifier": [
+            "urn:bnum:10013199",
+            "urn:undefined:NNSZ01415604",
+            "urn:undefined:(WaOLN)nyp0213163"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Administrative agencies -- Argentina.",
+            "Argentina -- Politics and government -- 1983-"
+          ],
+          "titleDisplay": [
+            "Estructura y organización de los ministerios de poder ejecutivo nacional : [aportes para el estudio de la estructura del poder durante el gobierno del Dr. Alfonsín] / José Horacio Fardeso."
+          ],
+          "uri": "b10013199",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Buenos Aires :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10013199"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433063254944"
+                    ],
+                    "physicalLocation": [
+                      "JLK 86-206"
+                    ],
+                    "shelfMark_sort": "aJLK 86-206 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i14747397",
+                    "shelfMark": [
+                      "JLK 86-206 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JLK 86-206 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433063254944"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433063254944"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013321",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "5 v. in 1."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Logic",
+            "Logic -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "Minerva,"
+          ],
+          "language": [
+            {
+              "id": "lang:lat",
+              "label": "Latin"
+            }
+          ],
+          "dateEndString": [
+            "1597"
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Problemata logica. Marburg 1597."
+          ],
+          "shelfMark": [
+            "JFB 86-112"
+          ],
+          "creatorLiteral": [
+            "Goclenius, Rudolph, 1547-1628."
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "68110653"
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFB 86-112"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013321"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "68110653"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415735"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213284"
+            }
+          ],
+          "dateEndYear": [
+            1597
+          ],
+          "updatedAt": 1636123523500,
+          "publicationStatement": [
+            "Frankfurt, Minerva, 1967."
+          ],
+          "identifier": [
+            "urn:bnum:10013321",
+            "urn:lccn:68110653",
+            "urn:undefined:NNSZ01415735",
+            "urn:undefined:(WaOLN)nyp0213284"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Logic -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "Problemata logica. Marburg 1597."
+          ],
+          "uri": "b10013321",
+          "lccClassification": [
+            "BC60 .G62"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Frankfurt,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "15 cm."
+          ]
+        },
+        "sort": [
+          "b10013321"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005151620"
+                    ],
+                    "physicalLocation": [
+                      "JFB 86-112"
+                    ],
+                    "shelfMark_sort": "aJFB 86-000112",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10006744",
+                    "shelfMark": [
+                      "JFB 86-112"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFB 86-112"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005151620"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433005151620"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013473",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "155 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Perspective"
+          ],
+          "publisherLiteral": [
+            "M. Tavernier,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1643
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "La perspective speculative, et pratique [microform] : ou sont demonstrez les fondemens de cet art, & de tout ce qui en a esté enseigné jusqu'ā present ..."
+          ],
+          "shelfMark": [
+            "*ZM-189"
+          ],
+          "creatorLiteral": [
+            "Aleaume, Jacques, -approximately 1627."
+          ],
+          "createdString": [
+            "1643"
+          ],
+          "dateStartYear": [
+            1643
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZM-189"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013473"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415893"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213436"
+            }
+          ],
+          "updatedAt": 1644357878029,
+          "publicationStatement": [
+            "Paris : M. Tavernier, 1643."
+          ],
+          "identifier": [
+            "urn:bnum:10013473",
+            "urn:undefined:NNSZ01415893",
+            "urn:undefined:(WaOLN)nyp0213436"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1643"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Perspective."
+          ],
+          "titleDisplay": [
+            "La perspective speculative, et pratique [microform] : ou sont demonstrez les fondemens de cet art, & de tout ce qui en a esté enseigné jusqu'ā present ... / de l'invention du feu sieur Aleaume ..."
+          ],
+          "uri": "b10013473",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10013473"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433090700216"
+                    ],
+                    "physicalLocation": [
+                      "3-MBF (Aleaume, J. Perspective speculative, et pratique)"
+                    ],
+                    "shelfMark_sort": "a3-MBF (Aleaume, J. Perspective speculative, et pratique)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10006752",
+                    "shelfMark": [
+                      "3-MBF (Aleaume, J. Perspective speculative, et pratique)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "3-MBF (Aleaume, J. Perspective speculative, et pratique)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433090700216"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "idBarcode": [
+                      "33433090700216"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110386137"
+                    ],
+                    "physicalLocation": [
+                      "*ZM-189"
+                    ],
+                    "shelfMark_sort": "a*ZM-000189",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10006750",
+                    "shelfMark": [
+                      "*ZM-189"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZM-189"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110386137"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433110386137"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013537",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "12 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Colonies. No. 10.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Signatures: A⁶.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Bibliothèque nationale (France). Catalogue de l’histoire de la Révolution française",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Racially mixed people",
+            "Racially mixed people -- Haiti",
+            "Racially mixed people -- Haiti -- Early works to 1800",
+            "Slavery",
+            "Slavery -- Haiti",
+            "Slavery -- Haiti -- Early works to 1800",
+            "Haiti",
+            "Haiti -- History",
+            "Haiti -- History -- Revolution, 1791-1804",
+            "Haiti -- History -- Revolution, 1791-1804 -- Early works to 1800",
+            "Haiti -- Politics and government",
+            "Haiti -- Politics and government -- Early works to 1800",
+            "France",
+            "France -- Administration",
+            "France -- Administration -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "De l'Imprimerie nationale"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1791
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Opinion de Jean-François Ducos sur l'exécution provisoire du concordat, & des arrêtés de l'Assemblée coloniale confirmatifs de cet accord : imprimée par ordre de l'Assemblée nationale."
+          ],
+          "shelfMark": [
+            "Sc Rare C 86-7"
+          ],
+          "creatorLiteral": [
+            "Ducos, Jean François, 1765-1793."
+          ],
+          "createdString": [
+            "1791"
+          ],
+          "contributorLiteral": [
+            "France. Assemblée nationale constituante (1789-1791)",
+            "Imprimerie nationale (France), publisher."
+          ],
+          "dateStartYear": [
+            1791
+          ],
+          "donor": [
+            "Home to Harlem Project funded by the Andrew W. Mellon Foundation."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare C 86-7"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013537"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415958"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213499"
+            }
+          ],
+          "updatedAt": 1654777211240,
+          "publicationStatement": [
+            "A Paris : De l'Imprimerie nationale, 1791."
+          ],
+          "identifier": [
+            "urn:bnum:10013537",
+            "urn:undefined:NNSZ01415958",
+            "urn:undefined:(WaOLN)nyp0213499"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1791"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Racially mixed people -- Haiti -- Early works to 1800.",
+            "Slavery -- Haiti -- Early works to 1800.",
+            "Haiti -- History -- Revolution, 1791-1804 -- Early works to 1800.",
+            "Haiti -- Politics and government -- Early works to 1800.",
+            "France -- Administration -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "Opinion de Jean-François Ducos sur l'exécution provisoire du concordat, & des arrêtés de l'Assemblée coloniale confirmatifs de cet accord : imprimée par ordre de l'Assemblée nationale."
+          ],
+          "uri": "b10013537",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "A Paris"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10013537"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10013537-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Opinion+de+Jean-François+Ducos+sur+l'exécution+provisoire+du+concordat,+and+des+arrêtés+de+l'Assemblée+coloniale+confirmatifs+de+cet+accord+:+imprimée+par+ordre+de+l'Assemblée+nationale.&Site=SCHRB&CallNumber=Sc+Rare+C+86-7&Author=Ducos,+Jean+François,&ItemPlace=A+Paris+:&ItemPublisher=De+l'Imprimerie+nationale,&Date=1791.&ItemInfo3=https://catalog.nypl.org/record=b10013537&ReferenceNumber=b100135377&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927121&ItemISxN=i11901189x&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013537-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901189",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 86-7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 86-7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927121"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 86-7"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927121"
+                    ],
+                    "idBarcode": [
+                      "33433036927121"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Opinion+de+Jean-François+Ducos+sur+l'exécution+provisoire+du+concordat,+and+des+arrêtés+de+l'Assemblée+coloniale+confirmatifs+de+cet+accord+:+imprimée+par+ordre+de+l'Assemblée+nationale.&Site=SCHRB&CallNumber=Sc+Rare+C+86-7&Author=Ducos,+Jean+François,&ItemPlace=A+Paris+:&ItemPublisher=De+l'Imprimerie+nationale,&Date=1791.&ItemInfo3=https://catalog.nypl.org/record=b10013537&ReferenceNumber=b100135377&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927121&ItemISxN=i11901189x&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 86-000007"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013539",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "48 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "With a half-title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Avertissement. Quoique le titre de cet ouvrage semble announcer qu'on présentera la situation actuelle de toutes les colonies, je dois cependant prévenir le lecteur que, n'ayant en que des matériaux incomplets, j'ai été forcé pour le moment, de ne parler que de Saint-Domingue.\"--p. [2] (verso of half-title page). ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Signatures: A-C⁸.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Bibliothèque nationale (France). Catalogue de l’histoire de la Révolution française",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "France. Marine",
+            "France. Marine -- Early works to 1800",
+            "Racially mixed people",
+            "Racially mixed people -- Haiti",
+            "Racially mixed people -- Haiti -- Early works to 1800",
+            "Haiti",
+            "Haiti -- History",
+            "Haiti -- History -- Revolution, 1791-1804",
+            "Haiti -- History -- Revolution, 1791-1804 -- Early works to 1800",
+            "Haiti -- Politics and government",
+            "Haiti -- Politics and government -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "de le Imprimerie de L.-P. Couret, rue Christine, no. 2"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1792
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "De l'état actuel de la marine et des colonies"
+          ],
+          "shelfMark": [
+            "Sc Rare C 86-4"
+          ],
+          "creatorLiteral": [
+            "Brasseur."
+          ],
+          "createdString": [
+            "1792"
+          ],
+          "contributorLiteral": [
+            "Couret de Villeneuve, Louis-Pierre, 1749-1806"
+          ],
+          "dateStartYear": [
+            1792
+          ],
+          "donor": [
+            "Home to Harlem Project funded by the Andrew W. Mellon Foundation."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare C 86-4"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013539"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415960"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213501"
+            }
+          ],
+          "updatedAt": 1654777211068,
+          "publicationStatement": [
+            "A Paris : de le Imprimerie de L.-P. Couret, rue Christine, no. 2, 1792."
+          ],
+          "identifier": [
+            "urn:bnum:10013539",
+            "urn:undefined:NNSZ01415960",
+            "urn:undefined:(WaOLN)nyp0213501"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1792"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "France. Marine -- Early works to 1800.",
+            "Racially mixed people -- Haiti -- Early works to 1800.",
+            "Haiti -- History -- Revolution, 1791-1804 -- Early works to 1800.",
+            "Haiti -- Politics and government -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "De l'état actuel de la marine et des colonies / par M. Le Brasseur, ci-devant intendant-général de la Marine."
+          ],
+          "uri": "b10013539",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "A Paris"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10013539"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10013539-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=De+l'état+actuel+de+la+marine+et+des+colonies+/&Site=SCHRB&CallNumber=Sc+Rare+C+86-4&Author=Brasseur.&ItemPlace=A+Paris+:&ItemPublisher=de+le+Imprimerie+de+L.-P.+Couret,+rue+Christine,+no.+2,&Date=1792.&ItemInfo3=https://catalog.nypl.org/record=b10013539&ReferenceNumber=b100135390&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927147&ItemISxN=i119011918&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013539-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901191",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 86-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 86-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 86-4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927147"
+                    ],
+                    "idBarcode": [
+                      "33433036927147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=De+l'état+actuel+de+la+marine+et+des+colonies+/&Site=SCHRB&CallNumber=Sc+Rare+C+86-4&Author=Brasseur.&ItemPlace=A+Paris+:&ItemPublisher=de+le+Imprimerie+de+L.-P.+Couret,+rue+Christine,+no.+2,&Date=1792.&ItemInfo3=https://catalog.nypl.org/record=b10013539&ReferenceNumber=b100135390&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927147&ItemISxN=i119011918&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 86-000004"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013540",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "7 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Haiti",
+            "Haiti -- History",
+            "Haiti -- History -- Revolution, 1791-1804",
+            "Haiti -- History -- Revolution, 1791-1804 -- Sources"
+          ],
+          "publisherLiteral": [
+            "De l'Impr. de P.F. Didot le jeune"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1791
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Pétition faite à l'Assemblée nationale par MM. les Commissaires de l'Assemblée générale de la partie française de St.-Domingue : le 2 décembre 1791, et lue le 3."
+          ],
+          "shelfMark": [
+            "Sc Rare C 86-3"
+          ],
+          "creatorLiteral": [
+            "Saint-Domingue. Assemblée générale Commissaires."
+          ],
+          "createdString": [
+            "1791"
+          ],
+          "contributorLiteral": [
+            "France. Assemblée nationale législative (1791-1792)"
+          ],
+          "dateStartYear": [
+            1791
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare C 86-3"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013540"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415961"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213502"
+            }
+          ],
+          "updatedAt": 1654777211240,
+          "publicationStatement": [
+            "[Paris?] : De l'Impr. de P.F. Didot le jeune, [1791?]"
+          ],
+          "identifier": [
+            "urn:bnum:10013540",
+            "urn:undefined:NNSZ01415961",
+            "urn:undefined:(WaOLN)nyp0213502"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1791"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Haiti -- History -- Revolution, 1791-1804 -- Sources."
+          ],
+          "titleDisplay": [
+            "Pétition faite à l'Assemblée nationale par MM. les Commissaires de l'Assemblée générale de la partie française de St.-Domingue : le 2 décembre 1791, et lue le 3."
+          ],
+          "uri": "b10013540",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Paris?]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10013540"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10013540-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Pétition+faite+à+l'Assemblée+nationale+par+MM.+les+Commissaires+de+l'Assemblée+générale+de+la+partie+française+de+St.-Domingue+:+le+2+décembre+1791,+et+lue+le+3.&Site=SCHRB&CallNumber=Sc+Rare+C+86-3&Author=Saint-Domingue.&ItemPlace=[Paris?]+:&ItemPublisher=De+l'Impr.+de+P.F.+Didot+le+jeune,&Date=[1791?]&ItemInfo3=https://catalog.nypl.org/record=b10013540&ReferenceNumber=b100135407&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927154&ItemISxN=i11901192x&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013540-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901192",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 86-3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 86-3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927154"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 86-3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927154"
+                    ],
+                    "idBarcode": [
+                      "33433036927154"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Pétition+faite+à+l'Assemblée+nationale+par+MM.+les+Commissaires+de+l'Assemblée+générale+de+la+partie+française+de+St.-Domingue+:+le+2+décembre+1791,+et+lue+le+3.&Site=SCHRB&CallNumber=Sc+Rare+C+86-3&Author=Saint-Domingue.&ItemPlace=[Paris?]+:&ItemPublisher=De+l'Impr.+de+P.F.+Didot+le+jeune,&Date=[1791?]&ItemInfo3=https://catalog.nypl.org/record=b10013540&ReferenceNumber=b100135407&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927154&ItemISxN=i11901192x&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 86-000003"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013541",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "6, [2] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Imprint from colophon.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"No. 1606\" printed to right of head-piece above caption title. ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Decree of the National Assembly.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Signed on p. 6: Louis. Et plus bas, Roland.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Last [2] p. blank.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Signatures: [A]⁴ ([A]4 blank)",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suffrage",
+            "Suffrage -- Haiti",
+            "Suffrage -- Haiti -- Early works to 1800",
+            "Racially mixed people",
+            "Racially mixed people -- Civil rights",
+            "Racially mixed people -- Civil rights -- Haiti",
+            "Racially mixed people -- Civil rights -- Haiti -- Early works to 1800",
+            "Black people",
+            "Black people -- Civil rights",
+            "Black people -- Civil rights -- Haiti",
+            "Black people -- Civil rights -- Haiti -- Early works to 1800",
+            "France",
+            "France -- Administration",
+            "France -- Administration -- Early works to 1800",
+            "Haiti",
+            "Haiti -- Politics and government",
+            "Haiti -- Politics and government -- 1791-1804",
+            "Haiti -- Politics and government -- 1791-1804 -- Early works to 1800",
+            "France -- Politics and government",
+            "France -- Politics and government -- 1789-1799",
+            "France -- Politics and government -- 1789-1799 -- Early works to 1800",
+            "Haiti -- History",
+            "Haiti -- History -- Revolution, 1791-1804",
+            "Haiti -- History -- Revolution, 1791-1804 -- Sources"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Chez Jean-Baptiste Lefranc-Elies, imprimeur de Dép. des Deux Sèvres"
+          ],
+          "description": [
+            "Concerns suffrage rights given to men of color and free Blacks in all parish assemblies in all of the French West Indian colonies, specifically Saint-Domingue."
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1792
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Loi relative aux colonies, & aux moyens d'y appaiser les troubles : Donnée à Paris, le 4 avril 1792. "
+          ],
+          "shelfMark": [
+            "Sc Rare+  F 82-68"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "France."
+          ],
+          "createdString": [
+            "1792"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Roland de La Platière, Jean-Marie, 1734-1793.",
+            "Lefranc-Elies, Jean-Baptiste, 1764-",
+            "France. Sovereign (1774-1792 : Louis XVI)",
+            "France. Assemblée nationale législative (1791-1792)"
+          ],
+          "dateStartYear": [
+            1792
+          ],
+          "donor": [
+            "Home to Harlem Project funded by the Andrew W. Mellon Foundation."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare+  F 82-68"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013541"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG014000991-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415962"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213503"
+            }
+          ],
+          "idOclc": [
+            "NYPG014000991-B"
+          ],
+          "updatedAt": 1671650997886,
+          "publicationStatement": [
+            "A Niort : Chez Jean-Baptiste Lefranc-Elies, imprimeur de Dép. des Deux Sèvres, 1792."
+          ],
+          "identifier": [
+            "urn:bnum:10013541",
+            "urn:oclc:NYPG014000991-B",
+            "urn:undefined:NNSZ01415962",
+            "urn:undefined:(WaOLN)nyp0213503"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1792"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suffrage -- Haiti -- Early works to 1800.",
+            "Racially mixed people -- Civil rights -- Haiti -- Early works to 1800.",
+            "Black people -- Civil rights -- Haiti -- Early works to 1800.",
+            "France -- Administration -- Early works to 1800.",
+            "Haiti -- Politics and government -- 1791-1804 -- Early works to 1800.",
+            "France -- Politics and government -- 1789-1799 -- Early works to 1800.",
+            "Haiti -- History -- Revolution, 1791-1804 -- Sources."
+          ],
+          "titleDisplay": [
+            "Loi relative aux colonies, & aux moyens d'y appaiser les troubles : Donnée à Paris, le 4 avril 1792. "
+          ],
+          "uri": "b10013541",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "A Niort"
+          ],
+          "titleAlt": [
+            "Loi relative aux colonies, et aux moyens d'y appaiser les troubles"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10013541"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10013541-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Loi+relative+aux+colonies,+and+aux+moyens+d'y+appaiser+les+troubles+:+Donnée+à+Paris,+le+4+avril+1792.+&Site=SCHRB&CallNumber=Sc+Rare%2b+F+82-68&Author=France.&ItemPlace=A+Niort+:&ItemPublisher=Chez+Jean-Baptiste+Lefranc-Elies,+imprimeur+de+Dép.+des+Deux+Sèvres,&Date=1792.&ItemInfo3=https://catalog.nypl.org/record=b10013541&ReferenceNumber=b100135419&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927162&ItemISxN=i119011931&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "bi10013541-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901193",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare+ F 82-68"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare+ F 82-68",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927162"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare+ F 82-68"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927162"
+                    ],
+                    "idBarcode": [
+                      "33433036927162"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Loi+relative+aux+colonies,+and+aux+moyens+d'y+appaiser+les+troubles+:+Donnée+à+Paris,+le+4+avril+1792.+&Site=SCHRB&CallNumber=Sc+Rare%2b+F+82-68&Author=France.&ItemPlace=A+Niort+:&ItemPublisher=Chez+Jean-Baptiste+Lefranc-Elies,+imprimeur+de+Dép.+des+Deux+Sèvres,&Date=1792.&ItemInfo3=https://catalog.nypl.org/record=b10013541&ReferenceNumber=b100135419&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927162&ItemISxN=i119011931&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aSc Rare+ F 82-000068"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013542",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "3, [1] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Signed at end: Fait à Laon, le 6 Floréal, seconde année républicaine. Signé Lefevre, Président; Lelarge, Regnault, Partis, Caignart, Tranchant, Duchateau, Clouard, administrateurs. Contresigné M. J. J. P. Leleu, Secrétaire-Général du Département.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Pour copie conforme à l'Exemplaire qui nous a été adressé, certifié par l'Administration du Département de l'Aisne.\"--p. [3].",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Imprint from colophon.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At side of title: No. 3443.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Last page blank.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Signatures: [A]²",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Enslaved persons",
+            "Enslaved persons -- Colonies",
+            "Enslaved persons -- Colonies -- France",
+            "Enslaved persons -- Colonies -- France -- Early works to 1800",
+            "Slavery",
+            "Slavery -- France",
+            "Slavery -- France -- Colonies",
+            "Slavery -- France -- Colonies -- Early works to 1800",
+            "France",
+            "France -- Administration",
+            "France -- Administration -- Early works to 1800",
+            "France -- Politics and government",
+            "France -- Politics and government -- Early works to 1800"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "De l'Imprimerie de Veuve Melleville & fils, imprimeurs du Dép. de l'Aisne"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1794
+          ],
+          "dateEndString": [
+            "1795"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Decret de la Convention nationale, du 16.e jour de pluviôse, an 2.e de la République françoise, une & indivisible, qui abolit l'esclavage des Nègres dans les colonies."
+          ],
+          "shelfMark": [
+            "Sc Rare+ F 82-67"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "France. Convention nationale."
+          ],
+          "createdString": [
+            "1794"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "contributorLiteral": [
+            "Veuve Melleville & fils, printer."
+          ],
+          "dateStartYear": [
+            1794
+          ],
+          "donor": [
+            "Home to Harlem Project funded by the Andrew W. Mellon Foundation."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare+ F 82-67"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013542"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG014000992-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415963"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213504"
+            }
+          ],
+          "idOclc": [
+            "NYPG014000992-B"
+          ],
+          "dateEndYear": [
+            1795
+          ],
+          "updatedAt": 1679123316618,
+          "publicationStatement": [
+            "A Laon : De l'Imprimerie de Veuve Melleville & fils, imprimeurs du Dép. de l'Aisne, An 3 de la Républ. [1794 or 1795]"
+          ],
+          "identifier": [
+            "urn:bnum:10013542",
+            "urn:oclc:NYPG014000992-B",
+            "urn:undefined:NNSZ01415963",
+            "urn:undefined:(WaOLN)nyp0213504"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1794"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Enslaved persons -- Colonies -- France -- Early works to 1800.",
+            "Slavery -- France -- Colonies -- Early works to 1800.",
+            "France -- Administration -- Early works to 1800.",
+            "France -- Politics and government -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "Decret de la Convention nationale, du 16.e jour de pluviôse, an 2.e de la République françoise, une & indivisible, qui abolit l'esclavage des Nègres dans les colonies."
+          ],
+          "uri": "b10013542",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "A Laon"
+          ],
+          "titleAlt": [
+            "Abolit l'esclavage des Nègres dans les colonies."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10013542"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10013542-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Decret+de+la+Convention+nationale,+du+16.e+jour+de+pluviôse,+an+2.e+de+la+République+françoise,+une+and+indivisible,+qui+abolit+l'esclavage+des+Nègres+dans+les+colonies.&Site=SCHRB&CallNumber=Sc+Rare%2b+F+82-67&Author=France.&ItemPlace=A+Laon+:&ItemPublisher=De+l'Imprimerie+de+Veuve+Melleville+and+fils,+imprimeurs+du+Dép.+de+l'Aisne,&Date=An+3+de+la+Républ.+[1794+or+1795]&ItemInfo3=https://catalog.nypl.org/record=b10013542&ReferenceNumber=b100135420&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927170&ItemISxN=i119011943&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "bi10013542-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901194",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare+ F 82-67"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare+ F 82-67",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927170"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare+ F 82-67"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927170"
+                    ],
+                    "idBarcode": [
+                      "33433036927170"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Decret+de+la+Convention+nationale,+du+16.e+jour+de+pluviôse,+an+2.e+de+la+République+françoise,+une+and+indivisible,+qui+abolit+l'esclavage+des+Nègres+dans+les+colonies.&Site=SCHRB&CallNumber=Sc+Rare%2b+F+82-67&Author=France.&ItemPlace=A+Laon+:&ItemPublisher=De+l'Imprimerie+de+Veuve+Melleville+and+fils,+imprimeurs+du+Dép.+de+l'Aisne,&Date=An+3+de+la+Républ.+[1794+or+1795]&ItemInfo3=https://catalog.nypl.org/record=b10013542&ReferenceNumber=b100135420&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927170&ItemISxN=i119011943&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aSc Rare+ F 82-000067"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013544",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[23], 334 p., 81 leaves ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Suma del privilegio\" refers to the book under title: De instauranda aethiopum salute. Running title: Tract[atus] de inst[auranda] ethiop[um] sal[ute]",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jesuits",
+            "Jesuits -- Missions",
+            "Catholic Church",
+            "Catholic Church -- Missions",
+            "Black people",
+            "Black people -- Missions",
+            "Black people -- South America",
+            "Slave-trade",
+            "Slave-trade -- Africa",
+            "Africa",
+            "Africa -- Social life and customs"
+          ],
+          "publisherLiteral": [
+            "Por Francisco de Lira, impresor"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "createdYear": [
+            1627
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Naturaleza, policia sagrada i profana, costumbres i ritos, disciplina i catechismo evangelico de todos etiopes"
+          ],
+          "shelfMark": [
+            "Sc Rare F 82-70"
+          ],
+          "creatorLiteral": [
+            "Sandoval, Alonso de, 1576-1652."
+          ],
+          "createdString": [
+            "1627"
+          ],
+          "dateStartYear": [
+            1627
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare F 82-70"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013544"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01415965"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213506"
+            }
+          ],
+          "updatedAt": 1654777211068,
+          "publicationStatement": [
+            "En Sevilla : Por Francisco de Lira, impresor, 1627."
+          ],
+          "identifier": [
+            "urn:bnum:10013544",
+            "urn:undefined:NNSZ01415965",
+            "urn:undefined:(WaOLN)nyp0213506"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1627"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jesuits -- Missions.",
+            "Catholic Church -- Missions.",
+            "Black people -- Missions.",
+            "Black people -- South America.",
+            "Slave-trade -- Africa.",
+            "Africa -- Social life and customs."
+          ],
+          "titleDisplay": [
+            "Naturaleza, policia sagrada i profana, costumbres i ritos, disciplina i catechismo evangelico de todos etiopes / por el p. Alonso, de Sandoval ..."
+          ],
+          "uri": "b10013544",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "En Sevilla"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "De instauranda aethiopum salute.",
+            "Tractatus de instauranda ethiopum salute."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10013544"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10013544-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Naturaleza,+policia+sagrada+i+profana,+costumbres+i+ritos,+disciplina+i+catechismo+evangelico+de+todos+etiopes+/&Site=SCHRB&CallNumber=Sc+Rare+F+82-70&Author=Sandoval,+Alonso+de,&ItemPlace=En+Sevilla+:&ItemPublisher=Por+Francisco+de+Lira,+impresor,&Date=1627.&ItemInfo3=https://catalog.nypl.org/record=b10013544&ReferenceNumber=b100135444&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927188&ItemISxN=i119011955&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013544-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901195",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare F 82-70"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare F 82-70",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927188"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare F 82-70"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927188"
+                    ],
+                    "idBarcode": [
+                      "33433036927188"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Naturaleza,+policia+sagrada+i+profana,+costumbres+i+ritos,+disciplina+i+catechismo+evangelico+de+todos+etiopes+/&Site=SCHRB&CallNumber=Sc+Rare+F+82-70&Author=Sandoval,+Alonso+de,&ItemPlace=En+Sevilla+:&ItemPublisher=Por+Francisco+de+Lira,+impresor,&Date=1627.&ItemInfo3=https://catalog.nypl.org/record=b10013544&ReferenceNumber=b100135444&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927188&ItemISxN=i119011955&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare F 82-000070"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013584",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "6 v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Seventeen \"books\" in six vols.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Colonization",
+            "Colonization -- History",
+            "Commerce",
+            "Commerce -- History",
+            "East Indies",
+            "America",
+            "America -- Discovery and exploration"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "[s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            3
+          ],
+          "createdYear": [
+            1770
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Histoire philosophique et politique des établissemens & du commerce des Européens dans les deux Indes."
+          ],
+          "shelfMark": [
+            "Sc Rare C 86-2"
+          ],
+          "numItemVolumesParsed": [
+            3
+          ],
+          "creatorLiteral": [
+            "Raynal, abbé (Guillaume-Thomas-François), 1713-1796."
+          ],
+          "createdString": [
+            "1770"
+          ],
+          "numElectronicResources": [
+            1
+          ],
+          "dateStartYear": [
+            1770
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare C 86-2"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013584"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG014001035-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01416007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213546"
+            }
+          ],
+          "idOclc": [
+            "NYPG014001035-B"
+          ],
+          "updatedAt": 1679335512910,
+          "publicationStatement": [
+            "A Amsterdam : [s.n.], 1770."
+          ],
+          "identifier": [
+            "urn:bnum:10013584",
+            "urn:oclc:NYPG014001035-B",
+            "urn:undefined:NNSZ01416007",
+            "urn:undefined:(WaOLN)nyp0213546"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1770"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Colonization -- History.",
+            "Commerce -- History.",
+            "East Indies.",
+            "America -- Discovery and exploration."
+          ],
+          "titleDisplay": [
+            "Histoire philosophique et politique des établissemens & du commerce des Européens dans les deux Indes."
+          ],
+          "uri": "b10013584",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "A Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10013584"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10013584-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Histoire+philosophique+et+politique+des+établissemens+and+du+commerce+des+Européens+dans+les+deux+Indes.&Site=SCHRB&CallNumber=Sc+Rare+C+86-2&Author=Raynal,&ItemPlace=A+Amsterdam+:&ItemPublisher=[s.n.],&Date=1770.&ItemInfo3=https://catalog.nypl.org/record=b10013584&ReferenceNumber=b100135845&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "bi10013584-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32196084",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 86-2 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 86-2 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076137243"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 86-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076137243"
+                    ],
+                    "idBarcode": [
+                      "33433076137243"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Histoire+philosophique+et+politique+des+établissemens+and+du+commerce+des+Européens+dans+les+deux+Indes.&Site=SCHRB&CallNumber=Sc+Rare+C+86-2&Author=Raynal,&ItemPlace=A+Amsterdam+:&ItemPublisher=[s.n.],&Date=1770.&ItemInfo3=https://catalog.nypl.org/record=b10013584&ReferenceNumber=b100135845&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 6,
+                        "lte": 6
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         6-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 86-2 v. 000006"
+                  },
+                  "sort": [
+                    "         6-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32196083",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 86-2 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 86-2 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076137235"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 86-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076137235"
+                    ],
+                    "idBarcode": [
+                      "33433076137235"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Histoire+philosophique+et+politique+des+établissemens+and+du+commerce+des+Européens+dans+les+deux+Indes.&Site=SCHRB&CallNumber=Sc+Rare+C+86-2&Author=Raynal,&ItemPlace=A+Amsterdam+:&ItemPublisher=[s.n.],&Date=1770.&ItemInfo3=https://catalog.nypl.org/record=b10013584&ReferenceNumber=b100135845&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 86-2 v. 000002"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901467",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare C 86-2 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare C 86-2 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927279"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare C 86-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927279"
+                    ],
+                    "idBarcode": [
+                      "33433036927279"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=Histoire+philosophique+et+politique+des+établissemens+and+du+commerce+des+Européens+dans+les+deux+Indes.&Site=SCHRB&CallNumber=Sc+Rare+C+86-2&Author=Raynal,&ItemPlace=A+Amsterdam+:&ItemPublisher=[s.n.],&Date=1770.&ItemInfo3=https://catalog.nypl.org/record=b10013584&ReferenceNumber=b100135845&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aSc Rare C 86-2 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013594",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "20 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Slavery",
+            "Slavery -- West Indies, British",
+            "Sugar trade",
+            "Sugar trade -- West Indies, British"
+          ],
+          "publisherLiteral": [
+            "s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1792
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "An Address to Her Royal Highness the Dutchess of York, against the use of sugar."
+          ],
+          "shelfMark": [
+            "Sc Rare+ G 86-31"
+          ],
+          "createdString": [
+            "1792"
+          ],
+          "contributorLiteral": [
+            "Frederica Charlotte Ulrica Catherina, Duchess of York, 1767-1820."
+          ],
+          "dateStartYear": [
+            1792
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Rare+ G 86-31"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013594"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01416017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213556"
+            }
+          ],
+          "updatedAt": 1654777212731,
+          "publicationStatement": [
+            "[London? : s.n.], 1792."
+          ],
+          "identifier": [
+            "urn:bnum:10013594",
+            "urn:undefined:NNSZ01416017",
+            "urn:undefined:(WaOLN)nyp0213556"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1792"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Slavery -- West Indies, British.",
+            "Sugar trade -- West Indies, British."
+          ],
+          "titleDisplay": [
+            "An Address to Her Royal Highness the Dutchess of York, against the use of sugar."
+          ],
+          "uri": "b10013594",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[London?"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10013594"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i10013594-e",
+                    "electronicLocator": [
+                      {
+                        "url": "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=An+Address+to+Her+Royal+Highness+the+Dutchess+of+York,+against+the+use+of+sugar.&Site=SCHRB&CallNumber=Sc+Rare%2b+G+86-31&ItemPlace=[London?+:&ItemPublisher=s.n.],&Date=1792.&ItemInfo3=https://catalog.nypl.org/record=b10013594&ReferenceNumber=b100135948&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927360&ItemISxN=i119014762&Genre=Book-text&Location=Schomburg+Center",
+                        "label": "Request Access to Special Collections Material"
+                      }
+                    ],
+                    "shelfMark_sort": "bi10013594-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901476",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1116",
+                        "label": "Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1116||Schomburg Center for Research in Black Culture, Manuscripts, Archives and Rare Books Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scdd2",
+                        "label": "Schomburg Center - Manuscripts & Archives"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scdd2||Schomburg Center - Manuscripts & Archives"
+                    ],
+                    "shelfMark": [
+                      "Sc Rare+ G 86-31"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Rare+ G 86-31",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036927360"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Rare+ G 86-31"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036927360"
+                    ],
+                    "idBarcode": [
+                      "33433036927360"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "aeonUrl": [
+                      "https://specialcollections.nypl.org/aeon/Aeon.dll?Action=10&Form=30&Title=An+Address+to+Her+Royal+Highness+the+Dutchess+of+York,+against+the+use+of+sugar.&Site=SCHRB&CallNumber=Sc+Rare%2b+G+86-31&ItemPlace=[London?+:&ItemPublisher=s.n.],&Date=1792.&ItemInfo3=https://catalog.nypl.org/record=b10013594&ReferenceNumber=b100135948&ItemInfo1=USE+IN+LIBRARY&ItemNumber=33433036927360&ItemISxN=i119014762&Genre=Book-text&Location=Schomburg+Center"
+                    ],
+                    "shelfMark_sort": "aSc Rare+ G 86-000031"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013625",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Magazine for Filipinos.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Vol. 8, no. 1 (Oct. 1978)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Filipino Americans",
+            "Filipino Americans -- Periodicals",
+            "Philippines",
+            "Philippines -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ningas Corp."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "19"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ningas."
+          ],
+          "shelfMark": [
+            "JFM 85-295"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "idIssn": [
+            "0164-6966"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFM 85-295"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013625"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0164-6966"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "4417290"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "4417290"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG0144-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213587"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)4417290"
+            }
+          ],
+          "idOclc": [
+            "4417290",
+            "NYPG0144-S"
+          ],
+          "dateEndYear": [
+            19
+          ],
+          "updatedAt": 1669926832642,
+          "publicationStatement": [
+            "New York : Ningas Corp., 1978-"
+          ],
+          "identifier": [
+            "urn:bnum:10013625",
+            "urn:issn:0164-6966",
+            "urn:oclc:4417290",
+            "urn:oclc:NYPG0144-S",
+            "urn:undefined:(WaOLN)nyp0213587",
+            "urn:undefined:(OCoLC)4417290"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Filipino Americans -- Periodicals.",
+            "Philippines -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Ningas."
+          ],
+          "uri": "b10013625",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10013625"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10006769",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFM 85-295 v. 8  oct 1978- ma y1979"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFM 85-295 v. 8  oct 1978- ma y1979",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005091180"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 8  oct 1978- ma y1979"
+                    ],
+                    "physicalLocation": [
+                      "JFM 85-295"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005091180"
+                    ],
+                    "idBarcode": [
+                      "33433005091180"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 8,
+                        "lte": 8
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         8-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFM 85-295 v. 000008 oct 1978- ma y1979"
+                  },
+                  "sort": [
+                    "         8-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013626",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., plans ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Edited by M. Bontempelli and P.M. Bardi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "3 (luglio [1933])-"
+          ],
+          "subjectLiteral_exploded": [
+            "Architecture",
+            "Architecture -- Italy",
+            "Architecture -- Italy -- Periodicals",
+            "Fascism and architecture",
+            "Fascism and architecture -- Italy",
+            "Fascism and architecture -- Italy -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "[s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1933
+          ],
+          "dateEndString": [
+            "19"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Quadrante"
+          ],
+          "shelfMark": [
+            "*ZAN-M114"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1933"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Bontempelli, Massimo, 1878-1960.",
+            "Bardi, P. M. (Pietro Maria), 1900-"
+          ],
+          "dateStartYear": [
+            1933
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZAN-M114"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013626"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG0145-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213588"
+            }
+          ],
+          "idOclc": [
+            "NYPG0145-S"
+          ],
+          "uniformTitle": [
+            "Quadrante (Milan, Italy)"
+          ],
+          "dateEndYear": [
+            19
+          ],
+          "updatedAt": 1669925121957,
+          "publicationStatement": [
+            "Milano : [s.n.], 1933-"
+          ],
+          "identifier": [
+            "urn:bnum:10013626",
+            "urn:oclc:NYPG0145-S",
+            "urn:undefined:(WaOLN)nyp0213588"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1933"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Architecture -- Italy -- Periodicals.",
+            "Fascism and architecture -- Italy -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Quadrante [microform]."
+          ],
+          "uri": "b10013626",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Milano"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10013626"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30719650",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-M114 July 1933-July/Aug. 1935, inc."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-M114 July 1933-July/Aug. 1935, inc.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110459025"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "July 1933-July/Aug. 1935, inc."
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-M114"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110459025"
+                    ],
+                    "idBarcode": [
+                      "33433110459025"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-M114 July 1933-July/Aug. 1935, inc."
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013628",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13 v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Description based on: Vol. 1, no. 22 (July 21, 1977).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Vol. 4, no. 24 repeated in numbering.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "-v. 13, no. 27 (May 22, 1989)."
+          ],
+          "subjectLiteral_exploded": [
+            "Savings and loan associations",
+            "Savings and loan associations -- United States",
+            "Savings and loan associations -- United States -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            17
+          ],
+          "publisherLiteral": [
+            "National Thrift News"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            17
+          ],
+          "createdYear": [
+            198
+          ],
+          "dateEndString": [
+            "1989"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "National thrift news"
+          ],
+          "shelfMark": [
+            "*ZAN-T5363"
+          ],
+          "numItemVolumesParsed": [
+            15
+          ],
+          "createdString": [
+            "198"
+          ],
+          "idLccn": [
+            "79005118 /sn"
+          ],
+          "idIssn": [
+            "0193-287X"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            198
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZAN-T5363"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013628"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0193-287X"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79005118 /sn"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG0147-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213589"
+            }
+          ],
+          "idOclc": [
+            "NYPG0147-S"
+          ],
+          "dateEndYear": [
+            1989
+          ],
+          "updatedAt": 1675269962602,
+          "publicationStatement": [
+            "New York : National Thrift News, -1989."
+          ],
+          "identifier": [
+            "urn:bnum:10013628",
+            "urn:issn:0193-287X",
+            "urn:lccn:79005118 /sn",
+            "urn:oclc:NYPG0147-S",
+            "urn:undefined:(WaOLN)nyp0213589"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "198"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Savings and loan associations -- United States -- Periodicals."
+          ],
+          "titleDisplay": [
+            "National thrift news [microform]."
+          ],
+          "uri": "b10013628",
+          "numItems": [
+            17
+          ],
+          "numAvailable": [
+            17
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "titleAlt": [
+            "National thrift news"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "43 cm."
+          ]
+        },
+        "sort": [
+          "b10013628"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 17,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747442",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mai82",
+                        "label": "Schwarzman Building M1 - Microforms Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mai82||Schwarzman Building M1 - Microforms Room 315"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 13, no. 1-27 (Oct. 1988-May 22, 1989)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 13, no. 1-27 (Oct. 1988-May 22, 1989)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062614056"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 13, no. 1-27 (Oct. 1988-May 22, 1989)"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062614056"
+                    ],
+                    "idBarcode": [
+                      "33433062614056"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 13,
+                        "lte": 13
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1988",
+                        "lte": "1989"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        13-1988"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000013, no. 1-27 (Oct. 1988-May 22, 1989)"
+                  },
+                  "sort": [
+                    "        13-1988"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646161",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 13, Issue 1-27, Oct. (1988) - May 22 (1989)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 13, Issue 1-27, Oct. (1988) - May 22 (1989)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588832"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 13, Issue 1-27, Oct. (1988) - May 22 (1989)"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588832"
+                    ],
+                    "idBarcode": [
+                      "33433093588832"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 13,
+                        "lte": 13
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1988",
+                        "lte": "1989"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        13-1988"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000013, Issue 1-27, Oct. (1988) - May 22 (1989)"
+                  },
+                  "sort": [
+                    "        13-1988"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747445",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mai82",
+                        "label": "Schwarzman Building M1 - Microforms Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mai82||Schwarzman Building M1 - Microforms Room 315"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 13 (Oct. 3, 1988-May 22, 1989)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 13 (Oct. 3, 1988-May 22, 1989)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062614098"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 13 (Oct. 3, 1988-May 22, 1989)"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062614098"
+                    ],
+                    "idBarcode": [
+                      "33433062614098"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 13,
+                        "lte": 13
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1988",
+                        "lte": "1989"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        13-1988"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000013 (Oct. 3, 1988-May 22, 1989)"
+                  },
+                  "sort": [
+                    "        13-1988"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 13
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646727",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 12 Cont., Feb. 1 - Sep. 26 (1988) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 12 Cont., Feb. 1 - Sep. 26 (1988) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588709"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 12 Cont., Feb. 1 - Sep. 26 (1988) Incomplete"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588709"
+                    ],
+                    "idBarcode": [
+                      "33433093588709"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 12,
+                        "lte": 12
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1988",
+                        "lte": "1988"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        12-1988"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000012 Cont., Feb. 1 - Sep. 26 (1988) Incomplete"
+                  },
+                  "sort": [
+                    "        12-1988"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 12
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747444",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mai82",
+                        "label": "Schwarzman Building M1 - Microforms Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mai82||Schwarzman Building M1 - Microforms Room 315"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 12 (cont.) (Feb. 1, 1988-Sep. 26, 1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 12 (cont.) (Feb. 1, 1988-Sep. 26, 1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062614080"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 12 (cont.) (Feb. 1, 1988-Sep. 26, 1988)"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062614080"
+                    ],
+                    "idBarcode": [
+                      "33433062614080"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 12,
+                        "lte": 12
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1988",
+                        "lte": "1988"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        12-1988"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000012 (cont.) (Feb. 1, 1988-Sep. 26, 1988)"
+                  },
+                  "sort": [
+                    "        12-1988"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646717",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 11-12, Jan. 8 (1987) - Jan. 25 (1988) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 11-12, Jan. 8 (1987) - Jan. 25 (1988) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588717"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 11-12, Jan. 8 (1987) - Jan. 25 (1988) Incomplete"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588717"
+                    ],
+                    "idBarcode": [
+                      "33433093588717"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 11,
+                        "lte": 12
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1987",
+                        "lte": "1988"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        11-1987"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000011-12, Jan. 8 (1987) - Jan. 25 (1988) Incomplete"
+                  },
+                  "sort": [
+                    "        11-1987"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747443",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mai82",
+                        "label": "Schwarzman Building M1 - Microforms Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mai82||Schwarzman Building M1 - Microforms Room 315"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 11-12 (Jun. 8, 1987-Jan. 25, 1988) (inc.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 11-12 (Jun. 8, 1987-Jan. 25, 1988) (inc.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433062614072"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 11-12 (Jun. 8, 1987-Jan. 25, 1988) (inc.)"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433062614072"
+                    ],
+                    "idBarcode": [
+                      "33433062614072"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 11,
+                        "lte": 12
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1987",
+                        "lte": "1988"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        11-1987"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000011-12 (Jun. 8, 1987-Jan. 25, 1988) (inc.)"
+                  },
+                  "sort": [
+                    "        11-1987"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646742",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 10, Dec. 16 (1985) - Aug. 25 (1986) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 10, Dec. 16 (1985) - Aug. 25 (1986) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588667"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 10, Dec. 16 (1985) - Aug. 25 (1986) Incomplete"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588667"
+                    ],
+                    "idBarcode": [
+                      "33433093588667"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 10,
+                        "lte": 10
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1985",
+                        "lte": "1986"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        10-1985"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000010, Dec. 16 (1985) - Aug. 25 (1986) Incomplete"
+                  },
+                  "sort": [
+                    "        10-1985"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646739",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 9-10, Mar. 4 - Dec. 9 (1985)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 9-10, Mar. 4 - Dec. 9 (1985)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588675"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 9-10, Mar. 4 - Dec. 9 (1985)"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588675"
+                    ],
+                    "idBarcode": [
+                      "33433093588675"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 9,
+                        "lte": 10
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1985",
+                        "lte": "1985"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         9-1985"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000009-10, Mar. 4 - Dec. 9 (1985)"
+                  },
+                  "sort": [
+                    "         9-1985"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646735",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 8-9, July 9 (1984) - Feb. 25 (1985) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 8-9, July 9 (1984) - Feb. 25 (1985) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588683"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 8-9, July 9 (1984) - Feb. 25 (1985) Incomplete"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588683"
+                    ],
+                    "idBarcode": [
+                      "33433093588683"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 8,
+                        "lte": 9
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1984",
+                        "lte": "1985"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         8-1984"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000008-9, July 9 (1984) - Feb. 25 (1985) Incomplete"
+                  },
+                  "sort": [
+                    "         8-1984"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646705",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 8, Oct. 10 (1983) - Jun. 25 (1984) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 8, Oct. 10 (1983) - Jun. 25 (1984) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588915"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 8, Oct. 10 (1983) - Jun. 25 (1984) Incomplete"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588915"
+                    ],
+                    "idBarcode": [
+                      "33433093588915"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 8,
+                        "lte": 8
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1983",
+                        "lte": "1984"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         8-1983"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000008, Oct. 10 (1983) - Jun. 25 (1984) Incomplete"
+                  },
+                  "sort": [
+                    "         8-1983"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646653",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 6, Feb. 1 - Sep. 20 (1982)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 6, Feb. 1 - Sep. 20 (1982)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588956"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 6, Feb. 1 - Sep. 20 (1982)"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588956"
+                    ],
+                    "idBarcode": [
+                      "33433093588956"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 6,
+                        "lte": 6
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1982",
+                        "lte": "1982"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         6-1982"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000006, Feb. 1 - Sep. 20 (1982)"
+                  },
+                  "sort": [
+                    "         6-1982"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646643",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 5-6, Sep. 25 (1980) - Jan. 25 (1982)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 5-6, Sep. 25 (1980) - Jan. 25 (1982)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588824"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 5-6, Sep. 25 (1980) - Jan. 25 (1982)"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588824"
+                    ],
+                    "idBarcode": [
+                      "33433093588824"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 6
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1980",
+                        "lte": "1982"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-1980"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000005-6, Sep. 25 (1980) - Jan. 25 (1982)"
+                  },
+                  "sort": [
+                    "         5-1980"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646682",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 3-4, July 5 (1979) - Sep. 22 (1980)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 3-4, July 5 (1979) - Sep. 22 (1980)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588931"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 3-4, July 5 (1979) - Sep. 22 (1980)"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588931"
+                    ],
+                    "idBarcode": [
+                      "33433093588931"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 3,
+                        "lte": 4
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1979",
+                        "lte": "1980"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         3-1979"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000003-4, July 5 (1979) - Sep. 22 (1980)"
+                  },
+                  "sort": [
+                    "         3-1979"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646662",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 v. 1-3, July 21 (1977) - June 21 (1979)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 v. 1-3, July 21 (1977) - June 21 (1979)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588949"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-3, July 21 (1977) - June 21 (1979)"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588949"
+                    ],
+                    "idBarcode": [
+                      "33433093588949"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 3
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1977",
+                        "lte": "1979"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-1977"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 v. 000001-3, July 21 (1977) - June 21 (1979)"
+                  },
+                  "sort": [
+                    "         1-1977"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646732",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 Oct. 3 (1988) - May 22 (1989) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 Oct. 3 (1988) - May 22 (1989) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588691"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Oct. 3 (1988) - May 22 (1989) Incomplete"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588691"
+                    ],
+                    "idBarcode": [
+                      "33433093588691"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1988",
+                        "lte": "1989"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1988"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 Oct. 3 (1988) - May 22 (1989) Incomplete"
+                  },
+                  "sort": [
+                    "          -1988"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27646689",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-T5363 Sep. 27 (1982) - Sep. 26 (1983) Incomplete"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-T5363 Sep. 27 (1982) - Sep. 26 (1983) Incomplete",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093588923"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Sep. 27 (1982) - Sep. 26 (1983) Incomplete"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-T5363"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093588923"
+                    ],
+                    "idBarcode": [
+                      "33433093588923"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1982",
+                        "lte": "1983"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1982"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-T5363 Sep. 27 (1982) - Sep. 26 (1983) Incomplete"
+                  },
+                  "sort": [
+                    "          -1982"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013630",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Music",
+            "Music -- Periodicals",
+            "Music, Latvian",
+            "Music, Latvian -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Latvijas muziku biedrība"
+          ],
+          "language": [
+            {
+              "id": "lang:lav",
+              "label": "Latvian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "19"
+          ],
+          "createdYear": [
+            19
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Latvijas muzikis"
+          ],
+          "shelfMark": [
+            "*ZAN-*Q1241"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "19"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Latvijas muziku biedrība."
+          ],
+          "dateStartYear": [
+            19
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZAN-*Q1241"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013630"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG0149-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213591"
+            }
+          ],
+          "idOclc": [
+            "NYPG0149-S"
+          ],
+          "dateEndYear": [
+            19
+          ],
+          "updatedAt": 1670258371750,
+          "publicationStatement": [
+            "Riga : Latvijas muziku biedrība"
+          ],
+          "identifier": [
+            "urn:bnum:10013630",
+            "urn:oclc:NYPG0149-S",
+            "urn:undefined:(WaOLN)nyp0213591"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "19"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Music -- Periodicals.",
+            "Music, Latvian -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Latvijas muzikis [microform]."
+          ],
+          "uri": "b10013630",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Riga"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10013630"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30780148",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZAN-*Q1241 1929-May 1934"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZAN-*Q1241 1929-May 1934",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433110389370"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1929-May 1934"
+                    ],
+                    "physicalLocation": [
+                      "*ZAN-*Q1241"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433110389370"
+                    ],
+                    "idBarcode": [
+                      "33433110389370"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*ZAN-*Q1241 1929-May 001934"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013632",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "1-"
+          ],
+          "subjectLiteral_exploded": [
+            "American poetry",
+            "American poetry -- Women authors",
+            "American poetry -- Women authors -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Brainchild Collective"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            999
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brainchild."
+          ],
+          "shelfMark": [
+            "JFK 81-88"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "999"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Brainchild Collective (Springfield, Ill.)"
+          ],
+          "dateStartYear": [
+            999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 81-88"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013632"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG015-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213593"
+            }
+          ],
+          "idOclc": [
+            "NYPG015-S"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1670011705835,
+          "publicationStatement": [
+            "[Springfield, Ill. : Brainchild Collective, 197?-    ]"
+          ],
+          "identifier": [
+            "urn:bnum:10013632",
+            "urn:oclc:NYPG015-S",
+            "urn:undefined:(WaOLN)nyp0213593"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "American poetry -- Women authors -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Brainchild."
+          ],
+          "uri": "b10013632",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Springfield, Ill."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10013632"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10006770",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JFK 81-88 v. 2-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFK 81-88 v. 2-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005347897"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2-4"
+                    ],
+                    "physicalLocation": [
+                      "JFK 81-88"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005347897"
+                    ],
+                    "idBarcode": [
+                      "33433005347897"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 4
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFK 81-88 v. 000002-4"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10013633",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "1981-"
+          ],
+          "subjectLiteral_exploded": [
+            "Statesmen",
+            "Statesmen -- Directories",
+            "International agencies",
+            "International agencies -- Directories"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lambert Publications"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            3
+          ],
+          "dateEndString": [
+            "198"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lambert's worldwide government directory with inter-governmental organizations."
+          ],
+          "shelfMark": [
+            "JLM 81-504"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLM 81-504"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10013633"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "7426456"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "7426456"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG0150-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0213594"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)7426456"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "RCON-EPA"
+            }
+          ],
+          "idOclc": [
+            "7426456",
+            "NYPG0150-S"
+          ],
+          "dateEndYear": [
+            198
+          ],
+          "updatedAt": 1669918511723,
+          "publicationStatement": [
+            "Washington : Lambert Publications, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10013633",
+            "urn:oclc:7426456",
+            "urn:oclc:NYPG0150-S",
+            "urn:undefined:(WaOLN)nyp0213594",
+            "urn:undefined:(OCoLC)7426456",
+            "urn:undefined:RCON-EPA"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Statesmen -- Directories.",
+            "International agencies -- Directories."
+          ],
+          "titleDisplay": [
+            "Lambert's worldwide government directory with inter-governmental organizations."
+          ],
+          "uri": "b10013633",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Washington"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "titleAlt": [
+            "Worldwide government directory with inter-governmental organizations"
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10013633"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540645",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-504 1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-504 1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019909617"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1984"
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-504"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019909617"
+                    ],
+                    "idBarcode": [
+                      "33433019909617"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJLM 81-504 001984"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540644",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-504 1982"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-504 1982",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019909609"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1982"
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-504"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019909609"
+                    ],
+                    "idBarcode": [
+                      "33433019909609"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJLM 81-504 001982"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540643",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-504 1981"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-504 1981",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019909591"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1981"
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-504"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019909591"
+                    ],
+                    "idBarcode": [
+                      "33433019909591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJLM 81-504 001981"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-a5cc44874bcc1fbd2f26e73d30f66daf.json
+++ b/test/fixtures/query-a5cc44874bcc1fbd2f26e73d30f66daf.json
@@ -1,0 +1,918 @@
+{
+  "took": 39,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.902664,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.902664,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-a6ab5f5028a6209fe696436643b92307.json
+++ b/test/fixtures/query-a6ab5f5028a6209fe696436643b92307.json
@@ -1,0 +1,23475 @@
+{
+  "took": 195,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 299,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004373",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 3- have imprint: Mysore : Sahyādri Prakāśana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuvempu, 1904-1994"
+          ],
+          "publisherLiteral": [
+            "Karnāṭaka Sahakārī Prakāśana Mandira"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 83-3417"
+          ],
+          "creatorLiteral": [
+            "Javare Gowda, Deve Gowda, 1918-"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902119"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-3417"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004373"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902119"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304738"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204365"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636109940889,
+          "publicationStatement": [
+            "Beṅgaḷūru] Karnāṭaka Sahakārī Prakāśana Mandira [1971]-"
+          ],
+          "identifier": [
+            "urn:bnum:10004373",
+            "urn:lccn:72902119",
+            "urn:undefined:NNSZ00304738",
+            "urn:undefined:(WaOLN)nyp0204365"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "titleDisplay": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu. [Lēkhaka] Dējagau."
+          ],
+          "uri": "b10004373",
+          "lccClassification": [
+            "PL4659.P797 S7934"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004373"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001707623"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "shelfMark_sort": "a*OLA 83-3417 Library has: Vol. 1, 3.",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003188",
+                    "shelfMark": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-3417 Library has: Vol. 1, 3."
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001707623"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001707623"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057523718"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-341"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-341 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i12858227",
+                    "shelfMark": [
+                      "*OLA 83-341 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-341 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057523718"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433057523718"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008327",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Editors vary.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Folk literature, Kannada",
+            "Folk literature, Kannada -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Adhyayana Pīṭha, Karnāṭaka Viśvavidyālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Jānapada sāhityadarśana"
+          ],
+          "shelfMark": [
+            "*OLA 83-2636"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75904046"
+          ],
+          "seriesStatement": [
+            "Jānapada sammēḷana smaraṇe ; 1-2, 4"
+          ],
+          "contributorLiteral": [
+            "Hiremath, Rudrayya Chandrayya, 1922-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-2636"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008327"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75904046"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00609733"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0208308"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108824394,
+          "publicationStatement": [
+            "Dhāravāḍa : Kannaḍa Adhyayana Pīṭha, Karnāṭaka Viśvavidyālaya, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10008327",
+            "urn:lccn:75904046",
+            "urn:undefined:NNSZ00609733",
+            "urn:undefined:(WaOLN)nyp0208308"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Folk literature, Kannada -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Jānapada sāhityadarśana / sampādakaru Ār. Si. Hirēmaṭha."
+          ],
+          "uri": "b10008327",
+          "lccClassification": [
+            "PL4654 .J3"
+          ],
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10008327"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013119130"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-2636"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-2636 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10004641",
+                    "shelfMark": [
+                      "*OLA 83-2636 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-2636 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013119130"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433013119130"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544246"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-2636"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-2636 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10004640",
+                    "shelfMark": [
+                      "*OLA 83-2636 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-2636 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544246"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433005544246"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544238"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-2636"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-2636 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10004639",
+                    "shelfMark": [
+                      "*OLA 83-2636 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-2636 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544238"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433005544238"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011457",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographic references and indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada and Sanskrit (Kannada script), includes quotations in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Music",
+            "Music -- India",
+            "Music -- India -- History and criticism",
+            "Carnatic music",
+            "Carnatic music -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Prasārāṅga, Maisuru Viśvavidyanilaya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrī Śārṅgadēva viracita Saṅgītaratnākara : Nihśaṅkahrdaya vemba Kannaḍa vyākhyāna samēta"
+          ],
+          "shelfMark": [
+            "JMM 86-1"
+          ],
+          "creatorLiteral": [
+            "Śārṅgadeva."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "contributorLiteral": [
+            "Satyanarayana, R."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMM 86-1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011457"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01213437"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211429"
+            }
+          ],
+          "uniformTitle": [
+            "Saṅgītaratnākara"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1653404645341,
+          "publicationStatement": [
+            "Maisūru : Prasārāṅga, Maisuru Viśvavidyanilaya, 1968-"
+          ],
+          "identifier": [
+            "urn:bnum:10011457",
+            "urn:undefined:NNSZ01213437",
+            "urn:undefined:(WaOLN)nyp0211429"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Music -- India -- History and criticism.",
+            "Carnatic music -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Śrī Śārṅgadēva viracita Saṅgītaratnākara : Nihśaṅkahrdaya vemba Kannaḍa vyākhyāna samēta / anuvāda mattu vyākhyāna, Ra. Satyanārāyaṇa (Maisūru Sahōdararu)."
+          ],
+          "uri": "b10011457",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maisūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Saṅgītaratnākara",
+            "Niḥśaṅkahrdaya."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10011457"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433068848849"
+                    ],
+                    "physicalLocation": [
+                      "JMM 86-1"
+                    ],
+                    "shelfMark_sort": "aJMM 86-1 v. 000001, pt. 1",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i14747261",
+                    "shelfMark": [
+                      "JMM 86-1 v. 1, pt. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JMM 86-1 v. 1, pt. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068848849"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1, pt. 1"
+                    ],
+                    "idBarcode": [
+                      "33433068848849"
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011462",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. illus., maps (part fold.)"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "India",
+            "India -- Description and travel"
+          ],
+          "publisherLiteral": [
+            "Prasārāṅga, Maisūru Viśvavidyānilaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Pravāsi kaṇḍa Iṇḍiyā."
+          ],
+          "shelfMark": [
+            "*OLA 86-308"
+          ],
+          "creatorLiteral": [
+            "Nāgēgauḍa, H. L."
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 67002221"
+          ],
+          "seriesStatement": [
+            "Maisūru Viśvavidyānilaya Kannaḍa granthamāle, 71, 84"
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 86-308"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011462"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 67002221"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01213442"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211434"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636123272140,
+          "publicationStatement": [
+            "[Maisūru] Prasārāṅga, Maisūru Viśvavidyānilaya, 1964-"
+          ],
+          "identifier": [
+            "urn:bnum:10011462",
+            "urn:lccn:sa 67002221",
+            "urn:undefined:NNSZ01213442",
+            "urn:undefined:(WaOLN)nyp0211434"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "India -- Description and travel."
+          ],
+          "titleDisplay": [
+            "Pravāsi kaṇḍa Iṇḍiyā. [Lēkhaka] Ec. El. Nāgēgauḍa."
+          ],
+          "uri": "b10011462",
+          "lccClassification": [
+            "DS409 .N3"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Maisūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10011462"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999664"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 86-308|zLibrary has: Vol. 4, 6."
+                    ],
+                    "shelfMark_sort": "a*OLA 86-308|zLibrary has: Vol. 4, 6. v. 000006",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10005558",
+                    "shelfMark": [
+                      "*OLA 86-308|zLibrary has: Vol. 4, 6. v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 86-308|zLibrary has: Vol. 4, 6. v. 6"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999664"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "idBarcode": [
+                      "33433012999664"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999656"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 86-308|zLibrary has: Vol. 4, 6."
+                    ],
+                    "shelfMark_sort": "a*OLA 86-308|zLibrary has: Vol. 4, 6. v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10005557",
+                    "shelfMark": [
+                      "*OLA 86-308|zLibrary has: Vol. 4, 6. v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 86-308|zLibrary has: Vol. 4, 6. v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999656"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433012999656"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011472",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes Jambukhaṇḍi Vadirājacāryaʼs Bhavāsucana ṭ̄kā and Vyāsadāsa's Siddhānta Kaumudī ṭīkā in Sanskrit (Kannada Script) with Kannada rendering by Kēśavācārya Jālihāḷa.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Dates taken from the book; vol. 6 published in 1964.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada; explanatory notes in Sanskrit (Kannada script) and Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vishnu (Hindu deity)",
+            "Vishnu (Hindu deity) -- Poetry",
+            "Dvaita (Vedanta)"
+          ],
+          "publisherLiteral": [
+            "H. Gorabāḷa"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1959
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrī Harikathāmrtasāra ṭīkā Pañcaratna prakāśikā"
+          ],
+          "shelfMark": [
+            "*OLA 86-1120"
+          ],
+          "creatorLiteral": [
+            "Jagannātha Dāsa, 1487-1547."
+          ],
+          "createdString": [
+            "1959"
+          ],
+          "seriesStatement": [
+            "Śrī Varadēndra Haridāsa Sāhitya Maṇḍala prakaṭane ; 72"
+          ],
+          "contributorLiteral": [
+            "Gorabāḷa, Hanumantarāva.",
+            "Jalihāḷa, Kēśavācārya."
+          ],
+          "dateStartYear": [
+            1959
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 86-1120"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011472"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01213452"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211444"
+            }
+          ],
+          "uniformTitle": [
+            "Harikathāmrtasāra"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1653404645185,
+          "publicationStatement": [
+            "Lingasūgūru : H. Gorabāḷa, 1959?-"
+          ],
+          "identifier": [
+            "urn:bnum:10011472",
+            "urn:undefined:NNSZ01213452",
+            "urn:undefined:(WaOLN)nyp0211444"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1959"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vishnu (Hindu deity) -- Poetry.",
+            "Dvaita (Vedanta)"
+          ],
+          "titleDisplay": [
+            "Śrī Harikathāmrtasāra ṭīkā Pañcaratna prakāśikā / Śrīmajjagannātha Dāsārya viracita ; sandhigaḷa sāra Gorabāḷa (Sundara Viṭhala)"
+          ],
+          "uri": "b10011472",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Lingasūgūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Harikathāmrtasāra",
+            "Pancaratna prakāśikā."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10011472"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013000082"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 86-1120|zLibrary has: Vol. 6."
+                    ],
+                    "shelfMark_sort": "a*OLA 86-1120|zLibrary has: Vol. 6. v. 000006",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10005568",
+                    "shelfMark": [
+                      "*OLA 86-1120|zLibrary has: Vol. 6. v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 86-1120|zLibrary has: Vol. 6. v. 6"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013000082"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "idBarcode": [
+                      "33433013000082"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011759",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes music in letter notation.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: v. 1, p. [204]",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Carnatic music",
+            "Carnatic music -- History and criticism",
+            "Songs, Telugu"
+          ],
+          "publisherLiteral": [
+            "Prasārāṅga, Maisūru Viśvavidyānilaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kīrtana darpaṇa : prāyōgika saṅgītaśāstra"
+          ],
+          "shelfMark": [
+            "JML 86-5"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75907259"
+          ],
+          "seriesStatement": [
+            "Paṭhyapustaka māle ; 76"
+          ],
+          "contributorLiteral": [
+            "Anantharamaiah, R. L., 1937-",
+            "Ramaratnam, V., 1917-",
+            "Ratna, M. V."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JML 86-5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011759"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75907259"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01314591"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211726"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636110092201,
+          "publicationStatement": [
+            "Maisūru : Prasārāṅga, Maisūru Viśvavidyānilaya, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10011759",
+            "urn:lccn:75907259",
+            "urn:undefined:NNSZ01314591",
+            "urn:undefined:(WaOLN)nyp0211726"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Carnatic music -- History and criticism.",
+            "Songs, Telugu."
+          ],
+          "titleDisplay": [
+            "Kīrtana darpaṇa : prāyōgika saṅgītaśāstra / sampādakaru Vi. Rāmaratnaṃ, Eṃ. Vi. Ratna, Ār. El. Anantarāmayya."
+          ],
+          "uri": "b10011759",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maisūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10011759"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433068817299"
+                    ],
+                    "physicalLocation": [
+                      "JML 86-5"
+                    ],
+                    "shelfMark_sort": "aJML 86-5 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i14747298",
+                    "shelfMark": [
+                      "JML 86-5 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JML 86-5 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068817299"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433068817299"
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10011947",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Encyclopedias and dictionaries, Kannada",
+            "Folklore",
+            "Folklore -- Karnataka",
+            "Folklore -- Karnataka -- Dictionaries"
+          ],
+          "publisherLiteral": [
+            "Kannada Sāhitya Pariṣattu,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa jānapada viśvakōśa"
+          ],
+          "shelfMark": [
+            "*OLA 86-2952"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "85904648"
+          ],
+          "contributorLiteral": [
+            "Kambar, Chandrasekhara, 1938-"
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 86-2952"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10011947"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "85904648"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01313921"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0211913"
+            }
+          ],
+          "updatedAt": 1636108864346,
+          "publicationStatement": [
+            "Beṅgaḷūru : Kannada Sāhitya Pariṣattu, 1985."
+          ],
+          "identifier": [
+            "urn:bnum:10011947",
+            "urn:lccn:85904648",
+            "urn:undefined:NNSZ01313921",
+            "urn:undefined:(WaOLN)nyp0211913"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Encyclopedias and dictionaries, Kannada.",
+            "Folklore -- Karnataka -- Dictionaries."
+          ],
+          "titleDisplay": [
+            "Kannaḍa jānapada viśvakōśa / sampadakaru, Candraśēkhara Kambāra."
+          ],
+          "uri": "b10011947",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10011947"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013001759"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 86-2952"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-2952 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10005916",
+                    "shelfMark": [
+                      "*OLA 86-2952 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 86-2952 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013001759"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433013001759"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013001767"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 86-2952"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-2952 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10005915",
+                    "shelfMark": [
+                      "*OLA 86-2952 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 86-2952 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013001767"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433013001767"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10012152",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xviii, 128, [16] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Texts of English poems translated by B. M. Srikantayya, 1884-1946, with titles also in Kannada and citations for Kannada translations: p. [57]-128, [16].",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added title in English on verso of t.p.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Śrīkaṇṭhayya, Bi. Eṃ., 1884-1946"
+          ],
+          "publisherLiteral": [
+            "Bi. Eṃ. Śrī. Smāraka Pratiṣṭhāna"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrīgandha : Bi. Eṃ. Śrī. janmaśatamānōtsava saṃsmaraṇa sañcike"
+          ],
+          "shelfMark": [
+            "*OLA 86-3118"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "85910191"
+          ],
+          "contributorLiteral": [
+            "Śrīnivāsarāju, Ci., 1942-2007."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 86-3118"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10012152"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "85910191"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01314127"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0212117"
+            }
+          ],
+          "updatedAt": 1653404646740,
+          "publicationStatement": [
+            "Beṅgaḷūru : Bi. Eṃ. Śrī. Smāraka Pratiṣṭhāna, 1985."
+          ],
+          "identifier": [
+            "urn:bnum:10012152",
+            "urn:lccn:85910191",
+            "urn:undefined:NNSZ01314127",
+            "urn:undefined:(WaOLN)nyp0212117"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Śrīkaṇṭhayya, Bi. Eṃ., 1884-1946."
+          ],
+          "titleDisplay": [
+            "Śrīgandha : Bi. Eṃ. Śrī. janmaśatamānōtsava saṃsmaraṇa sañcike / sampādakaru Ci. Śrīnivāsarāju ... [et al.]."
+          ],
+          "uri": "b10012152",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10012152"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013002005"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 86-3118"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-003118",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10006103",
+                    "shelfMark": [
+                      "*OLA 86-3118"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 86-3118"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013002005"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013002005"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10015200",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxi, 220, 14 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A poem, with prose version.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bhīma (Hindu mythology)",
+            "Bhīma (Hindu mythology) -- Poetry"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Sāhitya Pariṣattu,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sāhasabhīmavijayaṃ (Gadāyuddhaṃ)"
+          ],
+          "shelfMark": [
+            "*OLA 87-2376"
+          ],
+          "creatorLiteral": [
+            "Ranna, active 993."
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86903378"
+          ],
+          "seriesStatement": [
+            "Vajramahōtsava varṣa pañcavārṣika yōjaneya pustakamāle"
+          ],
+          "contributorLiteral": [
+            "Kulakarṇi, Ār. Vi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 87-2376"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10015200"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86903378"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01618431"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0215159"
+            }
+          ],
+          "uniformTitle": [
+            "Gadayuddha"
+          ],
+          "updatedAt": 1636098054027,
+          "publicationStatement": [
+            "Beṅgaḷūru : Kannaḍa Sāhitya Pariṣattu, 1985."
+          ],
+          "identifier": [
+            "urn:bnum:10015200",
+            "urn:lccn:86903378",
+            "urn:undefined:NNSZ01618431",
+            "urn:undefined:(WaOLN)nyp0215159"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bhīma (Hindu mythology) -- Poetry."
+          ],
+          "titleDisplay": [
+            "Sāhasabhīmavijayaṃ (Gadāyuddhaṃ) / Kavicakravarti Kaviranna viracitam ; gadyānuvāda Ār. Vi. Kulakarṇi."
+          ],
+          "uri": "b10015200",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Gadayuddha",
+            "Sāhasabhīma vijaya."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10015200"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013128214"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-002376",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10007322",
+                    "shelfMark": [
+                      "*OLA 87-2376"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013128214"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013128214"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10015230",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Kannada and Sanskrit; introductory matter in Kannada.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 5 published in 1978.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added English t.p.: a practical Samskrita-Kannada dictionary.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Dictionaries",
+            "Sanskrit language -- Dictionaries -- Kannada"
+          ],
+          "publisherLiteral": [
+            "Gōpālācārya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śabdārthakaustubhaṃ : prāyōgika Saṃskrta-Karṇāṭaka śabdakōśa = Saṃskrta-Kannaḍa śabdakōśa"
+          ],
+          "shelfMark": [
+            "*OLA 87-2131"
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "contributorLiteral": [
+            "Gōpālācārya, Cakravarti Śrīnivāsa."
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 87-2131"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10015230"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01618462"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0215189"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1653404650786,
+          "publicationStatement": [
+            "Beṅgaḷūru : Gōpālācārya, 1978?-"
+          ],
+          "identifier": [
+            "urn:bnum:10015230",
+            "urn:undefined:NNSZ01618462",
+            "urn:undefined:(WaOLN)nyp0215189"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Dictionaries -- Kannada."
+          ],
+          "titleDisplay": [
+            "Śabdārthakaustubhaṃ : prāyōgika Saṃskrta-Karṇāṭaka śabdakōśa = Saṃskrta-Kannaḍa śabdakōśa / granthakarta-prakāśaka Cakravarti Śrīnivāsa Gōpālācārya."
+          ],
+          "uri": "b10015230",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Saṃskrta-Kannaḍa śabdakōśa.",
+            "Sanskrit-Kannada dictionary.",
+            "Practical Samskrita-Kannada dictionary."
+          ],
+          "tableOfContents": [
+            "4. Namaskāra-Bahuvīrya -- 5. Bahuvrīhi - Vēdānta -- 6. Vedāntin- Hveya."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10015230"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013128156"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-002131",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10007343",
+                    "shelfMark": [
+                      "*OLA 87-2131"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013128156"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013128156"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013128149"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-002131",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10007342",
+                    "shelfMark": [
+                      "*OLA 87-2131"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013128149"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013128149"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013128164"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-002131",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10007344",
+                    "shelfMark": [
+                      "*OLA 87-2131"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013128164"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013128164"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10015231",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. (some col.)"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Pañcama puṣpa.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 5 published in 1966.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada; includes quotations in Sanskrit (Kannada script).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vādirāja, active 16th century",
+            "Dvaita (Vedanta)"
+          ],
+          "publisherLiteral": [
+            "Gurukrpā Granthamālā : pustaka doreyuva sthaḷa, Gōvindarāv, Beṅgaḷūru"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrī Vādirāja rjutva prakāśikā"
+          ],
+          "shelfMark": [
+            "*OKN 87-2441"
+          ],
+          "creatorLiteral": [
+            "Guru Gōvinda Viṭhala Dāsaru."
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 87-2441"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10015231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01618463"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0215190"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1653404650775,
+          "publicationStatement": [
+            "Maisūru : Gurukrpā Granthamālā : pustaka doreyuva sthaḷa, Gōvindarāv, Beṅgaḷūru, 1966-"
+          ],
+          "identifier": [
+            "urn:bnum:10015231",
+            "urn:undefined:NNSZ01618463",
+            "urn:undefined:(WaOLN)nyp0215190"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vādirāja, active 16th century.",
+            "Dvaita (Vedanta)"
+          ],
+          "titleDisplay": [
+            "Śrī Vādirāja rjutva prakāśikā / Guru Gōvinda Vithala Dāsaru."
+          ],
+          "uri": "b10015231",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maisūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10015231"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058620984"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 87-2441 Library has: Vol. 5."
+                    ],
+                    "shelfMark_sort": "a*OKN 87-2441 Library has: Vol. 5. v. 000005",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13786568",
+                    "shelfMark": [
+                      "*OKN 87-2441 Library has: Vol. 5. v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKN 87-2441 Library has: Vol. 5. v. 5"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058620984"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "idBarcode": [
+                      "33433058620984"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10016133",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "43 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Yakṣagāna plays"
+          ],
+          "publisherLiteral": [
+            "Ār. Viṭṭappa Śeṇai eṇḍ Sans,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "1985"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Krṣṇagāruḍi emba yakṣagāna prasaṅgavu : Bhīmārjuna garvabhaṅga : Mahabhārata purāṇāntargata"
+          ],
+          "shelfMark": [
+            "*OLA 87-3857"
+          ],
+          "creatorLiteral": [
+            "Śrīnivāsa Nāyak, Kōṭa."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "idLccn": [
+            "77913591"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 87-3857"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10016133"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77913591"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01719432"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0216084"
+            }
+          ],
+          "dateEndYear": [
+            1985
+          ],
+          "updatedAt": 1636109877952,
+          "publicationStatement": [
+            "Kārkaḷa, Da. Ka. : Ār. Viṭṭappa Śeṇai eṇḍ Sans, [19-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10016133",
+            "urn:lccn:77913591",
+            "urn:undefined:NNSZ01719432",
+            "urn:undefined:(WaOLN)nyp0216084"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Yakṣagāna plays."
+          ],
+          "titleDisplay": [
+            "Krṣṇagāruḍi emba yakṣagāna prasaṅgavu : Bhīmārjuna garvabhaṅga : Mahabhārata purāṇāntargata / lēkhaka, Kōta Śrīnivāsa Nāyak."
+          ],
+          "uri": "b10016133",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kārkaḷa, Da. Ka. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10016133"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013126648"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-003857",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10007595",
+                    "shelfMark": [
+                      "*OLA 87-3857"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013126648"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013126648"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10016294",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xliv, 96, 22 p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada (Kannada and roman scripts); paraphrase in English and Kannada; introd. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada language",
+            "Kannada language -- Grammar"
+          ],
+          "publisherLiteral": [
+            "Asian Educational Services,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "1884"
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nāga Varmā's Karnātaka bhāshā-bhūshana : the oldest grammar extant of the language Karṇāṭaka bhāṣābhūṣana"
+          ],
+          "shelfMark": [
+            "*OLA 87-1958"
+          ],
+          "creatorLiteral": [
+            "Nāgavarma, active 12th century."
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "85901530"
+          ],
+          "contributorLiteral": [
+            "Rice, B. Lewis (Benjamin Lewis), 1837-1927."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 87-1958"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10016294"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "85901530"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01719593"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0216245"
+            }
+          ],
+          "uniformTitle": [
+            "Karṇāṭaka bhāṣabhūṣaṇa"
+          ],
+          "dateEndYear": [
+            1884
+          ],
+          "updatedAt": 1636108982258,
+          "publicationStatement": [
+            "New Delhi : Asian Educational Services, 1985."
+          ],
+          "identifier": [
+            "urn:bnum:10016294",
+            "urn:lccn:85901530",
+            "urn:undefined:NNSZ01719593",
+            "urn:undefined:(WaOLN)nyp0216245"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Nāga Varmā's Karnātaka bhāshā-bhūshana : the oldest grammar extant of the language Karṇāṭaka bhāṣābhūṣana / Nāgavarma krta ; edited with an introduction, Lewis Rice."
+          ],
+          "uri": "b10016294",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Karṇāṭaka bhāṣabhūṣaṇa"
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10016294"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013128081"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-001958",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10007686",
+                    "shelfMark": [
+                      "*OLA 87-1958"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013128081"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013128081"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10016426",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 published in 1968.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada; introductory matter in English or Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Karnāṭaka Viśvavidyālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bhairavēśvara kāvyada kathāmaṇisūtraratnākara"
+          ],
+          "shelfMark": [
+            "*OLA 87-3543"
+          ],
+          "creatorLiteral": [
+            "Śāntaliṅgadēśika."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "seriesStatement": [
+            "Karnāṭaka Viśvavidyālaya : Kannaḍa kāvyamāle ; 7"
+          ],
+          "contributorLiteral": [
+            "Hiremath, Rudrayya Chandrayya, 1922-",
+            "Sunkapur, M. S."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 87-3543"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10016426"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01719726"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0216377"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636077680351,
+          "publicationStatement": [
+            "Dhāravāḍa : Karnāṭaka Viśvavidyālaya, 1968-"
+          ],
+          "identifier": [
+            "urn:bnum:10016426",
+            "urn:undefined:NNSZ01719726",
+            "urn:undefined:(WaOLN)nyp0216377"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Bhairavēśvara kāvyada kathāmaṇisūtraratnākara / Śāntaliṅgadēśika krta ; sampādakaru Ār. Si. Hirēmaṭha, Eṃ. Es. Sunkāpura."
+          ],
+          "uri": "b10016426",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10016426"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013126325"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-003543",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10007795",
+                    "shelfMark": [
+                      "*OLA 87-3543"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013126325"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013126325"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10016756",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "vii, 262 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Five hundred Indian plants, in Kanarese.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada; includes scientific names in Latin; popular names in English and Indic languages (Kannada script).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Medicinal plants",
+            "Medicinal plants -- India",
+            "Medicinal plants -- India -- Dictionaries"
+          ],
+          "publisherLiteral": [
+            "Periodical Expert Book Agency,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "1922"
+          ],
+          "createdYear": [
+            1986
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Five hundred Indian plants, their use in medicine and arts Sahasrārdha vrkṣādigaḷa varṇane."
+          ],
+          "shelfMark": [
+            "*OLA 87-4611"
+          ],
+          "createdString": [
+            "1986"
+          ],
+          "idLccn": [
+            "87900750"
+          ],
+          "dateStartYear": [
+            1986
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 87-4611"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10016756"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "87900750"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01820065"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0216706"
+            }
+          ],
+          "dateEndYear": [
+            1922
+          ],
+          "updatedAt": 1636096234866,
+          "publicationStatement": [
+            "Delhi, India : Periodical Expert Book Agency, 1986."
+          ],
+          "identifier": [
+            "urn:bnum:10016756",
+            "urn:lccn:87900750",
+            "urn:undefined:NNSZ01820065",
+            "urn:undefined:(WaOLN)nyp0216706"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1986"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Medicinal plants -- India -- Dictionaries."
+          ],
+          "titleDisplay": [
+            "Five hundred Indian plants, their use in medicine and arts Sahasrārdha vrkṣādigaḷa varṇane."
+          ],
+          "uri": "b10016756",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Delhi, India :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sahasrārdha vrkṣādigaḷa varṇane."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10016756"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013271295"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 87-4611"
+                    ],
+                    "shelfMark_sort": "a*OLA 87-004611",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10008066",
+                    "shelfMark": [
+                      "*OLA 87-4611"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 87-4611"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013271295"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013271295"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10315622",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Description based on: 46, 1 (Mar./Apr. 1964); title from cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: Sampuṭa 85, san̄ike 336/338 (2005/2006).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada literature",
+            "Kannada literature -- Periodicals",
+            "Karnataka (India)",
+            "Karnataka (India) -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            20
+          ],
+          "publisherLiteral": [
+            "Maisūru Viśvevidyānilaya."
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "numItemsTotal": [
+            50
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            999
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Prabuddha Karṇāṭaka."
+          ],
+          "shelfMark": [
+            "*OLA 76-1248"
+          ],
+          "numItemVolumesParsed": [
+            46
+          ],
+          "createdString": [
+            "999"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            999
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 76-1248"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10315622"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG764781564-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0318890"
+            }
+          ],
+          "idOclc": [
+            "NYPG764781564-S"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "46(1964/65)-56(1974/75),60(1978/79), 62(1980/81)-63(1981/82), 65(1983/84)-68(1986/87),70(1988)-71(1989/90), 74(1992/93)-80(1999), 84(2003)-85(2004/2007)-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "No. 74 (1992)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "No. 75 (1993)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "No. 76-77 (1996)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "No. 78-79 (1998)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "No. 80 (1999)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 82 No. 323/326 (2001)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "Vol. 84 No. 331/334 (2003)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "Vol. 85 No. 335-338 (2004)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "Vol. 88 No. 343-346 (2010)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "Vol. 89 No. 347-350 (2013)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "Vol. 91 No. 351 (2014)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Bound"
+                },
+                {
+                  "coverage": "",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*OLA 76-1248"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*OLA 76-1248"
+                }
+              ],
+              "physicalLocation": [
+                "*OLA 76-1248"
+              ],
+              "location": [
+                {
+                  "code": "loc:rc2ma",
+                  "label": "Offsite"
+                }
+              ],
+              "uri": "h1066378",
+              "shelfMark": [
+                "*OLA 76-1248"
+              ]
+            }
+          ],
+          "updatedAt": 1675260501608,
+          "publicationStatement": [
+            "Maisūru, Maisūru Viśvevidyānilaya."
+          ],
+          "identifier": [
+            "urn:bnum:10315622",
+            "urn:oclc:NYPG764781564-S",
+            "urn:undefined:(WaOLN)nyp0318890"
+          ],
+          "numCheckinCardItems": [
+            14
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada literature -- Periodicals.",
+            "Karnataka (India) -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Prabuddha Karṇāṭaka."
+          ],
+          "uri": "b10315622",
+          "numItems": [
+            36
+          ],
+          "numAvailable": [
+            36
+          ],
+          "placeOfPublication": [
+            "Maisūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10315622"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 36,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 49
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36286477",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 91 no. 351 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 91 no. 351 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121642221"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 91 no. 351 (2014)"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121642221"
+                    ],
+                    "idBarcode": [
+                      "33433121642221"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 91,
+                        "lte": 91
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        91-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000091 no. 351 (2014)"
+                  },
+                  "sort": [
+                    "        91-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 48
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33724983",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 89 no. 347-350 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 89 no. 347-350 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433117979967"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 89 no. 347-350 (2013)"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433117979967"
+                    ],
+                    "idBarcode": [
+                      "33433117979967"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 89,
+                        "lte": 89
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        89-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000089 no. 347-350 (2013)"
+                  },
+                  "sort": [
+                    "        89-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 47
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33721281",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 88 no. 343-346 (2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 88 no. 343-346 (2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433117980106"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 88 no. 343-346 (2010)"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433117980106"
+                    ],
+                    "idBarcode": [
+                      "33433117980106"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 88,
+                        "lte": 88
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        88-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000088 no. 343-346 (2010)"
+                  },
+                  "sort": [
+                    "        88-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 46
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23191778",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 85, no. 335/338 (2004/ 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 85, no. 335/338 (2004/ 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085539777"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 85, no. 335/338 (2004/ 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085539777"
+                    ],
+                    "idBarcode": [
+                      "33433085539777"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 85,
+                        "lte": 85
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        85-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000085, no. 335/338 (2004/ 2007)"
+                  },
+                  "sort": [
+                    "        85-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 45
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23191779",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 84, no. 331/334 (2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 84, no. 331/334 (2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085541104"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 84, no. 331/334 (2003)"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085541104"
+                    ],
+                    "idBarcode": [
+                      "33433085541104"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 84,
+                        "lte": 84
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        84-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000084, no. 331/334 (2003)"
+                  },
+                  "sort": [
+                    "        84-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 44
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17458423",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcma2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcma2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 82, no. 323/326 (2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 82, no. 323/326 (2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074631197"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 82, no. 323/326 (2001)"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074631197"
+                    ],
+                    "idBarcode": [
+                      "33433074631197"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 82,
+                        "lte": 82
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        82-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000082, no. 323/326 (2001)"
+                  },
+                  "sort": [
+                    "        82-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 43
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074597",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 78-79 (1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 78-79 (1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013574946"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 78-79 (1998)"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013574946"
+                    ],
+                    "idBarcode": [
+                      "33433013574946"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 78,
+                        "lte": 79
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1998",
+                        "lte": "1998"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        78-1998"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000078-79 (1998)"
+                  },
+                  "sort": [
+                    "        78-1998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 42
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12950094",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 76-77 (1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 76-77 (1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015942182"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 76-77 (1996)"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015942182"
+                    ],
+                    "idBarcode": [
+                      "33433015942182"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 76,
+                        "lte": 77
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        76-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000076-77 (1996)"
+                  },
+                  "sort": [
+                    "        76-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 41
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074595",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 75"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 75",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575918"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 75"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575918"
+                    ],
+                    "idBarcode": [
+                      "33433014575918"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 75,
+                        "lte": 75
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        75-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000075"
+                  },
+                  "sort": [
+                    "        75-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 40
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074594",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 74"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 74",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575900"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 74"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575900"
+                    ],
+                    "idBarcode": [
+                      "33433014575900"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 74,
+                        "lte": 74
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        74-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000074"
+                  },
+                  "sort": [
+                    "        74-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 39
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31158194",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 73 (1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 73 (1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433111366286"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 73 (1992)"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433111366286"
+                    ],
+                    "idBarcode": [
+                      "33433111366286"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 73,
+                        "lte": 73
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1992",
+                        "lte": "1992"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        73-1992"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000073 (1992)"
+                  },
+                  "sort": [
+                    "        73-1992"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 38
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074592",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 72"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 72",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576510"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 72"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576510"
+                    ],
+                    "idBarcode": [
+                      "33433014576510"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 72,
+                        "lte": 72
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        72-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000072"
+                  },
+                  "sort": [
+                    "        72-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 37
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074591",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 71"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 71",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576502"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 71"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576502"
+                    ],
+                    "idBarcode": [
+                      "33433014576502"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 71,
+                        "lte": 71
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        71-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000071"
+                  },
+                  "sort": [
+                    "        71-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 36
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074593",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 70"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 70",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576528"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576528"
+                    ],
+                    "idBarcode": [
+                      "33433014576528"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000070"
+                  },
+                  "sort": [
+                    "        70-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 35
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074588",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 68"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 68",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576478"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 68"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576478"
+                    ],
+                    "idBarcode": [
+                      "33433014576478"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 68,
+                        "lte": 68
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        68-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000068"
+                  },
+                  "sort": [
+                    "        68-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 34
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074587",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 67"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 67",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576460"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 67"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576460"
+                    ],
+                    "idBarcode": [
+                      "33433014576460"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 67,
+                        "lte": 67
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        67-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000067"
+                  },
+                  "sort": [
+                    "        67-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 33
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074589",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576486"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 66"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576486"
+                    ],
+                    "idBarcode": [
+                      "33433014576486"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 66,
+                        "lte": 66
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        66-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000066"
+                  },
+                  "sort": [
+                    "        66-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 32
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074590",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 65"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 65",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576494"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 65"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576494"
+                    ],
+                    "idBarcode": [
+                      "33433014576494"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 65,
+                        "lte": 65
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        65-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000065"
+                  },
+                  "sort": [
+                    "        65-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 31
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074586",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 63"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 63",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576452"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 63"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576452"
+                    ],
+                    "idBarcode": [
+                      "33433014576452"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 63,
+                        "lte": 63
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        63-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000063"
+                  },
+                  "sort": [
+                    "        63-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 30
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074585",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 62"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 62",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576445"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 62"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576445"
+                    ],
+                    "idBarcode": [
+                      "33433014576445"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 62,
+                        "lte": 62
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        62-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000062"
+                  },
+                  "sort": [
+                    "        62-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 29
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074584",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 60"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 60",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576437"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 60"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576437"
+                    ],
+                    "idBarcode": [
+                      "33433014576437"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 60,
+                        "lte": 60
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        60-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000060"
+                  },
+                  "sort": [
+                    "        60-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 28
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074583",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 56, no. 1-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 56, no. 1-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576429"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 56, no. 1-4"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576429"
+                    ],
+                    "idBarcode": [
+                      "33433014576429"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 56,
+                        "lte": 56
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        56-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000056, no. 1-4"
+                  },
+                  "sort": [
+                    "        56-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 27
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074582",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 55"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 55",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576411"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 55"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576411"
+                    ],
+                    "idBarcode": [
+                      "33433014576411"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 55,
+                        "lte": 55
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        55-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000055"
+                  },
+                  "sort": [
+                    "        55-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 26
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074581",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 54"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 54",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576049"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 54"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576049"
+                    ],
+                    "idBarcode": [
+                      "33433014576049"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 54,
+                        "lte": 54
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        54-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000054"
+                  },
+                  "sort": [
+                    "        54-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 25
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074580",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 53"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 53",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576031"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 53"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576031"
+                    ],
+                    "idBarcode": [
+                      "33433014576031"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 53,
+                        "lte": 53
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        53-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000053"
+                  },
+                  "sort": [
+                    "        53-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 24
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074579",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 52, no. 3-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 52, no. 3-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576023"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 52, no. 3-4"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576023"
+                    ],
+                    "idBarcode": [
+                      "33433014576023"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 52,
+                        "lte": 52
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        52-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000052, no. 3-4"
+                  },
+                  "sort": [
+                    "        52-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 23
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074578",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 51, no. 3-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 51, no. 3-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576015"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 51, no. 3-4"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576015"
+                    ],
+                    "idBarcode": [
+                      "33433014576015"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 51,
+                        "lte": 51
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        51-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000051, no. 3-4"
+                  },
+                  "sort": [
+                    "        51-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 22
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074577",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 50, no. 3-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 50, no. 3-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576007"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 50, no. 3-4"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576007"
+                    ],
+                    "idBarcode": [
+                      "33433014576007"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 50,
+                        "lte": 50
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        50-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000050, no. 3-4"
+                  },
+                  "sort": [
+                    "        50-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 21
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074576",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 50, no. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 50, no. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575991"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 50, no. 1-2"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575991"
+                    ],
+                    "idBarcode": [
+                      "33433014575991"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 50,
+                        "lte": 50
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        50-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000050, no. 1-2"
+                  },
+                  "sort": [
+                    "        50-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 20
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074575",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 49"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 49",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575983"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 49"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575983"
+                    ],
+                    "idBarcode": [
+                      "33433014575983"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 49,
+                        "lte": 49
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        49-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000049"
+                  },
+                  "sort": [
+                    "        49-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 19
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074573",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 48, no. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 48, no. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575967"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 48, no. 1-2"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575967"
+                    ],
+                    "idBarcode": [
+                      "33433014575967"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 48,
+                        "lte": 48
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        48-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000048, no. 1-2"
+                  },
+                  "sort": [
+                    "        48-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 18
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074574",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 48 no. 3-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 48 no. 3-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575975"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 48 no. 3-4"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575975"
+                    ],
+                    "idBarcode": [
+                      "33433014575975"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 48,
+                        "lte": 48
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        48-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000048 no. 3-4"
+                  },
+                  "sort": [
+                    "        48-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 17
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074572",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 47, no. 1-4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 47, no. 1-4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575959"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 47, no. 1-4"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575959"
+                    ],
+                    "idBarcode": [
+                      "33433014575959"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 47,
+                        "lte": 47
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        47-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000047, no. 1-4"
+                  },
+                  "sort": [
+                    "        47-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 16
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074571",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 46, no. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 46, no. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575942"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 46, no. 4"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575942"
+                    ],
+                    "idBarcode": [
+                      "33433014575942"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 46,
+                        "lte": 46
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        46-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000046, no. 4"
+                  },
+                  "sort": [
+                    "        46-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 15
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074570",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248 v. 46, no. 1-3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248 v. 46, no. 1-3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014575934"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 46, no. 1-3"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014575934"
+                    ],
+                    "idBarcode": [
+                      "33433014575934"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 46,
+                        "lte": 46
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        46-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-1248 v. 000046, no. 1-3"
+                  },
+                  "sort": [
+                    "        46-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 14
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10074596",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 76-1248"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 76-1248",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001543184"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 76-1248"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001543184"
+                    ],
+                    "idBarcode": [
+                      "33433001543184"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 76-001248"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10379755",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14 v. : ill. (part col.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Published by the Institute of Kannada studies, University of Mysore.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Encyclopedias and dictionaries, Kannada"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Adhyayana Saṃsthe, Maisūru Viśvavidāyanilaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa viśvakośa"
+          ],
+          "shelfMark": [
+            "*OLA+ 76-462"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "sa 73910921"
+          ],
+          "contributorLiteral": [
+            "Javare Gowda, Deve Gowda, 1918-",
+            "University of Mysore. Institute of Kannada Studies."
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA+ 76-462"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10379755"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 73910921"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN764423629"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0383283"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108872056,
+          "publicationStatement": [
+            "Maisūru : Kannaḍa Adhyayana Saṃsthe, Maisūru Viśvavidāyanilaya, 1971-2004."
+          ],
+          "identifier": [
+            "urn:bnum:10379755",
+            "urn:lccn:sa 73910921",
+            "urn:undefined:NN764423629",
+            "urn:undefined:(WaOLN)nyp0383283"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Encyclopedias and dictionaries, Kannada."
+          ],
+          "titleDisplay": [
+            "Kannaḍa viśvakośa / chief editor D. Javare Gowda."
+          ],
+          "uri": "b10379755",
+          "numItems": [
+            12
+          ],
+          "numAvailable": [
+            12
+          ],
+          "placeOfPublication": [
+            "Maisūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10379755"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 12,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 11
+                  },
+                  "_score": null,
+                  "_source": {
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433069710808"
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000014",
+                    "catalogItemType_packed": [
+                      "catalogItemType:65||book, good condition, non-MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i17460427",
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA+ 76-462 v. 14"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433069710808"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "idBarcode": [
+                      "33433069710808"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:65",
+                        "label": "book, good condition, non-MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433069710790"
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000013",
+                    "catalogItemType_packed": [
+                      "catalogItemType:65||book, good condition, non-MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i17460426",
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 13"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA+ 76-462 v. 13"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433069710790"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 13"
+                    ],
+                    "idBarcode": [
+                      "33433069710790"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:65",
+                        "label": "book, good condition, non-MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842282"
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000012",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13837533",
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 12"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA+ 76-462 v. 12"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842282"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 12"
+                    ],
+                    "idBarcode": [
+                      "33433057842282"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842274"
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000011",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13837532",
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 11"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA+ 76-462 v. 11"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842274"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 11"
+                    ],
+                    "idBarcode": [
+                      "33433057842274"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842266"
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000009",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13837531",
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA+ 76-462 v. 9"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842266"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9"
+                    ],
+                    "idBarcode": [
+                      "33433057842266"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842258"
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000007",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13837530",
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA+ 76-462 v. 7"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842258"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "idBarcode": [
+                      "33433057842258"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842241"
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000006",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13837529",
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA+ 76-462 v. 6"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842241"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "idBarcode": [
+                      "33433057842241"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842233"
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000005",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13837528",
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA+ 76-462 v. 5"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842233"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "idBarcode": [
+                      "33433057842233"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842225"
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13837527",
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA+ 76-462 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842225"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433057842225"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842217"
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13837526",
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA+ 76-462 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842217"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433057842217"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842209"
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13837525",
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA+ 76-462 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842209"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433057842209"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842191"
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 76-462"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 76-462 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13837524",
+                    "shelfMark": [
+                      "*OLA+ 76-462 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA+ 76-462 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842191"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433057842191"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10387344",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. <1-9> ; "
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 1-5, & 7 has subtitle: Mudrita Kannaḍa krtigaḷa vivarāṇātmaka granthasūci 1817-1968.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada imprints"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Prasarāṅga, Maisūru Viśvavidyānilaya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "numItemsTotal": [
+            9
+          ],
+          "createdYear": [
+            1971
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa granthasūci; mudrita Kannaḍa krtigala vivaraṇātmaka granthasūci."
+          ],
+          "shelfMark": [
+            "*OLA 75-3000"
+          ],
+          "numItemVolumesParsed": [
+            9
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "sa 71922330"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Javare Gowda, Deve Gowda, 1918-"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 75-3000"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10387344"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 71922330"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "13887294"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "13887294"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG764506752-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN764506752"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0390904"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)13887294"
+            }
+          ],
+          "idOclc": [
+            "13887294",
+            "NYPG764506752-B"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1675264211896,
+          "publicationStatement": [
+            "Maisūru] Prasarāṅga, Maisūru Viśvavidyānilaya, 1971-<2003>"
+          ],
+          "identifier": [
+            "urn:bnum:10387344",
+            "urn:lccn:sa 71922330",
+            "urn:oclc:13887294",
+            "urn:oclc:NYPG764506752-B",
+            "urn:undefined:NN764506752",
+            "urn:undefined:(WaOLN)nyp0390904",
+            "urn:undefined:(OCoLC)13887294"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada imprints."
+          ],
+          "titleDisplay": [
+            "Kannaḍa granthasūci; mudrita Kannaḍa krtigala vivaraṇātmaka granthasūci. [Compiled by an Editorial Committee consisting of D. Javaregowda and others."
+          ],
+          "uri": "b10387344",
+          "lccClassification": [
+            "Z3201 .K35"
+          ],
+          "numItems": [
+            9
+          ],
+          "numAvailable": [
+            9
+          ],
+          "placeOfPublication": [
+            "Maisūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Śuddha vijñānagaḷu -- 2. Bhāṣe-vyākaraṇa-dharma-tattva-lalitkalegaḷu-upayukta kalegaḷu-nighantugaḷu-vyakaraṇagaḷu -- 3. Sāhitya-vimarśe-kāvya-hosagannaḍa kāvya -- 4. Gadya saṇṇakathe-nāṭaka-prabandha -- 5. Kādambari-aitihāsika-pattēdāri -- 6. Bāla sāhitya -- 7. Anuvāda sāhitya -- 8. Jīvana caritre-patra sāhitya-pravāsa sāhitya-jānapada sāhitya -- 9. Samājaśāstra-vāṇijyaśāstra-sikṣaṇaśāstra-bhūgōla mattu itihāsa"
+          ],
+          "dimensions": [
+            " 30 cm."
+          ]
+        },
+        "sort": [
+          "b10387344"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 9,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092431",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546423"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 9"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546423"
+                    ],
+                    "idBarcode": [
+                      "33433005546423"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 9,
+                        "lte": 9
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         9-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000009"
+                  },
+                  "sort": [
+                    "         9-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092430",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 8"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546415"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 8"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546415"
+                    ],
+                    "idBarcode": [
+                      "33433005546415"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 8,
+                        "lte": 8
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         8-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000008"
+                  },
+                  "sort": [
+                    "         8-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092429",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546647"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546647"
+                    ],
+                    "idBarcode": [
+                      "33433005546647"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 7,
+                        "lte": 7
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         7-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000007"
+                  },
+                  "sort": [
+                    "         7-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092428",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546639"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546639"
+                    ],
+                    "idBarcode": [
+                      "33433005546639"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 6,
+                        "lte": 6
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         6-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000006"
+                  },
+                  "sort": [
+                    "         6-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092427",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546621"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546621"
+                    ],
+                    "idBarcode": [
+                      "33433005546621"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 5
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000005"
+                  },
+                  "sort": [
+                    "         5-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092426",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546613"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546613"
+                    ],
+                    "idBarcode": [
+                      "33433005546613"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 4,
+                        "lte": 4
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         4-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000004"
+                  },
+                  "sort": [
+                    "         4-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092425",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546605"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546605"
+                    ],
+                    "idBarcode": [
+                      "33433005546605"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 3,
+                        "lte": 3
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         3-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000003"
+                  },
+                  "sort": [
+                    "         3-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092424",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546597"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546597"
+                    ],
+                    "idBarcode": [
+                      "33433005546597"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000002"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10092423",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 75-3000 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 75-3000 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005546589"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 75-3000"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005546589"
+                    ],
+                    "idBarcode": [
+                      "33433005546589"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 75-3000 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10430533",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "- v."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada language",
+            "Kannada language -- Dictionaries"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Sāhitya Pariṣattu"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa Sāhitya Paṛiṣattina Kannaḍa nighaṇṭu."
+          ],
+          "shelfMark": [
+            "*OLA+ 77-1212"
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 68015538"
+          ],
+          "contributorLiteral": [
+            "Kannaḍa Sāhitya Pariṣattu."
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA+ 77-1212"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10430533"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68015538"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "33334610"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "33334610"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN774598719"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0434297"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)33334610"
+            }
+          ],
+          "idOclc": [
+            "33334610"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659153256254,
+          "publicationStatement": [
+            "Biṅgaḷoru, Kannaḍa Sāhitya Pariṣattu, 1964-"
+          ],
+          "identifier": [
+            "urn:bnum:10430533",
+            "urn:lccn:sa 68015538",
+            "urn:oclc:33334610",
+            "urn:undefined:NN774598719",
+            "urn:undefined:(WaOLN)nyp0434297",
+            "urn:undefined:(OCoLC)33334610"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada language -- Dictionaries."
+          ],
+          "titleDisplay": [
+            "Kannaḍa Sāhitya Paṛiṣattina Kannaḍa nighaṇṭu."
+          ],
+          "uri": "b10430533",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Biṅgaḷoru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10430533"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13844383",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA+ 77-1212 v. 1 nos. 1-7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA+ 77-1212 v. 1 nos. 1-7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057842290"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA+ 77-1212"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1 nos. 1-7"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057842290"
+                    ],
+                    "idBarcode": [
+                      "33433057842290"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA+ 77-1212 v. 000001 nos. 1-7"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10448884",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. illus., maps."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada literature",
+            "Kannada literature -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Prakaṭaṇa Mattu Pracārō Panyāsa Vibhāga, Beṅgaḷūru Viśvavidyālaya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "numItemsTotal": [
+            6
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Samagra Kannaḍa sāhitya caritre. [Pradhāna Sampādakaru Jī. Esau. Sivarudrappa]"
+          ],
+          "shelfMark": [
+            "*OLA 77-1564"
+          ],
+          "numItemVolumesParsed": [
+            6
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75907097"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sivarudrappa, G. S., 1926-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 77-1564"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10448884"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75907097"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "25483666"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "25483666"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG774800277-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN774800277"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0452778"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)25483666"
+            }
+          ],
+          "idOclc": [
+            "25483666",
+            "NYPG774800277-B"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1675274772412,
+          "publicationStatement": [
+            "Beṅgaḷūru, Prakaṭaṇa Mattu Pracārō Panyāsa Vibhāga, Beṅgaḷūru Viśvavidyālaya, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10448884",
+            "urn:lccn:75907097",
+            "urn:oclc:25483666",
+            "urn:oclc:NYPG774800277-B",
+            "urn:undefined:NN774800277",
+            "urn:undefined:(WaOLN)nyp0452778",
+            "urn:undefined:(OCoLC)25483666"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Samagra Kannaḍa sāhitya caritre. [Pradhāna Sampādakaru Jī. Esau. Sivarudrappa]"
+          ],
+          "uri": "b10448884",
+          "numItems": [
+            6
+          ],
+          "numAvailable": [
+            6
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10448884"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 6,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105102",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544758"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544758"
+                    ],
+                    "idBarcode": [
+                      "33433005544758"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 6,
+                        "lte": 6
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         6-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000006"
+                  },
+                  "sort": [
+                    "         6-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105101",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 4 pt. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 4 pt. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544741"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 4 pt. 2"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544741"
+                    ],
+                    "idBarcode": [
+                      "33433005544741"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 4,
+                        "lte": 4
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         4-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000004 pt. 2"
+                  },
+                  "sort": [
+                    "         4-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105100",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 4 pt. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 4 pt. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544733"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 4 pt. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544733"
+                    ],
+                    "idBarcode": [
+                      "33433005544733"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 4,
+                        "lte": 4
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         4-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000004 pt. 1"
+                  },
+                  "sort": [
+                    "         4-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105099",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545201"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545201"
+                    ],
+                    "idBarcode": [
+                      "33433005545201"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 3,
+                        "lte": 3
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         3-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000003"
+                  },
+                  "sort": [
+                    "         3-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105098",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545193"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545193"
+                    ],
+                    "idBarcode": [
+                      "33433005545193"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000002"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105097",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545185"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545185"
+                    ],
+                    "idBarcode": [
+                      "33433005545185"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1564|zLibrary has: Vol. 1-3, 4 (pt.1-2), 6. v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10448885",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "- v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Kannaḍa Adhyayana Saṃstheya prakaṭaṇe: Sāmānyamāle.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada literature",
+            "Kannada literature -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Adhyayana Saṃsthe, Maisūru Viśvavidyānilaya: Mārāṭagāraru, Prasārāṅga"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "numItemsTotal": [
+            6
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa Adhyayana Saṃstheya Kannaḍa sāhitya caritre. Pradhāna Sampādaka, Hā. Mā. Nāyaka: Sampādaka, Ṭi. Vi. Veṅkaṭācala Śāstrī. 1st ed."
+          ],
+          "shelfMark": [
+            "*OLA 77-1563"
+          ],
+          "numItemVolumesParsed": [
+            6
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75905691"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Nayak, Harogadde Manappa, 1931-",
+            "Venkatachala Sastry, T. V., 1933-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 77-1563"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10448885"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75905691"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG774800289-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN774800289"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0452779"
+            }
+          ],
+          "idOclc": [
+            "NYPG774800289-B"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1675259064154,
+          "publicationStatement": [
+            "Maisūru: Kannaḍa Adhyayana Saṃsthe, Maisūru Viśvavidyānilaya: Mārāṭagāraru, Prasārāṅga, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10448885",
+            "urn:lccn:75905691",
+            "urn:oclc:NYPG774800289-B",
+            "urn:undefined:NN774800289",
+            "urn:undefined:(WaOLN)nyp0452779"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Kannaḍa Adhyayana Saṃstheya Kannaḍa sāhitya caritre. Pradhāna Sampādaka, Hā. Mā. Nāyaka: Sampādaka, Ṭi. Vi. Veṅkaṭācala Śāstrī. 1st ed."
+          ],
+          "uri": "b10448885",
+          "numItems": [
+            6
+          ],
+          "numAvailable": [
+            6
+          ],
+          "placeOfPublication": [
+            "Maisūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10448885"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 6,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105108",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1563 v. 5 pt. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1563 v. 5 pt. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545177"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1563"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545177"
+                    ],
+                    "idBarcode": [
+                      "33433005545177"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 5
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1563 v. 000005 pt. 1"
+                  },
+                  "sort": [
+                    "         5-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105107",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1563 v. 4 pt. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1563 v. 4 pt. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545169"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 4 pt. 2"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1563"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545169"
+                    ],
+                    "idBarcode": [
+                      "33433005545169"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 4,
+                        "lte": 4
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         4-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1563 v. 000004 pt. 2"
+                  },
+                  "sort": [
+                    "         4-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105106",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1563 v. 4 pt. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1563 v. 4 pt. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545151"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 4 pt. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1563"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545151"
+                    ],
+                    "idBarcode": [
+                      "33433005545151"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 4,
+                        "lte": 4
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         4-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1563 v. 000004 pt. 1"
+                  },
+                  "sort": [
+                    "         4-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105105",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1563 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1563 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545144"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1563"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545144"
+                    ],
+                    "idBarcode": [
+                      "33433005545144"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 3,
+                        "lte": 3
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         3-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1563 v. 000003"
+                  },
+                  "sort": [
+                    "         3-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105104",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1563 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1563 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545136"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1563"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545136"
+                    ],
+                    "idBarcode": [
+                      "33433005545136"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1563 v. 000002"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10105103",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 77-1563 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 77-1563 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005545128"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 77-1563"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005545128"
+                    ],
+                    "idBarcode": [
+                      "33433005545128"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLA 77-1563 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10621864",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "-v."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuvempu, 1904-1994",
+            "Kuvempu, 1904-1994 -- Correspondence"
+          ],
+          "publisherLiteral": [
+            "Bayalunēmi Prakāśana,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kuvempu patragaḷu. Sampādaka Hariharapriya. 1. Āvṛtti."
+          ],
+          "shelfMark": [
+            "*OLA 79-209"
+          ],
+          "creatorLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75905629"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 79-209"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10621864"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75905629"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN804084236"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0627536"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636109952581,
+          "publicationStatement": [
+            "Mandagere, Bayalunēmi Prakāśana, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10621864",
+            "urn:lccn:75905629",
+            "urn:undefined:NN804084236",
+            "urn:undefined:(WaOLN)nyp0627536"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuvempu, 1904-1994 -- Correspondence."
+          ],
+          "titleDisplay": [
+            "Kuvempu patragaḷu. Sampādaka Hariharapriya. 1. Āvṛtti."
+          ],
+          "uri": "b10621864",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Mandagere,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10621864"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014576221"
+                    ],
+                    "shelfMark_sort": "a*OLA 79-000209",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10139695",
+                    "shelfMark": [
+                      "*OLA 79-209"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014576221"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433014576221"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10691564",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Carnatic (India)",
+            "Carnatic (India) -- Biography"
+          ],
+          "publisherLiteral": [
+            "Kāvyālaya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Jñāpaka citraśāle."
+          ],
+          "shelfMark": [
+            "*OLA 81-2012"
+          ],
+          "creatorLiteral": [
+            "Gundappa, D. V."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "70911699"
+          ],
+          "seriesStatement": [
+            "Kannaḍa Kāvyamāle"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 81-2012"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10691564"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "70911699"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "20232509"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "20232509"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0698090"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)20232509"
+            }
+          ],
+          "idOclc": [
+            "20232509"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659153164180,
+          "publicationStatement": [
+            "Maisūru, Kāvyālaya [1969-"
+          ],
+          "identifier": [
+            "urn:bnum:10691564",
+            "urn:lccn:70911699",
+            "urn:oclc:20232509",
+            "urn:undefined:(WaOLN)nyp0698090",
+            "urn:undefined:(OCoLC)20232509"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Carnatic (India) -- Biography."
+          ],
+          "titleDisplay": [
+            "Jñāpaka citraśāle. [Lēkhaka] Di. Vi. Ji."
+          ],
+          "uri": "b10691564",
+          "lccClassification": [
+            "DS485.C24 G85"
+          ],
+          "numItems": [
+            4
+          ],
+          "numAvailable": [
+            4
+          ],
+          "placeOfPublication": [
+            "Maisūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10691564"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 4,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10153975",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2012 v. 8"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2012 v. 8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013122498"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2012"
+                    ],
+                    "enumerationChronology": [
+                      "v. 8"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013122498"
+                    ],
+                    "idBarcode": [
+                      "33433013122498"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2012 v. 000008"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10153974",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2012 v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2012 v. 7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013118769"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2012"
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013118769"
+                    ],
+                    "idBarcode": [
+                      "33433013118769"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2012 v. 000007"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10153973",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2012 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2012 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013118751"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2012"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013118751"
+                    ],
+                    "idBarcode": [
+                      "33433013118751"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2012 v. 000005"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10153972",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2012 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2012 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013118744"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2012"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013118744"
+                    ],
+                    "idBarcode": [
+                      "33433013118744"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2012 v. 000004"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10734117",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Karanth, Kota Shivarama, 1902-",
+            "Authors, Kannada",
+            "Authors, Kannada -- 20th century",
+            "Authors, Kannada -- 20th century -- Biography"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Smrti pataladinda"
+          ],
+          "shelfMark": [
+            "*OLA 81-2376"
+          ],
+          "creatorLiteral": [
+            "Karanth, Kota Shivarama, 1902-"
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 81-2376"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10734117"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "10695468"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "10695468"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0740886"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)10695468"
+            }
+          ],
+          "idOclc": [
+            "10695468"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659170872872,
+          "identifier": [
+            "urn:bnum:10734117",
+            "urn:oclc:10695468",
+            "urn:undefined:(WaOLN)nyp0740886",
+            "urn:undefined:(OCoLC)10695468"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Karanth, Kota Shivarama, 1902-",
+            "Authors, Kannada -- 20th century -- Biography."
+          ],
+          "titleDisplay": [
+            "Smrti pataladinda / Śivarāma Kāranta."
+          ],
+          "uri": "b10734117",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10734117"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10161646",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2376 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2376 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013122290"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2376"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013122290"
+                    ],
+                    "idBarcode": [
+                      "33433013122290"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2376 v. 000003"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10161645",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2376 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2376 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013122282"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2376"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013122282"
+                    ],
+                    "idBarcode": [
+                      "33433013122282"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2376 v. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10161644",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 81-2376 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 81-2376 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013122274"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 81-2376"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013122274"
+                    ],
+                    "idBarcode": [
+                      "33433013122274"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 81-2376 v. 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10756472",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. in illus."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title, text and musical notation in Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Songs, Tamil",
+            "Music, Kannada"
+          ],
+          "publisherLiteral": [
+            "Guru Guha Gana Nilaya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1963
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Maharaja Sri Swati Tirunal kritis. With notation."
+          ],
+          "shelfMark": [
+            "JML 82-4"
+          ],
+          "creatorLiteral": [
+            "Svātitirunāḷ, 1813-1846."
+          ],
+          "createdString": [
+            "1963"
+          ],
+          "idLccn": [
+            "sa 66002381"
+          ],
+          "seriesStatement": [
+            "Karnataka sangeetha tarangini series book 5-"
+          ],
+          "contributorLiteral": [
+            "Sreenivasa Iyer, Semmangudi R.",
+            "Shankara Murthy, Mathur R."
+          ],
+          "dateStartYear": [
+            1963
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JML 82-4"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10756472"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 66002381"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "10408849"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "10408849"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0763357"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)10408849"
+            }
+          ],
+          "idOclc": [
+            "10408849"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659158548927,
+          "publicationStatement": [
+            "Bangalore, Guru Guha Gana Nilaya [1963-"
+          ],
+          "identifier": [
+            "urn:bnum:10756472",
+            "urn:lccn:sa 66002381",
+            "urn:oclc:10408849",
+            "urn:undefined:(WaOLN)nyp0763357",
+            "urn:undefined:(OCoLC)10408849"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1963"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Songs, Tamil.",
+            "Music, Kannada."
+          ],
+          "titleDisplay": [
+            "Maharaja Sri Swati Tirunal kritis. With notation. / Tamil original edited by Semmangudi Srinivasa Aiyar. [Translated] by M.R. Shankaramurthy."
+          ],
+          "uri": "b10756472",
+          "lccClassification": [
+            "M1808.R256 M3"
+          ],
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Bangalore"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10756472"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14902566",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JML 82-4 v. 4-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JML 82-4 v. 4-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068812035"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JML 82-4"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4-5"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433068812035"
+                    ],
+                    "idBarcode": [
+                      "33433068812035"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJML 82-4 v. 000004-5"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14902565",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JML 82-4 v. 2-3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JML 82-4 v. 2-3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068812027"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JML 82-4"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2-3"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433068812027"
+                    ],
+                    "idBarcode": [
+                      "33433068812027"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJML 82-4 v. 000002-3"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14902564",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JML 82-4 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JML 82-4 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068812019"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JML 82-4"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433068812019"
+                    ],
+                    "idBarcode": [
+                      "33433068812019"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJML 82-4 v. 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10836580",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Without the music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Songs, Kannada",
+            "Songs, Kannada -- Texts"
+          ],
+          "publisherLiteral": [
+            "[s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Yakṣagāna chandassu."
+          ],
+          "shelfMark": [
+            "*OLA 82-1982"
+          ],
+          "creatorLiteral": [
+            "Kedilaya, K. P. Seetharama, 1930-"
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 68015716"
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-1982"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10836580"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68015716"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "24824716"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "24824716"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0843597"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)24824716"
+            }
+          ],
+          "idOclc": [
+            "24824716"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659354931153,
+          "publicationStatement": [
+            "Śiśila, [s.n.] 1964-"
+          ],
+          "identifier": [
+            "urn:bnum:10836580",
+            "urn:lccn:sa 68015716",
+            "urn:oclc:24824716",
+            "urn:undefined:(WaOLN)nyp0843597",
+            "urn:undefined:(OCoLC)24824716"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Songs, Kannada -- Texts."
+          ],
+          "titleDisplay": [
+            "Yakṣagāna chandassu. Lēkhaka mattu prakāśaka Ka. Pu. Sītārāma Kedilāya."
+          ],
+          "uri": "b10836580",
+          "lccClassification": [
+            "M1803.K427 Y3"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Śiśila"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10836580"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10179896",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013124239"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013124239"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013124239"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-1982"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-001982"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10840234",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Authors, Kannada",
+            "Authors, Kannada -- 20th century",
+            "Authors, Kannada -- 20th century -- Biography",
+            "Kaṭṭīmani, Basavarāja, 1919-1989",
+            "Kaṭṭīmani, Basavarāja, 1919-1989 -- Biography"
+          ],
+          "publisherLiteral": [
+            "Sāhityaśrī : mārāṭagāraruSam̲aja Pustuk̲alaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Basavarāja Kaṭṭīmani avara ātmakathe."
+          ],
+          "shelfMark": [
+            "*OLA 82-4677"
+          ],
+          "creatorLiteral": [
+            "Kaṭṭīmani, Basavarāja, 1919-1989."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901672"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-4677"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10840234"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901672"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0847257"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636173090017,
+          "publicationStatement": [
+            "Dhāravāḍa : Sāhityaśrī : mārāṭagāraruSam̲aja Pustuk̲alaya, 1976-"
+          ],
+          "identifier": [
+            "urn:bnum:10840234",
+            "urn:lccn:76901672",
+            "urn:undefined:(WaOLN)nyp0847257"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Authors, Kannada -- 20th century -- Biography.",
+            "Kaṭṭīmani, Basavarāja, 1919-1989 -- Biography."
+          ],
+          "titleDisplay": [
+            "Basavarāja Kaṭṭīmani avara ātmakathe."
+          ],
+          "uri": "b10840234",
+          "lccClassification": [
+            "PL4659.K35 Z463"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Kundaranāḍina kanda."
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10840234"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013117753"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 82-4677"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-004677",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10180475",
+                    "shelfMark": [
+                      "*OLA 82-4677"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 82-4677"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013117753"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013117753"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10840658",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Folk songs, Kannada",
+            "Folk songs, Kannada -- Texts"
+          ],
+          "publisherLiteral": [
+            "Gurumūrti Prākāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa janapada sāhitya bhaṇḍāra"
+          ],
+          "shelfMark": [
+            "*OLA 82-5593"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900850"
+          ],
+          "contributorLiteral": [
+            "Krishnamurthy, Matighatta.",
+            "Krishnasarma, Betageri Shrinivasarao, 1900-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-5593"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10840658"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900850"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "25604444"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "25604444"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0847681"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)25604444"
+            }
+          ],
+          "idOclc": [
+            "25604444"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659324546764,
+          "publicationStatement": [
+            "Beṅgaḷūru : Gurumūrti Prākāśana, 1975-"
+          ],
+          "identifier": [
+            "urn:bnum:10840658",
+            "urn:lccn:76900850",
+            "urn:oclc:25604444",
+            "urn:undefined:(WaOLN)nyp0847681",
+            "urn:undefined:(OCoLC)25604444"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Folk songs, Kannada -- Texts."
+          ],
+          "titleDisplay": [
+            "Kannaḍa janapada sāhitya bhaṇḍāra / sangrāhaka, sampādaka, Matighaṭṭa Krṣṇamūrti ; Beṭagēri Krṣṇaśarma avara munnuḍiyondige."
+          ],
+          "uri": "b10840658",
+          "lccClassification": [
+            "PL4656 .K33"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Gītegaḷu."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10840658"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10180545",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013126176"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013126176"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013126176"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-5593"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-005593"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10841472",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : port."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Plays; some previously published in various periodicals.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Bi. Es. Śāstri"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kṣīrasāgarara nāṭakagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 82-5560"
+          ],
+          "creatorLiteral": [
+            "Kṣīrasāgara."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-5560"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10841472"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "28795121"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "28795121"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0848495"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)28795121"
+            }
+          ],
+          "idOclc": [
+            "28795121"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659325090623,
+          "publicationStatement": [
+            "Beṅgaḷūru : Bi. Es. Śāstri, 1967̲"
+          ],
+          "identifier": [
+            "urn:bnum:10841472",
+            "urn:oclc:28795121",
+            "urn:undefined:(WaOLN)nyp0848495",
+            "urn:undefined:(OCoLC)28795121"
+          ],
+          "genreForm": [
+            "Kannada drama."
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Kṣīrasāgarara nāṭakagaḷu."
+          ],
+          "uri": "b10841472",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10841472"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10180726",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013126085"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013126085"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013126085"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-5560"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-005560"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10180727",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013126093"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013126093"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013126093"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-5560"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-005560"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10841507",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Inscriptions, Kannada"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Adhyayanapīṭha, Karnāṭaska Viśvavidyālaya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śāsana vy̲asaṅga"
+          ],
+          "shelfMark": [
+            "*OLA 82-3004"
+          ],
+          "creatorLiteral": [
+            "Kalaburgi, M. M."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75900286"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-3004"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10841507"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75900286"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0848530"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1653404959303,
+          "publicationStatement": [
+            "Dhāravāḍa : Kannaḍa Adhyayanapīṭha, Karnāṭaska Viśvavidyālaya, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10841507",
+            "urn:lccn:75900286",
+            "urn:undefined:(WaOLN)nyp0848530"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Inscriptions, Kannada."
+          ],
+          "titleDisplay": [
+            "Śāsana vy̲asaṅga / Em. Em. Kalaburgi; pradhāna samp̲adakaru Ār. Si. Hirēmaṭha."
+          ],
+          "uri": "b10841507",
+          "lccClassification": [
+            "PL4654 .K27"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10841507"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013123777"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-003004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10180742",
+                    "shelfMark": [
+                      "*OLA 82-3004"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013123777"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013123777"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013123785"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-003004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10180743",
+                    "shelfMark": [
+                      "*OLA 82-3004"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013123785"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013123785"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10843261",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. in"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 1-3 in 1 vol., previously published seperately.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada language",
+            "Kannada language -- Style"
+          ],
+          "publisherLiteral": [
+            "Kāvyālaya Prakāśakaru"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śaili."
+          ],
+          "shelfMark": [
+            "*OLA 82-5545"
+          ],
+          "creatorLiteral": [
+            "Raṅgaṇṇa, Es. Vi., 1898-"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72904770"
+          ],
+          "seriesStatement": [
+            "Kannaḍa kāvyamāle"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 82-5545"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10843261"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72904770"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "20553317"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "20553317"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0850287"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)20553317"
+            }
+          ],
+          "idOclc": [
+            "20553317"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659355572451,
+          "publicationStatement": [
+            "Maisūru, Kāvyālaya Prakāśakaru, 1971-"
+          ],
+          "identifier": [
+            "urn:bnum:10843261",
+            "urn:lccn:72904770",
+            "urn:oclc:20553317",
+            "urn:undefined:(WaOLN)nyp0850287",
+            "urn:undefined:(OCoLC)20553317"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada language -- Style."
+          ],
+          "titleDisplay": [
+            "Śaili. [Lēkhaka] Es. Vi. Raṅgaṇṇa."
+          ],
+          "uri": "b10843261",
+          "lccClassification": [
+            "PL4649 .R3"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maisūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10843261"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10181027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013126036"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013126036"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013126036"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 82-5545"
+                    ],
+                    "shelfMark_sort": "a*OLA 82-005545"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10843271",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Eṃ. El. Śrīkaṇṭhēśagauḍa Saṃsmaraṇa Samiti, Kannaḍa Adhyayana Saṃsthe"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śrīkaṇṭhēśagauḍara krtigaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 83-2833"
+          ],
+          "creatorLiteral": [
+            "Śrīkaṇṭhēśagauḍa, Eṃ. El., 1852-1926."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902729"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-2833"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10843271"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902729"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "25484171"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "25484171"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0850297"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)25484171"
+            }
+          ],
+          "idOclc": [
+            "25484171"
+          ],
+          "uniformTitle": [
+            "Works"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659354791974,
+          "publicationStatement": [
+            "Maisūru : Eṃ. El. Śrīkaṇṭhēśagauḍa Saṃsmaraṇa Samiti, Kannaḍa Adhyayana Saṃsthe, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10843271",
+            "urn:lccn:75902729",
+            "urn:oclc:25484171",
+            "urn:undefined:(WaOLN)nyp0850297",
+            "urn:undefined:(OCoLC)25484171"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Śrīkaṇṭhēśagauḍara krtigaḷu."
+          ],
+          "uri": "b10843271",
+          "lccClassification": [
+            "PL4659 .S6464 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maisūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Works"
+          ],
+          "tableOfContents": [
+            "1. Mūlakrtigaḷa saṅgraha."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10843271"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10181030",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013119056"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013119056"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013119056"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-2833"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-002833"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10848968",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Without music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes biographical sketches of the composers.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Composers",
+            "Composers -- Karnataka",
+            "Composers -- Karnataka -- Biography",
+            "Songs, Kannada",
+            "Songs, Kannada -- Texts"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Mejisṭik Pres"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1962
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dāsara kīrtanegaḷu."
+          ],
+          "shelfMark": [
+            "JMK 82-18"
+          ],
+          "numItemVolumesParsed": [
+            2
+          ],
+          "createdString": [
+            "1962"
+          ],
+          "idLccn": [
+            "sa 64006360 /M"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Mañjunāthayya, K."
+          ],
+          "dateStartYear": [
+            1962
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMK 82-18"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10848968"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 64006360 /M"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "23301757"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "23301757"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG84-B25944"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0855999"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)23301757"
+            }
+          ],
+          "idOclc": [
+            "23301757",
+            "NYPG84-B25944"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1671736587343,
+          "publicationStatement": [
+            "Uḍupi, Mejisṭik Pres [1962-"
+          ],
+          "identifier": [
+            "urn:bnum:10848968",
+            "urn:lccn:sa 64006360 /M",
+            "urn:oclc:23301757",
+            "urn:oclc:NYPG84-B25944",
+            "urn:undefined:(WaOLN)nyp0855999",
+            "urn:undefined:(OCoLC)23301757"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1962"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Composers -- Karnataka -- Biography.",
+            "Songs, Kannada -- Texts."
+          ],
+          "titleDisplay": [
+            "Dāsara kīrtanegaḷu. Saṅgrāhakaru Ke. Mañjunāthayya. [Pariśōdhakaru Eṃ. Rājagōpālācārya]"
+          ],
+          "uri": "b10848968",
+          "lccClassification": [
+            "M1808.S55 D4"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Uḍupi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10848968"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14915103",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMK 82-18 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMK 82-18 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071260552"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "physicalLocation": [
+                      "JMK 82-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071260552"
+                    ],
+                    "idBarcode": [
+                      "33433071260552"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJMK 82-18 v. 000002"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14915102",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMK 82-18 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMK 82-18 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071260776"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "JMK 82-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071260776"
+                    ],
+                    "idBarcode": [
+                      "33433071260776"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJMK 82-18 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10864908",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "India",
+            "India -- History"
+          ],
+          "publisherLiteral": [
+            "Prasārāṇga, Maisūru Viśvavidyānilaya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bhāratada caritre."
+          ],
+          "shelfMark": [
+            "*OLL 82-770"
+          ],
+          "creatorLiteral": [
+            "Narasayya, K."
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "idLccn": [
+            "sa 68002831"
+          ],
+          "seriesStatement": [
+            "Maisūru Viśvavidyānilayada Kannaḍa granthamāle, 54"
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLL 82-770"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10864908"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68002831"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "31187193"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "31187193"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0871959"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)31187193"
+            }
+          ],
+          "idOclc": [
+            "31187193"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659308511682,
+          "publicationStatement": [
+            "[Maisūru] Prasārāṇga, Maisūru Viśvavidyānilaya, 196-"
+          ],
+          "identifier": [
+            "urn:bnum:10864908",
+            "urn:lccn:sa 68002831",
+            "urn:oclc:31187193",
+            "urn:undefined:(WaOLN)nyp0871959",
+            "urn:undefined:(OCoLC)31187193"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "India -- History."
+          ],
+          "titleDisplay": [
+            "Bhāratada caritre. [Lēkhaka] Ke. Narasayya."
+          ],
+          "uri": "b10864908",
+          "lccClassification": [
+            "DS436 .N37"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Maisūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10864908"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13932012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLL 82-770"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLL 82-770",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061320531"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLL 82-770"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061320531"
+                    ],
+                    "idBarcode": [
+                      "33433061320531"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLL 82-000770"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10893177",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"State level school reader in Kannada for non-Kannada speaking students.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added t. p. in English: Kannada nudi /editor, M. S.Thirumalai.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada and Hindi ;introductory and explanatory matter in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada language",
+            "Kannada language -- Textbooks for foreign speakers"
+          ],
+          "publisherLiteral": [
+            "Senṭral Insṭiṭyūte āph Iṇḍiyan Lāngvējas"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa nuḍi"
+          ],
+          "shelfMark": [
+            "*OLA 84-2050"
+          ],
+          "creatorLiteral": [
+            "Mallikārjuna, B."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "83901906"
+          ],
+          "seriesStatement": [
+            "CIIL second language textbooks series ; 6,7"
+          ],
+          "contributorLiteral": [
+            "Thirumalai, M. S."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-2050"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10893177"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83901906"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "14129155"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "14129155"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0900270"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)14129155"
+            }
+          ],
+          "idOclc": [
+            "14129155"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659324553239,
+          "publicationStatement": [
+            "Maisūru : Senṭral Insṭiṭyūte āph Iṇḍiyan Lāngvējas, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10893177",
+            "urn:lccn:83901906",
+            "urn:oclc:14129155",
+            "urn:undefined:(WaOLN)nyp0900270",
+            "urn:undefined:(OCoLC)14129155"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada language -- Textbooks for foreign speakers."
+          ],
+          "titleDisplay": [
+            "Kannaḍa nuḍi / lēkhaka, Bha. Mallikārjuna ;sampadaka, Mā. Su. Tirumalai."
+          ],
+          "uri": "b10893177",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Maisūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10893177"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10187928",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-2050|zLibrary has: Vols. 1-3. v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-2050|zLibrary has: Vols. 1-3. v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997643"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-2050|zLibrary has: Vols. 1-3."
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997643"
+                    ],
+                    "idBarcode": [
+                      "33433012997643"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-2050|zLibrary has: Vols. 1-3. v. 000003"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10187926",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-2050|zLibrary has: Vols. 1-3. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-2050|zLibrary has: Vols. 1-3. v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997627"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-2050|zLibrary has: Vols. 1-3."
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997627"
+                    ],
+                    "idBarcode": [
+                      "33433012997627"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-2050|zLibrary has: Vols. 1-3. v. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10187927",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-2050|zLibrary has: Vols. 1-3. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-2050|zLibrary has: Vols. 1-3. v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997635"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-2050|zLibrary has: Vols. 1-3."
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997635"
+                    ],
+                    "idBarcode": [
+                      "33433012997635"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-2050|zLibrary has: Vols. 1-3. v. 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10893183",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Songs without music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 published in 1974.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Purandaradāsa, 1484-1564",
+            "Purandaradāsa, 1484-1564 -- Criticism and interpretation",
+            "Carnatic music"
+          ],
+          "publisherLiteral": [
+            "Śrīpurandaradāsara Nānnūraneya Varṣada Utsava Maṇḍala"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "̄Srī Purandaradāsara sāhitya"
+          ],
+          "shelfMark": [
+            "JMK 84-11"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "contributorLiteral": [
+            "Purandaradāsa, 1484-1564.",
+            "Krṣṇaśarmā, Beṭagēri, 1900-",
+            "Huccarāyaru, Beṅgēri."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMK 84-11"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10893183"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0900276"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1653404970525,
+          "publicationStatement": [
+            "Dhāravāḍa : Śrīpurandaradāsara Nānnūraneya Varṣada Utsava Maṇḍala, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10893183",
+            "urn:undefined:(WaOLN)nyp0900276"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Purandaradāsa, 1484-1564 -- Criticism and interpretation.",
+            "Carnatic music."
+          ],
+          "titleDisplay": [
+            "̄Srī Purandaradāsara sāhitya / sampādakaru Śrī Beṭagēri Krṣṇaśarma ; Śrī Beṅgēri Huccarāyaru."
+          ],
+          "uri": "b10893183",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "2. Ārtabhāva."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10893183"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433068805302"
+                    ],
+                    "physicalLocation": [
+                      "JMK 84-11"
+                    ],
+                    "shelfMark_sort": "aJMK 84-11 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i14916909",
+                    "shelfMark": [
+                      "JMK 84-11 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JMK 84-11 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433068805302"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433068805302"
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10894417",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Yakṣagāna",
+            "Actors",
+            "Actors -- Karnataka",
+            "Actors -- Karnataka -- Biography"
+          ],
+          "publisherLiteral": [
+            "Mayura Prakashana : adhikrta mārātagāraru, Pragatiśīla Sāhitya Saṅgha"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Yakṣagāna kalāvidaru"
+          ],
+          "shelfMark": [
+            "*OLA 84-1994"
+          ],
+          "creatorLiteral": [
+            "Alse, A. Ganapaiah, 1940-"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75906010"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-1994"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10894417"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75906010"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "20808576"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "20808576"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0901510"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)20808576"
+            }
+          ],
+          "idOclc": [
+            "20808576"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659354932047,
+          "publicationStatement": [
+            "Beṅgaḷūru : Mayura Prakashana : adhikrta mārātagāraru, Pragatiśīla Sāhitya Saṅgha, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10894417",
+            "urn:lccn:75906010",
+            "urn:oclc:20808576",
+            "urn:undefined:(WaOLN)nyp0901510",
+            "urn:undefined:(OCoLC)20808576"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Yakṣagāna.",
+            "Actors -- Karnataka -- Biography."
+          ],
+          "titleDisplay": [
+            "Yakṣagāna kalāvidaru / A. Gaṇapayya Alse."
+          ],
+          "uri": "b10894417",
+          "lccClassification": [
+            "PN2881.5 .A4"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10894417"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10188096",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-1994|zLibrary has: Vol. 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-1994|zLibrary has: Vol. 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997601"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-1994|zLibrary has: Vol. 1."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997601"
+                    ],
+                    "idBarcode": [
+                      "33433012997601"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-1994|zLibrary has: Vol. 1."
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10894424",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., map ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1959.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Rājya Sāhitya Akāḍemiyinda puraskrta grantha, 1960.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: v.1, p. [290]-296.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada literature",
+            "Kannada literature -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Samāja Pustakālaya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sāhitya saṃśōdhane mattu samālōcane"
+          ],
+          "shelfMark": [
+            "*OLA 83-4874"
+          ],
+          "creatorLiteral": [
+            "Naik, Sadanand Narayan, 1913-"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74904049"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-4874"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10894424"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74904049"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "20496091"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "20496091"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0901517"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)20496091"
+            }
+          ],
+          "idOclc": [
+            "20496091"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659344353544,
+          "publicationStatement": [
+            "Dhāravāḍa : Samāja Pustakālaya, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10894424",
+            "urn:lccn:74904049",
+            "urn:oclc:20496091",
+            "urn:undefined:(WaOLN)nyp0901517",
+            "urn:undefined:(OCoLC)20496091"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Sāhitya saṃśōdhane mattu samālōcane / lēkhakaru Sadānanda N̄yaka."
+          ],
+          "uri": "b10894424",
+          "lccClassification": [
+            "PL4650.5 .N26 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10894424"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10188098",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 83-4874|zLibrary has: Vol. 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 83-4874|zLibrary has: Vol. 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012996918"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-4874|zLibrary has: Vol. 1."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012996918"
+                    ],
+                    "idBarcode": [
+                      "33433012996918"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-4874|zLibrary has: Vol. 1."
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10902372",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Without the music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 7: Karnāṭaka Viśvavidyālaya, Rajata Mahōtsava prakaṭane.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Folk songs, Kannada",
+            "Folk songs, Kannada -- Texts"
+          ],
+          "publisherLiteral": [
+            "Karnāṭaka Viśvavidyālaya"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Jīvana Jōkāli."
+          ],
+          "shelfMark": [
+            "*OLA 84-3320"
+          ],
+          "creatorLiteral": [
+            "Sunkapur, M. S."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "70928091"
+          ],
+          "seriesStatement": [
+            "Janapada sāhitya māle, 11, 16, 17"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-3320"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10902372"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "70928091"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0909480"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636202044347,
+          "publicationStatement": [
+            "Dhāravāḍa, Karnāṭaka Viśvavidyālaya [1971-"
+          ],
+          "identifier": [
+            "urn:bnum:10902372",
+            "urn:lccn:70928091",
+            "urn:undefined:(WaOLN)nyp0909480"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Folk songs, Kannada -- Texts."
+          ],
+          "titleDisplay": [
+            "Jīvana Jōkāli. Sampādakaru Eṃ. Es. Suṅkāpura."
+          ],
+          "uri": "b10902372",
+          "lccClassification": [
+            "M1808.S795 J6"
+          ],
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "6. Ḍoḷḷina hāḍu. -- 7. Gaṇgigauri saṃvāda-Bedeṇḍegabba. -- 8 K̲olupada."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10902372"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998203"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-3320|zLibrary has: Vol. 6-8."
+                    ],
+                    "shelfMark_sort": "a*OLA 84-3320|zLibrary has: Vol. 6-8. v. 000008",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10189109",
+                    "shelfMark": [
+                      "*OLA 84-3320|zLibrary has: Vol. 6-8. v. 8"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 84-3320|zLibrary has: Vol. 6-8. v. 8"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998203"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 8"
+                    ],
+                    "idBarcode": [
+                      "33433012998203"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998195"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-3320|zLibrary has: Vol. 6-8."
+                    ],
+                    "shelfMark_sort": "a*OLA 84-3320|zLibrary has: Vol. 6-8. v. 000007",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10189108",
+                    "shelfMark": [
+                      "*OLA 84-3320|zLibrary has: Vol. 6-8. v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 84-3320|zLibrary has: Vol. 6-8. v. 7"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998195"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "idBarcode": [
+                      "33433012998195"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998187"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-3320|zLibrary has: Vol. 6-8."
+                    ],
+                    "shelfMark_sort": "a*OLA 84-3320|zLibrary has: Vol. 6-8. v. 000006",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10189107",
+                    "shelfMark": [
+                      "*OLA 84-3320|zLibrary has: Vol. 6-8. v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 84-3320|zLibrary has: Vol. 6-8. v. 6"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998187"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "idBarcode": [
+                      "33433012998187"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10920342",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. port."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Comprises collected writings of the author, chiefly prefaces to his own works.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Viśvabhārati Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ciracētana."
+          ],
+          "shelfMark": [
+            "*OLA 84-4187"
+          ],
+          "creatorLiteral": [
+            "Krishnarao, A. N., 1908-1971."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "72907646"
+          ],
+          "contributorLiteral": [
+            "Krṣṇarāya, Śā. Maṃ."
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-4187"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10920342"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72907646"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "20716535"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "20716535"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0927484"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)20716535"
+            }
+          ],
+          "idOclc": [
+            "20716535"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659310404344,
+          "publicationStatement": [
+            "Maḍagāṃva, Viśvabhārati Prakāśana 1894- i.e. 1972-"
+          ],
+          "identifier": [
+            "urn:bnum:10920342",
+            "urn:lccn:72907646",
+            "urn:oclc:20716535",
+            "urn:undefined:(WaOLN)nyp0927484",
+            "urn:undefined:(OCoLC)20716535"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Ciracētana. Sampādaka Śā. Maṃ. Krṣṇarāya."
+          ],
+          "uri": "b10920342",
+          "lccClassification": [
+            "PL4659.K68 C5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Maḍagāṃva"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10920342"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10194087",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-4187|zLibrary has: Vol. 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-4187|zLibrary has: Vol. 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998468"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-4187|zLibrary has: Vol. 1."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998468"
+                    ],
+                    "idBarcode": [
+                      "33433012998468"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-4187|zLibrary has: Vol. 1."
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10920356",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada language",
+            "Kannada language -- Grammar"
+          ],
+          "publisherLiteral": [
+            "Kannada Saṃśōdhana Saṃsthe, Karnāṭaka Viśvavidyāla"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa vyākaraṇada kelavu samasyegaḷu"
+          ],
+          "shelfMark": [
+            "*OLA 84-4185"
+          ],
+          "creatorLiteral": [
+            "Krṣṇa Bhaṭṭa, Seḍiyāpu, 1902-"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75906826"
+          ],
+          "seriesStatement": [
+            "Saṃśōdhana upanyāsamāle ; 10-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-4185"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10920356"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75906826"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "35765149"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "35765149"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0927498"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)35765149"
+            }
+          ],
+          "idOclc": [
+            "35765149"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659324590260,
+          "publicationStatement": [
+            "Dhāravāḍa : Kannada Saṃśōdhana Saṃsthe, Karnāṭaka Viśvavidyāla, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10920356",
+            "urn:lccn:75906826",
+            "urn:oclc:35765149",
+            "urn:undefined:(WaOLN)nyp0927498",
+            "urn:undefined:(OCoLC)35765149"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Kannaḍa vyākaraṇada kelavu samasyegaḷu / upanyāsakaru sēḍiy̲apu lrṣṇabhaṭṭa."
+          ],
+          "uri": "b10920356",
+          "lccClassification": [
+            "PL4644 .K7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10920356"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10194093",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-4185|zLibrary has: Vol. 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-4185|zLibrary has: Vol. 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998450"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-4185|zLibrary has: Vol. 1."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998450"
+                    ],
+                    "idBarcode": [
+                      "33433012998450"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-4185|zLibrary has: Vol. 1."
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10920641",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Published on the occasion of the golden jubilee celebration of the Kannada Sahitya Parishat.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kannada literature",
+            "Kannada literature -- Congresses"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Sāhitya Pariṣattu"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kannaḍa sāhitya sammēḷanagaḷa adhyakṣara bhāṣaṇagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 84-4113"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "76922271"
+          ],
+          "seriesStatement": [
+            "Trivārṣika yōjaneya pustakamāle, 10"
+          ],
+          "contributorLiteral": [
+            "Kannada Literary Akademy.",
+            "Kannada Literary Conference."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-4113"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10920641"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76922271"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "35765152"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "35765152"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0927784"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)35765152"
+            }
+          ],
+          "idOclc": [
+            "35765152"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659324553239,
+          "publicationStatement": [
+            "Beṅgaḷūru, Kannaḍa Sāhitya Pariṣattu, 1970-"
+          ],
+          "identifier": [
+            "urn:bnum:10920641",
+            "urn:lccn:76922271",
+            "urn:oclc:35765152",
+            "urn:undefined:(WaOLN)nyp0927784",
+            "urn:undefined:(OCoLC)35765152"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kannada literature -- Congresses."
+          ],
+          "titleDisplay": [
+            "Kannaḍa sāhitya sammēḷanagaḷa adhyakṣara bhāṣaṇagaḷu."
+          ],
+          "uri": "b10920641",
+          "lccClassification": [
+            "PL4650 .A27"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10920641"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10194135",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-4113|zLibrary has: Vol. 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-4113|zLibrary has: Vol. 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998286"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-4113|zLibrary has: Vol. 1."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998286"
+                    ],
+                    "idBarcode": [
+                      "33433012998286"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-4113|zLibrary has: Vol. 1."
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10926039",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Geḷeyara Gumpu (Karnataka, India)"
+          ],
+          "publisherLiteral": [
+            "Rājahaṃsa Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nānu kaṇḍa Geḷeyara Gumpu"
+          ],
+          "shelfMark": [
+            "*OLA 84-2972"
+          ],
+          "creatorLiteral": [
+            "Kulakarṇi, S. G."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "idLccn": [
+            "79900881 /SA"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-2972"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10926039"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79900881 /SA"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "8845502"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "8845502"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0933193"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)8845502"
+            }
+          ],
+          "idOclc": [
+            "8845502"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659333550531,
+          "publicationStatement": [
+            "Dhāravāḍa : Rājahaṃsa Prakāśana, [1978]-"
+          ],
+          "identifier": [
+            "urn:bnum:10926039",
+            "urn:lccn:79900881 /SA",
+            "urn:oclc:8845502",
+            "urn:undefined:(WaOLN)nyp0933193",
+            "urn:undefined:(OCoLC)8845502"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Geḷeyara Gumpu (Karnataka, India)"
+          ],
+          "titleDisplay": [
+            "Nānu kaṇḍa Geḷeyara Gumpu / Śē. Gō. Kulakarṇi."
+          ],
+          "uri": "b10926039",
+          "lccClassification": [
+            "PL4650.A243 K84 1978"
+          ],
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Śānti-Nikētana.--2. Jayakarnāṭka.--3. Sādhana Mudraṇālaya mattu Jīvana māsapatrike."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10926039"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10195006",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-2972|zLibrary has: Vols. 1-3. v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-2972|zLibrary has: Vols. 1-3. v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997999"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-2972|zLibrary has: Vols. 1-3."
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997999"
+                    ],
+                    "idBarcode": [
+                      "33433012997999"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-2972|zLibrary has: Vols. 1-3. v. 000003"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10195005",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-2972|zLibrary has: Vols. 1-3. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-2972|zLibrary has: Vols. 1-3. v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997981"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-2972|zLibrary has: Vols. 1-3."
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997981"
+                    ],
+                    "idBarcode": [
+                      "33433012997981"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-2972|zLibrary has: Vols. 1-3. v. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10195004",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-2972|zLibrary has: Vols. 1-3. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-2972|zLibrary has: Vols. 1-3. v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012997973"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-2972|zLibrary has: Vols. 1-3."
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012997973"
+                    ],
+                    "idBarcode": [
+                      "33433012997973"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-2972|zLibrary has: Vols. 1-3. v. 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10946973",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 published in 1971.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kālidāsa.",
+            "Kālidāsa. -- Poetry"
+          ],
+          "publisherLiteral": [
+            "Rāsa Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Śākuntalā."
+          ],
+          "shelfMark": [
+            "*OLA 84-4754"
+          ],
+          "creatorLiteral": [
+            "Rāmarāya, Samētanahaḷḷi, 1917-1999."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "seriesStatement": [
+            "S. Rama Raya. Rāsa sāhitya, 16",
+            "Rāsa prakāśana, 9"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-4754"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10946973"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "32071380"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "32071380"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0954152"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)32071380"
+            }
+          ],
+          "idOclc": [
+            "32071380"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659355644076,
+          "publicationStatement": [
+            "[Maṇḍya?] Rāsa Prakāśana [1971-"
+          ],
+          "identifier": [
+            "urn:bnum:10946973",
+            "urn:oclc:32071380",
+            "urn:undefined:(WaOLN)nyp0954152",
+            "urn:undefined:(OCoLC)32071380"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kālidāsa. -- Poetry."
+          ],
+          "titleDisplay": [
+            "Śākuntalā. [Lēkhaka] Samētanahaḷḷi Rāmarāya."
+          ],
+          "uri": "b10946973",
+          "lccClassification": [
+            "PK4659.R316 S2"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Maṇḍya?]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "2. Vyavahārāṅgaṃ."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10946973"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10198402",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-4754|zLibrary has: Vol. 2."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-4754|zLibrary has: Vol. 2.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998641"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-4754|zLibrary has: Vol. 2."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998641"
+                    ],
+                    "idBarcode": [
+                      "33433012998641"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-4754|zLibrary has: Vol. 2."
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10956213",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit (Kannada script); introductory matter in English and Kannada; commentary in Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Madhva, active 13th century",
+            "Dvaita (Vedanta)",
+            "Dvaita (Vedanta) -- Early works to 1800"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Śrī Sarvajñācārya Sēvā Saṅgha"
+          ],
+          "description": [
+            "Exposition of philosophical concepts according to the Dvaita (dualism) school in Indian philosophy as propounded by Madhva, 13th cent."
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "numItemsTotal": [
+            10
+          ],
+          "createdYear": [
+            1978
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Yuktimallikā : mūlasahita Kannaḍa arthānuvāda"
+          ],
+          "shelfMark": [
+            "*OKN 85-1560"
+          ],
+          "numItemVolumesParsed": [
+            10
+          ],
+          "creatorLiteral": [
+            "Vādirāja, active 16th century."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "idLccn": [
+            "83901597 /SA"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 85-1560"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10956213"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83901597 /SA"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG85-B59981"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0963410"
+            }
+          ],
+          "idOclc": [
+            "NYPG85-B59981"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1675264539633,
+          "publicationStatement": [
+            "Dāvaṇagere : Śrī Sarvajñācārya Sēvā Saṅgha, 1978-"
+          ],
+          "identifier": [
+            "urn:bnum:10956213",
+            "urn:lccn:83901597 /SA",
+            "urn:oclc:NYPG85-B59981",
+            "urn:undefined:(WaOLN)nyp0963410"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Madhva, active 13th century.",
+            "Dvaita (Vedanta) -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "Yuktimallikā : mūlasahita Kannaḍa arthānuvāda / anuvādakaru Bi. Bhīmarāv."
+          ],
+          "uri": "b10956213",
+          "lccClassification": [
+            "BL1286.292.M34 V33 1978"
+          ],
+          "numItems": [
+            10
+          ],
+          "numAvailable": [
+            10
+          ],
+          "placeOfPublication": [
+            "Dāvaṇagere"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10956213"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 10,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951317",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 85-1560 v. 14",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618830"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 85-1560"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618830"
+                    ],
+                    "idBarcode": [
+                      "33433058618830"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 14,
+                        "lte": 14
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        14-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-1560 v. 000014"
+                  },
+                  "sort": [
+                    "        14-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951316",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560 v. 13"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 85-1560 v. 13",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618822"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 13"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 85-1560"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618822"
+                    ],
+                    "idBarcode": [
+                      "33433058618822"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 13,
+                        "lte": 13
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        13-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-1560 v. 000013"
+                  },
+                  "sort": [
+                    "        13-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951315",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560 v. 11"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 85-1560 v. 11",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618749"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 11"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 85-1560"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618749"
+                    ],
+                    "idBarcode": [
+                      "33433058618749"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 11,
+                        "lte": 11
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        11-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-1560 v. 000011"
+                  },
+                  "sort": [
+                    "        11-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951314",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560 v. 10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 85-1560 v. 10",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618731"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 10"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 85-1560"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618731"
+                    ],
+                    "idBarcode": [
+                      "33433058618731"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 10,
+                        "lte": 10
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        10-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-1560 v. 000010"
+                  },
+                  "sort": [
+                    "        10-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951313",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560 v. 8"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 85-1560 v. 8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618814"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 8"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 85-1560"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618814"
+                    ],
+                    "idBarcode": [
+                      "33433058618814"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 8,
+                        "lte": 8
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         8-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-1560 v. 000008"
+                  },
+                  "sort": [
+                    "         8-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951312",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560 v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 85-1560 v. 7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618806"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 85-1560"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618806"
+                    ],
+                    "idBarcode": [
+                      "33433058618806"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 7,
+                        "lte": 7
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         7-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-1560 v. 000007"
+                  },
+                  "sort": [
+                    "         7-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951311",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 85-1560 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618798"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 85-1560"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618798"
+                    ],
+                    "idBarcode": [
+                      "33433058618798"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 6,
+                        "lte": 6
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         6-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-1560 v. 000006"
+                  },
+                  "sort": [
+                    "         6-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951310",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 85-1560 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618780"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 85-1560"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618780"
+                    ],
+                    "idBarcode": [
+                      "33433058618780"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 5
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-1560 v. 000005"
+                  },
+                  "sort": [
+                    "         5-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951309",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 85-1560 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618772"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 85-1560"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618772"
+                    ],
+                    "idBarcode": [
+                      "33433058618772"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 4,
+                        "lte": 4
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         4-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-1560 v. 000004"
+                  },
+                  "sort": [
+                    "         4-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13951308",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 85-1560 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 85-1560 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618764"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 85-1560"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618764"
+                    ],
+                    "idBarcode": [
+                      "33433058618764"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 3,
+                        "lte": 3
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         3-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 85-1560 v. 000003"
+                  },
+                  "sort": [
+                    "         3-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10960071",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Folk songs, Kannada",
+            "Folk songs, Kannada -- Dhāwār (District)",
+            "Folk songs, Kannada -- Dhāwār (District) -- Texts"
+          ],
+          "publisherLiteral": [
+            "Bhārati Prakāśana ayāṇḍa Buk Ḍipō,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Gī gī padagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 85-1273"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "78903423 /SA"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 85-1273"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10960071"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78903423 /SA"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0967274"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636195364637,
+          "publicationStatement": [
+            "Hubbaḷḷi : Bhārati Prakāśana ayāṇḍa Buk Ḍipō, [197-]"
+          ],
+          "identifier": [
+            "urn:bnum:10960071",
+            "urn:lccn:78903423 /SA",
+            "urn:undefined:(WaOLN)nyp0967274"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Folk songs, Kannada -- Dhāwār (District) -- Texts."
+          ],
+          "titleDisplay": [
+            "Gī gī padagaḷu."
+          ],
+          "uri": "b10960071",
+          "lccClassification": [
+            "PL4658.5.D482 G5 1970z"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Hubbaḷḷi :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10960071"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999102"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 85-1273"
+                    ],
+                    "shelfMark_sort": "a*OLA 85-001273",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10200106",
+                    "shelfMark": [
+                      "*OLA 85-1273"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 85-1273"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999102"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433012999102"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10960726",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2-   Pradhāna sampādakaru Es. Eṃ. Vrṣabhēndrasvāmi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Basava, active 1160",
+            "Basava, active 1160 -- Criticism and interpretation",
+            "Lingayats"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Adhyayanapīṭha, Karnāṭaka Viśvavidyālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Basavamārga"
+          ],
+          "shelfMark": [
+            "*OLA 85-1658"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82903291 /SA"
+          ],
+          "contributorLiteral": [
+            "Kalaburgi, Eṃ. Eṃ., 1938-",
+            "Sunkapur, M. S."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 85-1658"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10960726"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82903291 /SA"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0967929"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636173089685,
+          "publicationStatement": [
+            "Dhāravāḍa : Kannaḍa Adhyayanapīṭha, Karnāṭaka Viśvavidyālaya, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10960726",
+            "urn:lccn:82903291 /SA",
+            "urn:undefined:(WaOLN)nyp0967929"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Basava, active 1160 -- Criticism and interpretation.",
+            "Lingayats."
+          ],
+          "titleDisplay": [
+            "Basavamārga / pradhāna sampādakaru Eṃ. Es. Suṅkāpura, sampādakaru Eṃ. Eṃ. Kalaburgi."
+          ],
+          "uri": "b10960726",
+          "lccClassification": [
+            "PL4659.B34 Z64 1980"
+          ],
+          "numItems": [
+            4
+          ],
+          "numAvailable": [
+            4
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1-2. Basavamārga.--3. Śivaśaraṇara kāyaka siddhānta.--4. Basavēśvara-Gāndhīji."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10960726"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 4,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999300"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4."
+                    ],
+                    "shelfMark_sort": "a*OLA 85-1658|zLibrary has: Vol. 1-4. v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10200274",
+                    "shelfMark": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433012999300"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999318"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4."
+                    ],
+                    "shelfMark_sort": "a*OLA 85-1658|zLibrary has: Vol. 1-4. v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10200273",
+                    "shelfMark": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999318"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433012999318"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999284"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4."
+                    ],
+                    "shelfMark_sort": "a*OLA 85-1658|zLibrary has: Vol. 1-4. v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10200272",
+                    "shelfMark": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999284"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433012999284"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012999292"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4."
+                    ],
+                    "shelfMark_sort": "a*OLA 85-1658|zLibrary has: Vol. 1-4. v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10200271",
+                    "shelfMark": [
+                      "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 85-1658|zLibrary has: Vol. 1-4. v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012999292"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433012999292"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10960742",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 2-   published by: Rāyabḡa, Jille Beḷagāvi : Kālagati Prakāśana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hinduism"
+          ],
+          "publisherLiteral": [
+            "Prasārāṅga, Beṅgaḷūru Viśvavidyālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Pravāha patitara karma ʻHindūʼ emba dharma"
+          ],
+          "shelfMark": [
+            "*OLY 85-1572"
+          ],
+          "creatorLiteral": [
+            "Joshi, Shankar Baldixit, 1896-"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77904440"
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 85-1572"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10960742"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77904440"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0967945"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636217462897,
+          "publicationStatement": [
+            "Beṅgaḷūru : Prasārāṅga, Beṅgaḷūru Viśvavidyālaya, c1976-"
+          ],
+          "identifier": [
+            "urn:bnum:10960742",
+            "urn:lccn:77904440",
+            "urn:undefined:(WaOLN)nyp0967945"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hinduism."
+          ],
+          "titleDisplay": [
+            "Pravāha patitara karma ʻHindūʼ emba dharma / Śaṃ. Bā. Jōśi."
+          ],
+          "uri": "b10960742",
+          "lccClassification": [
+            "BL1210 .J63 1976"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. [Without special title] -- 2. Vaivasvata Manupranita Manava dharma."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10960742"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13952123",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 85-1572 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 85-1572 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060421967"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 85-1572"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060421967"
+                    ],
+                    "idBarcode": [
+                      "33433060421967"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 85-1572 v. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13952122",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 85-1572 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 85-1572 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060421959"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLY 85-1572"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060421959"
+                    ],
+                    "idBarcode": [
+                      "33433060421959"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "a*OLY 85-1572 v. 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10977467",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Śūnyasampādane",
+            "Lingayat poetry, Kannada",
+            "Lingayat poetry, Kannada -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Ṡrī śaila Jagadguru Niḍumāmiḍi Nivāsa"
+          ],
+          "description": [
+            "On the Śūnyasampādane, 15th century anthology of Virasaivite poetry."
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sampādaneya sompu : samagra vivēcane"
+          ],
+          "shelfMark": [
+            "*OLA 84-4577"
+          ],
+          "creatorLiteral": [
+            "Ja. Ca. Ni., 1911-"
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "idLccn": [
+            "78904240 /SA"
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 84-4577"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10977467"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78904240 /SA"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11210904"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11210904"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0984696"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11210904"
+            }
+          ],
+          "idOclc": [
+            "11210904"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659340534228,
+          "publicationStatement": [
+            "Beṅgaḷūru : Ṡrī śaila Jagadguru Niḍumāmiḍi Nivāsa, 1977-"
+          ],
+          "identifier": [
+            "urn:bnum:10977467",
+            "urn:lccn:78904240 /SA",
+            "urn:oclc:11210904",
+            "urn:undefined:(WaOLN)nyp0984696",
+            "urn:undefined:(OCoLC)11210904"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Śūnyasampādane.",
+            "Lingayat poetry, Kannada -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Sampādaneya sompu : samagra vivēcane / Ja.Ca.Ni."
+          ],
+          "uri": "b10977467",
+          "lccClassification": [
+            "PL4656.S953 J3 1977"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Esaḷondu. Anubhava sampuṭa."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10977467"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10202056",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLA 84-4577|zLibrary has: Vol. 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLA 84-4577|zLibrary has: Vol. 1.",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012998591"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLA 84-4577|zLibrary has: Vol. 1."
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012998591"
+                    ],
+                    "idBarcode": [
+                      "33433012998591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*OLA 84-4577|zLibrary has: Vol. 1."
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10996867",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuvempu, 1904-1994",
+            "Kuvempu, 1904-1994 -- Biography",
+            "Authors, Kannada",
+            "Authors, Kannada -- 20th century",
+            "Authors, Kannada -- 20th century -- Biography"
+          ],
+          "publisherLiteral": [
+            "Sahyādri Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nenapina dōṇiyalli"
+          ],
+          "shelfMark": [
+            "*OLA 86-3268"
+          ],
+          "creatorLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "81901148 /SA"
+          ],
+          "seriesStatement": [
+            "Sahyādri Prakāśana ; 25"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 86-3268"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10996867"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81901148 /SA"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "8111415"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "8111415"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1004145"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)8111415"
+            }
+          ],
+          "idOclc": [
+            "8111415"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1659332831108,
+          "publicationStatement": [
+            "Maisūru : Sahyādri Prakāśana 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10996867",
+            "urn:lccn:81901148 /SA",
+            "urn:oclc:8111415",
+            "urn:undefined:(WaOLN)nyp1004145",
+            "urn:undefined:(OCoLC)8111415"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuvempu, 1904-1994 -- Biography.",
+            "Authors, Kannada -- 20th century -- Biography."
+          ],
+          "titleDisplay": [
+            "Nenapina dōṇiyalli / Kuvempu."
+          ],
+          "uri": "b10996867",
+          "lccClassification": [
+            "PL4659.K94 Z468"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Maisūru"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10996867"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10209587",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013120096"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013120096"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013120096"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 86-3268"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-003268"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10209586",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013120682"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013120682"
+                      }
+                    ],
+                    "idBarcode": [
+                      "33433013120682"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark": [
+                      "*OLA 86-3268"
+                    ],
+                    "shelfMark_sort": "a*OLA 86-003268"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-b6431c195b8d99937864a0cdb6b2b5c2.json
+++ b/test/fixtures/query-b6431c195b8d99937864a0cdb6b2b5c2.json
@@ -1,0 +1,918 @@
+{
+  "took": 56,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 15.448069,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 15.448069,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-bfe559fc81a64c231bab0be41419bbc0.json
+++ b/test/fixtures/query-bfe559fc81a64c231bab0be41419bbc0.json
@@ -1,0 +1,15715 @@
+{
+  "took": 411,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 965325,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Stauffenburg"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Gmelin, Hermann, 1900-1958.",
+            "Baum, Richard.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGNYPG-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "idOclc": [
+            "NYPGNYPG-B"
+          ],
+          "updatedAt": 1678937667178,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:oclc:NYPGNYPG-B",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen"
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "3923721544"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000432",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "94 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Amīr Kabīr"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mānilī va khānah-ʼi Sarīvaylī : du manẓūmah"
+          ],
+          "shelfMark": [
+            "*OMO 84-1527"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Yūshīj, Nīmā."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMO 84-1527"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000432"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000386-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100386"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200431"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000386-B"
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1674870767447,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Amīr Kabīr, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10000432",
+            "urn:oclc:NYPG001000386-B",
+            "urn:undefined:NNSZ00100386",
+            "urn:undefined:(WaOLN)nyp0200431"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Mānilī va khānah-ʼi Sarīvaylī : du manẓūmah / az Nīmā yūshīj."
+          ],
+          "uri": "b10000432",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Khānah-ʼi Sarīvaylī."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000432"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000245",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMO 84-1527"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMO 84-1527",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001898497"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMO 84-1527"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001898497"
+                    ],
+                    "idBarcode": [
+                      "33433001898497"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMO 84-001527"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001333",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., folded maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Geomorphology",
+            "Geomorphology -- Libya"
+          ],
+          "publisherLiteral": [
+            "al-Jāmiʻah al-Lībīyah, Kullīyat al-Ādāb,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Abḥāth fī zhiyūmūrfūlūzhīyat al-arāḍī al-Lībīyah"
+          ],
+          "shelfMark": [
+            "*OFO 82-5116"
+          ],
+          "creatorLiteral": [
+            "Jawdah, Jawdah Ḥasanayn."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75960642"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFO 82-5116"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001333"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960642"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201348"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201331"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636070536203,
+          "publicationStatement": [
+            "[Binghāzī] : al-Jāmiʻah al-Lībīyah, Kullīyat al-Ādāb, 1973-"
+          ],
+          "identifier": [
+            "urn:bnum:10001333",
+            "urn:lccn:75960642",
+            "urn:undefined:NNSZ00201348",
+            "urn:undefined:(WaOLN)nyp0201331"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Geomorphology -- Libya."
+          ],
+          "titleDisplay": [
+            "Abḥāth fī zhiyūmūrfūlūzhīyat al-arāḍī al-Lībīyah / Jawdah Ḥasanayn Jawdah."
+          ],
+          "uri": "b10001333",
+          "lccClassification": [
+            "GB440.L5 J38"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Binghāzī] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24cm."
+          ]
+        },
+        "sort": [
+          "b10001333"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586197"
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5116 al-Juzʼān 1-2."
+                    ],
+                    "shelfMark_sort": "a*OFO 82-5116 al-Juzʼān 1-2. v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10000872",
+                    "shelfMark": [
+                      "*OFO 82-5116 al-Juzʼān 1-2. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFO 82-5116 al-Juzʼān 1-2. v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586197"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433005586197"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586189"
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5116 al-Juzʼān 1-2."
+                    ],
+                    "shelfMark_sort": "a*OFO 82-5116 al-Juzʼān 1-2. v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10000871",
+                    "shelfMark": [
+                      "*OFO 82-5116 al-Juzʼān 1-2. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFO 82-5116 al-Juzʼān 1-2. v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586189"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433005586189"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001657",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on p. [4] of cover: Village gazetteer.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Bar asās-i natāyij-i sarshumārī-i ʻumūmī-i Ābānʼmāh-i 1345.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "English and Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Gazetteers",
+            "Villages",
+            "Villages -- Iran",
+            "Villages -- Iran -- Statistics"
+          ],
+          "publisherLiteral": [
+            "Markaz-i Āmār-i Īrān,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Farhang-i ābādīhā-yi kishvar."
+          ],
+          "shelfMark": [
+            "Map Div. 84-146"
+          ],
+          "creatorLiteral": [
+            "Markaz-i Āmār-i Īrān."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "81464564"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Map Div. 84-146"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001657"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81464564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201692"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201655"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636095534719,
+          "publicationStatement": [
+            "Tihrān : Markaz-i Āmār-i Īrān, 1347- [1969-]"
+          ],
+          "identifier": [
+            "urn:bnum:10001657",
+            "urn:lccn:81464564",
+            "urn:undefined:NNSZ00201692",
+            "urn:undefined:(WaOLN)nyp0201655"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Gazetteers.",
+            "Villages -- Iran -- Statistics."
+          ],
+          "titleDisplay": [
+            "Farhang-i ābādīhā-yi kishvar."
+          ],
+          "uri": "b10001657",
+          "lccClassification": [
+            "DS253 .M37"
+          ],
+          "numItems": [
+            11
+          ],
+          "numAvailable": [
+            11
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Village gazetteer."
+          ],
+          "tableOfContents": [
+            "Jild-i 2. Ustān-i Āẕarbāyjān-i Gharbī--Jild-i 3-5. Ustān-i Khurāsān--Jild-1 6. Ustān-i Kurdistān--Jild-i 9. Farmāndārī-i Kull-i Luristān--Jild-i 10. Farmāndārīhā-yi Kull-i Banādir va Jazāʼir-i Khalīj-i Fārs va Daryā-yi Ummān--Jild-i 11. Ustān-i Māzandarān--Jild-i 14. Ustān-i Markazī--Jild-i 15. Ustān-i Gilān--Jild-i 17. Farmāndārī-i Kull-i Simnān."
+          ],
+          "dimensions": [
+            "42x54 cm."
+          ]
+        },
+        "sort": [
+          "b10001657"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 11,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030870"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000017",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784147",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 17"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 17"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030870"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 17"
+                    ],
+                    "idBarcode": [
+                      "33433057030870"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030862"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000015",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784146",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 15"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 15"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030862"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 15"
+                    ],
+                    "idBarcode": [
+                      "33433057030862"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030854"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000014",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784145",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 14"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030854"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "idBarcode": [
+                      "33433057030854"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030847"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000010",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784144",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 10"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030847"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10"
+                    ],
+                    "idBarcode": [
+                      "33433057030847"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030839"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000009",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784143",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 9"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030839"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9"
+                    ],
+                    "idBarcode": [
+                      "33433057030839"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030821"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000006",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784142",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 6"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030821"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "idBarcode": [
+                      "33433057030821"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030813"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000005",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784141",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 5"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030813"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "idBarcode": [
+                      "33433057030813"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030805"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784140",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030805"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433057030805"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030797"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784139",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030797"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433057030797"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030789"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784138",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030789"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433057030789"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030771"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784137",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030771"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433057030771"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001844",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: The Brahmasūtra Śāṅkarbhāṣya.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindu philosophy",
+            "Vedanta"
+          ],
+          "publisherLiteral": [
+            "Chaukhambā Vidyābhavana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brahmasūtraśāṅkarabhāṣyam. 'Brahmatatvavimarśinī' Hindīvyākhyāsahitam."
+          ],
+          "shelfMark": [
+            "*OKN 82-2276"
+          ],
+          "creatorLiteral": [
+            "Bādarāyaṇa."
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 65007118"
+          ],
+          "seriesStatement": [
+            "Vidyābhavara Saṃskrta granthamālā, 124"
+          ],
+          "contributorLiteral": [
+            "Sastri, Hanumanadas, Swami.",
+            "Śaṅkarācārya."
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 82-2276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001844"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 65007118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201882"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201842"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636079011965,
+          "publicationStatement": [
+            "Vārāṇasī, Chaukhambā Vidyābhavana [1964-"
+          ],
+          "identifier": [
+            "urn:bnum:10001844",
+            "urn:lccn:sa 65007118",
+            "urn:undefined:NNSZ00201882",
+            "urn:undefined:(WaOLN)nyp0201842"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindu philosophy.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Brahmasūtraśāṅkarabhāṣyam. 'Brahmatatvavimarśinī' Hindīvyākhyāsahitam. Vyākhyākāra [sic] Svāmī Hanumānadāsa Shaṭśāstrī. Bhūmikā-lekhaka Vīramaṇi Prasāda Upādhyāya."
+          ],
+          "uri": "b10001844",
+          "lccClassification": [
+            "B132.V3 B22"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasī,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Brahmasūtra Śaṅkarbhāṣya."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10001844"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058617816"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 82-2276"
+                    ],
+                    "shelfMark_sort": "a*OKN 82-002276",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784177",
+                    "shelfMark": [
+                      "*OKN 82-2276"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKN 82-2276"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058617816"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433058617816"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002118",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "204 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Wakālat Nāy,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1999"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Awlād bi-al-jumlah"
+          ],
+          "shelfMark": [
+            "*OFD 82-4488"
+          ],
+          "creatorLiteral": [
+            "Gilbreth, Frank B. (Frank Bunker), 1911-2001."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "contributorLiteral": [
+            "Carey, Ernestine Moller, 1908-",
+            "Ṭāhā, Aḥmad."
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFD 82-4488"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202160"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202114"
+            }
+          ],
+          "uniformTitle": [
+            "Cheaper by the dozen. Arabic"
+          ],
+          "dateEndYear": [
+            1999
+          ],
+          "updatedAt": 1636076222810,
+          "publicationStatement": [
+            "Dimashq : Wakālat Nāy, 19--."
+          ],
+          "identifier": [
+            "urn:bnum:10002118",
+            "urn:undefined:NNSZ00202160",
+            "urn:undefined:(WaOLN)nyp0202114"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Awlād bi-al-jumlah / taʼlīf Firānk Bi. Jīlbrith wa-Irnistin Jīlbrith Kārī ; tarjumat Aḥmad Ṭaha."
+          ],
+          "uri": "b10002118",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Cheaper by the dozen."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10002118"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001997497"
+                    ],
+                    "physicalLocation": [
+                      "*OFD 82-4488"
+                    ],
+                    "shelfMark_sort": "a*OFD 82-004488",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10001459",
+                    "shelfMark": [
+                      "*OFD 82-4488"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFD 82-4488"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001997497"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001997497"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002297",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Politics and government",
+            "Iran -- Politics and government -- 20th century"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Firdawsī,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Khāṭirāt-i Sayyid Àlī Muḥammad Dawlatābādī : līdir-i Ìtidālīyūn."
+          ],
+          "shelfMark": [
+            "*OMZ 84-1529"
+          ],
+          "creatorLiteral": [
+            "Dawlatābādī, Àlī Muḥammad."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-1529"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002297"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202345"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202293"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636109324448,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Firdawsī, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10002297",
+            "urn:undefined:NNSZ00202345",
+            "urn:undefined:(WaOLN)nyp0202293"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Politics and government -- 20th century."
+          ],
+          "titleDisplay": [
+            "Khāṭirāt-i Sayyid Àlī Muḥammad Dawlatābādī : līdir-i Ìtidālīyūn."
+          ],
+          "uri": "b10002297",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10002297"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539872"
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-1529"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-001529",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10942128",
+                    "shelfMark": [
+                      "*OMZ 84-1529"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMZ 84-1529"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539872"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433014539872"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002303",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "280 p. : facsim. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Politics and government",
+            "Iran -- Politics and government -- 20th century",
+            "Political prisoners",
+            "Political prisoners -- Iran",
+            "Political prisoners -- Iran -- Biography"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Haftah,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Panjāh nafar... va sih nafar : asrār-i paydāyish, sāzmān va dastgīrī-i gurūh-i sīyāsī-i 53 nafar kih barā-yi avvalīn bār ifshā mīshavad"
+          ],
+          "shelfMark": [
+            "*OMZ 84-1538"
+          ],
+          "creatorLiteral": [
+            "Khāmahʼī, Anvar."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-1538"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002303"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202351"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202299"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636121044994,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Haftah, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10002303",
+            "urn:undefined:NNSZ00202351",
+            "urn:undefined:(WaOLN)nyp0202299"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Politics and government -- 20th century.",
+            "Political prisoners -- Iran -- Biography."
+          ],
+          "titleDisplay": [
+            "Panjāh nafar... va sih nafar : asrār-i paydāyish, sāzmān va dastgīrī-i gurūh-i sīyāsī-i 53 nafar kih barā-yi avvalīn bār ifshā mīshavad / khāṭirāt-i Anvar Khāmah'ī."
+          ],
+          "uri": "b10002303",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10002303"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539880"
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-1538"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-001538",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10942130",
+                    "shelfMark": [
+                      "*OMZ 84-1538"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMZ 84-1538"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539880"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433014539880"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003134",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "397 p. : ill., port., facsim. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- History",
+            "Iran -- History -- Qajar dynasty, 1794-1925",
+            "Statesmen",
+            "Statesmen -- Iran",
+            "Statesmen -- Iran -- Biography"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Amīr Kabīr,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Khāṭirāt-i Mumtaḥin al-Dawlah : zindigīnāmah-ʼi Mīrzā Mahdī Khān Mumtaḥin al-Dawlah Shaqāqī"
+          ],
+          "shelfMark": [
+            "*OMZ 84-1427"
+          ],
+          "creatorLiteral": [
+            "Mumtaḥin al-Dawlah Shaqāqī, Mahdī Khān."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "seriesStatement": [
+            "Majmūʻah-ʼi guzashtah-ʼi Īrān dar nivishtah-ʼi pīshīnīyān, 1"
+          ],
+          "contributorLiteral": [
+            "Khānshaqāqī, Ḥusaynqulī."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-1427"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003134"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303485"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203127"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636109324448,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Amīr Kabīr, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10003134",
+            "urn:undefined:NNSZ00303485",
+            "urn:undefined:(WaOLN)nyp0203127"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- History -- Qajar dynasty, 1794-1925.",
+            "Statesmen -- Iran -- Biography."
+          ],
+          "titleDisplay": [
+            "Khāṭirāt-i Mumtaḥin al-Dawlah : zindigīnāmah-ʼi Mīrzā Mahdī Khān Mumtaḥin al-Dawlah Shaqāqī / bi-kūshish-i Ḥusaynqulī Khānshaqāqī."
+          ],
+          "uri": "b10003134",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24cm."
+          ]
+        },
+        "sort": [
+          "b10003134"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539856"
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-1427"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-001427",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10942159",
+                    "shelfMark": [
+                      "*OMZ 84-1427"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMZ 84-1427"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539856"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433014539856"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003171",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "412 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Nashr-i Naw"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Āvāz-i kushtigān"
+          ],
+          "shelfMark": [
+            "*OMP 84-2030"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Baraheni, Reza, 1935-2022."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2030"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003171"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG003000626-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303522"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203164"
+            }
+          ],
+          "idOclc": [
+            "NYPG003000626-B"
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1675110792889,
+          "publicationStatement": [
+            "Tihrān : Nashr-i Naw, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10003171",
+            "urn:oclc:NYPG003000626-B",
+            "urn:undefined:NNSZ00303522",
+            "urn:undefined:(WaOLN)nyp0203164"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Āvāz-i kushtigān / Rizā Barāhinī."
+          ],
+          "uri": "b10003171",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm."
+          ]
+        },
+        "sort": [
+          "b10003171"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002196",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2030"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2030",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173038"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2030"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173038"
+                    ],
+                    "idBarcode": [
+                      "33433013173038"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002030"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003179",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "101 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Nashr-i Naw"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Chāh bih chāh"
+          ],
+          "shelfMark": [
+            "*OMP 84-2039"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Baraheni, Reza, 1935-2022."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2039"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003179"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG003000634-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303530"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203172"
+            }
+          ],
+          "idOclc": [
+            "NYPG003000634-B"
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1675110792235,
+          "publicationStatement": [
+            "Tihrān : Nashr-i Naw, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10003179",
+            "urn:oclc:NYPG003000634-B",
+            "urn:undefined:NNSZ00303530",
+            "urn:undefined:(WaOLN)nyp0203172"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Chāh bih chāh / Rizā Barāhinī."
+          ],
+          "uri": "b10003179",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10003179"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002203",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2039"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2039",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2039"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173053"
+                    ],
+                    "idBarcode": [
+                      "33433013173053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002039"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003180",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "235 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam and state",
+            "Islam and state -- Iran",
+            "Khomeini, Ruhollah"
+          ],
+          "publisherLiteral": [
+            "Org. of Act. Constitutionalist Iranians,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1989"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Qizāvat"
+          ],
+          "shelfMark": [
+            "*OMZ 84-965"
+          ],
+          "creatorLiteral": [
+            "ʻAbd al-Raḥmān."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-965"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003180"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303531"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203173"
+            }
+          ],
+          "dateEndYear": [
+            1989
+          ],
+          "updatedAt": 1636124389229,
+          "publicationStatement": [
+            "Los Angeles : Org. of Act. Constitutionalist Iranians, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10003180",
+            "urn:undefined:NNSZ00303531",
+            "urn:undefined:(WaOLN)nyp0203173"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam and state -- Iran.",
+            "Khomeini, Ruhollah."
+          ],
+          "titleDisplay": [
+            "Qizāvat / ʻAbd al-Raḥmān..."
+          ],
+          "uri": "b10003180",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Los Angeles :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10003180"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539666"
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-965"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-000965",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10942161",
+                    "shelfMark": [
+                      "*OMZ 84-965"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMZ 84-965"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539666"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433014539666"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003410",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. facsims."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Imam Ṭaḥāwī's Disagreement of jurists (Ikhtilāf al-fuqahāʼ)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Introd. in Arabic and English ; text in Arabic.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: v. 1, p. [313]-314.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islamic law"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ikhtilāf al-fuqahāʼ,"
+          ],
+          "shelfMark": [
+            "*OGM 84-702"
+          ],
+          "creatorLiteral": [
+            "Ṭaḥāwī, Aḥmad ibn Muḥammad, 852?-933."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72930954"
+          ],
+          "seriesStatement": [
+            "Maṭbūʻāt Maʻhad al-Abḥāth al-Islāmīyāh. Publication no. 23"
+          ],
+          "contributorLiteral": [
+            "Maʻṣūmī, M. Ṣaghīr Ḥasan (Muḥammad Ṣaghīr Ḥasan)"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGM 84-702"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003410"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72930954"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303765"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203402"
+            }
+          ],
+          "uniformTitle": [
+            "Publication (Islamic Research Institute (Pakistan)) ; \\no.23."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636104747880,
+          "publicationStatement": [
+            "Islām Ābād [1971-"
+          ],
+          "identifier": [
+            "urn:bnum:10003410",
+            "urn:lccn:72930954",
+            "urn:undefined:NNSZ00303765",
+            "urn:undefined:(WaOLN)nyp0203402"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islamic law."
+          ],
+          "titleDisplay": [
+            "Ikhtilāf al-fuqahāʼ, lil-Imām Abī Jaʻfar Aḥmad ibn Muḥammad al-Ṭaḥāwī. Ḥaqqaqahu wa-ʻallaqa ʻalayhi Muḥammad Ṣaghīr Ḥasan al-Maʻṣūmī."
+          ],
+          "uri": "b10003410",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Islām Ābād"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003410"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001944960"
+                    ],
+                    "physicalLocation": [
+                      "*OGM 84-702"
+                    ],
+                    "shelfMark_sort": "a*OGM 84-000702",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002358",
+                    "shelfMark": [
+                      "*OGM 84-702"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OGM 84-702"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001944960"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001944960"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003414",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Skandamahāpurāṇam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added t.p. in English or Hindi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 1:2. Saṃskaraṇam; v. 2-: 1. Saṃskaraṇam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Manasukharāya Mora,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Skandamahāpurāṇam"
+          ],
+          "shelfMark": [
+            "*OKOK 84-641"
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "73902099"
+          ],
+          "seriesStatement": [
+            "Gurumaṇḍalagranthamālāyāḥ ; puṣpam 20"
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKOK 84-641"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003414"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73902099"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303769"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203406"
+            }
+          ],
+          "uniformTitle": [
+            "Puranas Skanda Purāṇa."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636124303127,
+          "publicationStatement": [
+            "Kalakattā : Manasukharāya Mora, 1960-"
+          ],
+          "identifier": [
+            "urn:bnum:10003414",
+            "urn:lccn:73902099",
+            "urn:undefined:NNSZ00303769",
+            "urn:undefined:(WaOLN)nyp0203406"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Skandamahāpurāṇam  / Śrāmanmaharṣikrṣṇadvaipāyanavyāsaviracitam."
+          ],
+          "uri": "b10003414",
+          "lccClassification": [
+            "PK3621 .S5 1960"
+          ],
+          "numItems": [
+            6
+          ],
+          "numAvailable": [
+            6
+          ],
+          "placeOfPublication": [
+            "Kalakattā :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Skanda-Purāṇam."
+          ],
+          "tableOfContents": [
+            "1. Māheśvarakhaṇḍātmakaḥ.--2. Vaiṣṇavakhaṇḍātmakaḥ.--3. Brahmakhandātmakaḥ.--4. Kāśīkhaṇḍātmakaḥ.--5. Avantīkhaṇḍātmakah. 2 pts."
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10003414"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 6,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221423"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000005 pt 2",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002364",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 5 pt 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 5 pt 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221423"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt 2"
+                    ],
+                    "idBarcode": [
+                      "33433013221423"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221415"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000005 pt 1",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002363",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 5 pt 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 5 pt 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221415"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt 1"
+                    ],
+                    "idBarcode": [
+                      "33433013221415"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221407"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002362",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221407"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433013221407"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221399"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002365",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221399"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433013221399"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221381"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002361",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221381"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433013221381"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221373"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002360",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221373"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433013221373"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003502",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Partly translations from German poetry (with German texts included).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally published in 1856, under title: Dziesmiņas latviešu valodai pārtulkotas; original t.p. included.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Liesma,"
+          ],
+          "language": [
+            {
+              "id": "lang:lav",
+              "label": "Latvian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dziesmiņas"
+          ],
+          "shelfMark": [
+            "*QYN 82-2046"
+          ],
+          "creatorLiteral": [
+            "Alunāns, Juris, 1832-1864."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "seriesStatement": [
+            "Literārā mantojuma mazā bibliotēka"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*QYN 82-2046"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003502"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303857"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203494"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636091475285,
+          "publicationStatement": [
+            "Riga : Liesma, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10003502",
+            "urn:undefined:NNSZ00303857",
+            "urn:undefined:(WaOLN)nyp0203494"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Dziesmiņas / Juris Alunāns."
+          ],
+          "uri": "b10003502",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Riga :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "17 cm."
+          ]
+        },
+        "sort": [
+          "b10003502"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013501782"
+                    ],
+                    "physicalLocation": [
+                      "*QYN 82-2046 Dala 1."
+                    ],
+                    "shelfMark_sort": "a*QYN 82-2046 Dala 1.",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002421",
+                    "shelfMark": [
+                      "*QYN 82-2046 Dala 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*QYN 82-2046 Dala 1."
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013501782"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013501782"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003671",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Egypt",
+            "Egypt -- Politics and government",
+            "Egypt -- Politics and government -- 640-1882"
+          ],
+          "publisherLiteral": [
+            "Maktabat al-Anjlū al-Miṣrīyah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nuẓum al-Fāṭimīyīn wa-rusūmuhum fī Miṣr. Institutions et cérémonial des Faṭimides en Égypte."
+          ],
+          "shelfMark": [
+            "*OFP 82-1931"
+          ],
+          "creatorLiteral": [
+            "Mājid, ʻAbd al-Munʻim."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "73960873"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFP 82-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003671"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73960873"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304029"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203663"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636119319155,
+          "publicationStatement": [
+            "al-Qāhirah, Maktabat al-Anjlū al-Miṣrīyah, 1973-"
+          ],
+          "identifier": [
+            "urn:bnum:10003671",
+            "urn:lccn:73960873",
+            "urn:undefined:NNSZ00304029",
+            "urn:undefined:(WaOLN)nyp0203663"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Egypt -- Politics and government -- 640-1882."
+          ],
+          "titleDisplay": [
+            "Nuẓum al-Fāṭimīyīn wa-rusūmuhum fī Miṣr. Institutions et cérémonial des Faṭimides en Égypte. Taʼlīf ʻAbd al-Munʻim Mājid."
+          ],
+          "uri": "b10003671",
+          "lccClassification": [
+            "JQ3824 .M34 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Institutions et cérémonial des Fatimides en Égypte."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003671"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001937121"
+                    ],
+                    "physicalLocation": [
+                      "*OFP 82-1931"
+                    ],
+                    "shelfMark_sort": "a*OFP 82-001931",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002566",
+                    "shelfMark": [
+                      "*OFP 82-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFP 82-1931"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001937121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001937121"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003719",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 2 & 4: pariṣkarta Puripanda.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Telugu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Telugu literature",
+            "Telugu literature -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Āndhrapradēś Sāhitya Akāḍami"
+          ],
+          "language": [
+            {
+              "id": "lang:tel",
+              "label": "Telugu"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sārasvata vyāsamulu; Telumgu kavitvapu tīru tennulu."
+          ],
+          "shelfMark": [
+            "*OLC 83-35"
+          ],
+          "creatorLiteral": [
+            "Subrahmanyam, G. V., 1935-"
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "71912553"
+          ],
+          "contributorLiteral": [
+            "Appalaswamy, Puripanda, 1904-",
+            "Āndhra Pradēśa Sāhitya Akāḍami."
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLC 83-35"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003719"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "71912553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304078"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203711"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636132209400,
+          "publicationStatement": [
+            "Haidrābādu, Āndhrapradēś Sāhitya Akāḍami [1969-"
+          ],
+          "identifier": [
+            "urn:bnum:10003719",
+            "urn:lccn:71912553",
+            "urn:undefined:NNSZ00304078",
+            "urn:undefined:(WaOLN)nyp0203711"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Telugu literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Sārasvata vyāsamulu; Telumgu kavitvapu tīru tennulu. Saṅkalanakarta Ji. Vi. Subrahmaṇyaṃ."
+          ],
+          "uri": "b10003719",
+          "lccClassification": [
+            "PL4780.05 S79"
+          ],
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            5
+          ],
+          "placeOfPublication": [
+            "Haidrābādu,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10003719"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197476"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000005",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002605",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 5"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197476"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "idBarcode": [
+                      "33433011197476"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197468"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002604",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197468"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433011197468"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197450"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002603",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197450"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433011197450"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197443"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002602",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197443"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433011197443"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197435"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002601",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197435"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433011197435"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003958",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "39, 18, 83, 3 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Version",
+              "label": "Reprint of the 1910 ? ed.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Logic",
+            "Logic -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "Maktabat Āyat Allāh al-ʻUẓmá al-Najafī al-Marʻashī,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1910"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Qaṣīdah al-muzdawijah fī al-manṭiq wa-manṭiq al-mashriqīyīn,"
+          ],
+          "shelfMark": [
+            "*OGL 83-2455"
+          ],
+          "creatorLiteral": [
+            "Avicenna, 980-1037."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "idLccn": [
+            "73960850"
+          ],
+          "contributorLiteral": [
+            "Avicenna, 980-1037."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGL 83-2455"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003958"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73960850"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304319"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203950"
+            }
+          ],
+          "dateEndYear": [
+            1910
+          ],
+          "updatedAt": 1636072413178,
+          "publicationStatement": [
+            "Qum : Maktabat Āyat Allāh al-ʻUẓmá al-Najafī al-Marʻashī, 1405 [1984 or 1985]"
+          ],
+          "identifier": [
+            "urn:bnum:10003958",
+            "urn:lccn:73960850",
+            "urn:undefined:NNSZ00304319",
+            "urn:undefined:(WaOLN)nyp0203950"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Logic -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "al-Qaṣīdah al-muzdawijah fī al-manṭiq wa-manṭiq al-mashriqīyīn, taṣnīf Abī ʻAlī ibn Sīnā."
+          ],
+          "uri": "b10003958",
+          "lccClassification": [
+            "B751 .M4 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Qum :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10003958"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058069919"
+                    ],
+                    "physicalLocation": [
+                      "*OGL 83-2455"
+                    ],
+                    "shelfMark_sort": "a*OGL 83-002455",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i12858216",
+                    "shelfMark": [
+                      "*OGL 83-2455"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OGL 83-2455"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058069919"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433058069919"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004373",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 3- have imprint: Mysore : Sahyādri Prakāśana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuvempu, 1904-1994"
+          ],
+          "publisherLiteral": [
+            "Karnāṭaka Sahakārī Prakāśana Mandira"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 83-3417"
+          ],
+          "creatorLiteral": [
+            "Javare Gowda, Deve Gowda, 1918-"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902119"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-3417"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004373"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902119"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304738"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204365"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636109940889,
+          "publicationStatement": [
+            "Beṅgaḷūru] Karnāṭaka Sahakārī Prakāśana Mandira [1971]-"
+          ],
+          "identifier": [
+            "urn:bnum:10004373",
+            "urn:lccn:72902119",
+            "urn:undefined:NNSZ00304738",
+            "urn:undefined:(WaOLN)nyp0204365"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "titleDisplay": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu. [Lēkhaka] Dējagau."
+          ],
+          "uri": "b10004373",
+          "lccClassification": [
+            "PL4659.P797 S7934"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004373"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001707623"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "shelfMark_sort": "a*OLA 83-3417 Library has: Vol. 1, 3.",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003188",
+                    "shelfMark": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-3417 Library has: Vol. 1, 3."
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001707623"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001707623"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057523718"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-341"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-341 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i12858227",
+                    "shelfMark": [
+                      "*OLA 83-341 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-341 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057523718"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433057523718"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004788",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "277 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Plon"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Le château du soleil couchant : roman"
+          ],
+          "shelfMark": [
+            "JFE 84-3450"
+          ],
+          "creatorLiteral": [
+            "Grey, Marina."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "La saga de l'exil / Marina Grey ; [3]",
+            "Grey, Marina. Saga de l'exil ; \\[3]"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 84-3450"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004788"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "2259011187 :"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405900"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204778"
+            }
+          ],
+          "updatedAt": 1652324535423,
+          "publicationStatement": [
+            "Paris : Plon, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10004788",
+            "urn:isbn:2259011187 :",
+            "urn:undefined:NNSZ00405900",
+            "urn:undefined:(WaOLN)nyp0204778"
+          ],
+          "idIsbn": [
+            "2259011187 "
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Le château du soleil couchant : roman / Marina Grey."
+          ],
+          "uri": "b10004788",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "2259011187"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10004788"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858280",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 84-3450"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 84-3450",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113944"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 84-3450"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113944"
+                    ],
+                    "idBarcode": [
+                      "33433046113944"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFE 84-003450"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004816",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Martins Livreiro-Editor,"
+          ],
+          "language": [
+            {
+              "id": "lang:por",
+              "label": "Portuguese"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A outra face de J. Simões Lopes Neto"
+          ],
+          "shelfMark": [
+            "JFK 84-291"
+          ],
+          "creatorLiteral": [
+            "Lopes Neto, J. Simões (João Simões), 1865-1916."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "idLccn": [
+            "84227211"
+          ],
+          "contributorLiteral": [
+            "Moreira, Angelo Pires."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 84-291"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004816"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84227211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204806"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636069640817,
+          "publicationStatement": [
+            "Porto Alegre, RGSul [i.e. Rio Grande do Sul], Brasil : Martins Livreiro-Editor, 1983-"
+          ],
+          "identifier": [
+            "urn:bnum:10004816",
+            "urn:lccn:84227211",
+            "urn:undefined:(WaOLN)nyp0204806"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "A outra face de J. Simões Lopes Neto / [editor] Angelo Pires Moreira."
+          ],
+          "uri": "b10004816",
+          "lccClassification": [
+            "PQ9697.L7223 A6 1983"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Porto Alegre, RGSul [i.e. Rio Grande do Sul], Brasil :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004816"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003418559"
+                    ],
+                    "physicalLocation": [
+                      "JFK 84-291"
+                    ],
+                    "shelfMark_sort": "aJFK 84-291 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003383",
+                    "shelfMark": [
+                      "JFK 84-291 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFK 84-291 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003418559"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433003418559"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004947",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Geografi︠i︡a.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 170.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts",
+            "Geography",
+            "Geography -- Textbooks"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1926
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cografija [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-221 no. 8"
+          ],
+          "creatorLiteral": [
+            "Räshad, Gafyr."
+          ],
+          "createdString": [
+            "1926"
+          ],
+          "dateStartYear": [
+            1926
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-221 no. 8"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004947"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406058"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204937"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636082403668,
+          "publicationStatement": [
+            "Baqï : Azärnäshr, 1926-"
+          ],
+          "identifier": [
+            "urn:bnum:10004947",
+            "urn:undefined:NNSZ00406058",
+            "urn:undefined:(WaOLN)nyp0204937"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1926"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts.",
+            "Geography -- Textbooks."
+          ],
+          "titleDisplay": [
+            "Cografija [microform] / Gafyr Räshad."
+          ],
+          "uri": "b10004947",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Baqï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Geografi︠i︡a."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10004947"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673499"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-221"
+                    ],
+                    "shelfMark_sort": "a*ZO-221 11 Azerbaijani monographs",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30081242",
+                    "shelfMark": [
+                      "*ZO-221 11 Azerbaijani monographs"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZO-221 11 Azerbaijani monographs"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673499"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "11 Azerbaijani monographs"
+                    ],
+                    "idBarcode": [
+                      "33433105673499"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005127",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of cover title: Zähmät mäqtäbläri uçun tädris vä pedagozhi qitablarï.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Cover colophon title in Russian: Nachalʹnyĭ kurs geografii.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 151.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts",
+            "Geography",
+            "Geography -- Textbooks"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1928
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cografija [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-216 no. 15"
+          ],
+          "creatorLiteral": [
+            "Ivanov, G."
+          ],
+          "createdString": [
+            "1928"
+          ],
+          "dateStartYear": [
+            1928
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-216 no. 15"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005127"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406243"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205116"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636082403606,
+          "publicationStatement": [
+            "Baqï : Azärnäshr, 1928-"
+          ],
+          "identifier": [
+            "urn:bnum:10005127",
+            "urn:undefined:NNSZ00406243",
+            "urn:undefined:(WaOLN)nyp0205116"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1928"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts.",
+            "Geography -- Textbooks."
+          ],
+          "titleDisplay": [
+            "Cografija [microform] / Ivanof ; çäviräni Äsädylla Äbdurrähim-zadä."
+          ],
+          "uri": "b10005127",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Baqï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Nachalʹnyĭ kurs geografii."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10005127"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005211",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Khaos.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 586.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1929
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Xaos [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-220 no. 9"
+          ],
+          "creatorLiteral": [
+            "Shirvanzade, 1858-1935."
+          ],
+          "createdString": [
+            "1929"
+          ],
+          "dateStartYear": [
+            1929
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-220 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406328"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205200"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636144501921,
+          "publicationStatement": [
+            "Bagï : Azärnäshr, 1929"
+          ],
+          "identifier": [
+            "urn:bnum:10005211",
+            "urn:undefined:NNSZ00406328",
+            "urn:undefined:(WaOLN)nyp0205200"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1929"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts."
+          ],
+          "titleDisplay": [
+            "Xaos [microform] / Shirvanzada ; ermeni dilinden ceviräni F. Ismixanov ; tärcimäsinin redaktory Säid Mirkasïmzada."
+          ],
+          "uri": "b10005211",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bagï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Khaos."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10005211"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105674059"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-220"
+                    ],
+                    "shelfMark_sort": "a*ZO-220 collection of 10 titles (monographs)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30087469",
+                    "shelfMark": [
+                      "*ZO-220 collection of 10 titles (monographs)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZO-220 collection of 10 titles (monographs)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105674059"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "collection of 10 titles (monographs)"
+                    ],
+                    "idBarcode": [
+                      "33433105674059"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005860",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Swahili.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Swahili language",
+            "Swahili language -- Texts"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:swa",
+              "label": "Swahili"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mfuatano wa muundo na kazi za vyombo vya Serikali ya mapinduzi ya Zanzibar."
+          ],
+          "shelfMark": [
+            "Sc Ser.-N .Z288"
+          ],
+          "creatorLiteral": [
+            "Zanzibar."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-N .Z288"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005860"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507074"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205850"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636116169694,
+          "publicationStatement": [
+            "[Zanzibar : s.n., 1980-    ]"
+          ],
+          "identifier": [
+            "urn:bnum:10005860",
+            "urn:undefined:NNSZ00507074",
+            "urn:undefined:(WaOLN)nyp0205850"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Swahili language -- Texts."
+          ],
+          "titleDisplay": [
+            "Mfuatano wa muundo na kazi za vyombo vya Serikali ya mapinduzi ya Zanzibar."
+          ],
+          "uri": "b10005860",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Zanzibar :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Kitabu cha 1-9."
+          ],
+          "dimensions": [
+            "13-31 cm."
+          ]
+        },
+        "sort": [
+          "b10005860"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942241",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-N .Z288 Kituba cha 1-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-N .Z288 Kituba cha 1-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030859007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-N .Z288"
+                    ],
+                    "enumerationChronology": [
+                      "Kituba cha 1-9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030859007"
+                    ],
+                    "idBarcode": [
+                      "33433030859007"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-N .Z288 Kituba cha 1-000009"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005862",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Editor: Gerald A. McWorter.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- Study and teaching",
+            "African Americans -- Study and teaching -- Congresses",
+            "Black people",
+            "Black people -- Study and teaching",
+            "Black people -- Study and teaching -- Congresses"
+          ],
+          "publisherLiteral": [
+            "Afro-American Studies and Research Program, University of Illinois,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Proceedings"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .N3674"
+          ],
+          "creatorLiteral": [
+            "National Council for Black Studies (U.S.). Conference (6th : 1982 : Chicago, Ill.)"
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "contributorLiteral": [
+            "McWorter, Gerald A."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .N3674"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005862"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507076"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205852"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1144093",
+              "shelfMark": [
+                "Sc Ser.-M .N3674"
+              ]
+            }
+          ],
+          "updatedAt": 1643270732538,
+          "publicationStatement": [
+            "Urbana, Ill. : Afro-American Studies and Research Program, University of Illinois, [1983?-]"
+          ],
+          "identifier": [
+            "urn:bnum:10005862",
+            "urn:undefined:NNSZ00507076",
+            "urn:undefined:(WaOLN)nyp0205852"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- Study and teaching -- Congresses.",
+            "Black people -- Study and teaching -- Congresses."
+          ],
+          "titleDisplay": [
+            "Proceedings / National Council for Black Studies, 6th annual national conference."
+          ],
+          "uri": "b10005862",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Urbana, Ill. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "no. 1. Race/class.--no. 2. Studies on Black children and their families.--no. 3. Philosophical perspectives in Black studies.--no. 4. Black liberation movement.--no. 5. Social science and the Black experience."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10005862"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447316",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .N3674: 6th. 1982 no. 3-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .N3674: 6th. 1982 no. 3-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072219805"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .N3674: 6th. 1982"
+                    ],
+                    "enumerationChronology": [
+                      "no. 3-5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072219805"
+                    ],
+                    "idBarcode": [
+                      "33433072219805"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .N3674: 6th. 1982 no. 000003-5"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746590",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .N3674: 6th. 1982 no. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .N3674: 6th. 1982 no. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072219797"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .N3674: 6th. 1982"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072219797"
+                    ],
+                    "idBarcode": [
+                      "33433072219797"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .N3674: 6th. 1982 no. 000001-2"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005870",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "71 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"D'après le livre et le montage audiovisual 'L'Evolution de l'amour' por D. Sonet, légèrement adapté avec l'aimable autorisation de l'auteur.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sex instruction",
+            "Sex instruction -- Haiti",
+            "Sonet, D"
+          ],
+          "publisherLiteral": [
+            "Action familiale d'Haïti,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A quel age peut-on aimer? : pour une éducation à l'amour responsable"
+          ],
+          "shelfMark": [
+            "Sc D 84-595"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "Action familiale d'Haïti."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-595"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005870"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507084"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205860"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636069688379,
+          "publicationStatement": [
+            "Port-au-Prince : Action familiale d'Haïti, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10005870",
+            "urn:undefined:NNSZ00507084",
+            "urn:undefined:(WaOLN)nyp0205860"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sex instruction -- Haiti.",
+            "Sonet, D."
+          ],
+          "titleDisplay": [
+            "A quel age peut-on aimer? : pour une éducation à l'amour responsable / Action familiale d'Haïti."
+          ],
+          "uri": "b10005870",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Port-au-Prince :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10005870"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900461",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-595"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-595",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036649329"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-595"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036649329"
+                    ],
+                    "idBarcode": [
+                      "33433036649329"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000595"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005876",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxvii, 751 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of title: Unesco International Scientific Committee for the Drafting of a General History of Africa.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 692-733.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa",
+            "Africa -- History",
+            "Africa -- History -- To 1884"
+          ],
+          "publisherLiteral": [
+            "Heinemann ; University of California Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Africa from the twelfth to the sixteenth century"
+          ],
+          "shelfMark": [
+            "Sc E 84-288"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "idLccn": [
+            "84256508 //r86"
+          ],
+          "seriesStatement": [
+            "General history of Africa ; 4"
+          ],
+          "contributorLiteral": [
+            "Niane, Djibril Tamsir.",
+            "Unesco. International Scientific Committee for the Drafting of a General History of Africa."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc E 84-288"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005876"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0435948105"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0520039157 (University of California Press)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84256508 //r86"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205866"
+            }
+          ],
+          "updatedAt": 1652323261637,
+          "publicationStatement": [
+            "London : Heinemann ; Berkeley, Calif. : University of California Press, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10005876",
+            "urn:isbn:0435948105",
+            "urn:isbn:0520039157 (University of California Press)",
+            "urn:lccn:84256508 //r86",
+            "urn:undefined:(WaOLN)nyp0205866"
+          ],
+          "idIsbn": [
+            "0435948105",
+            "0520039157 (University of California Press)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa -- History -- To 1884."
+          ],
+          "titleDisplay": [
+            "Africa from the twelfth to the sixteenth century / editor, D.T. Niane."
+          ],
+          "uri": "b10005876",
+          "lccClassification": [
+            "DT20 .G45 1981 vol. 4 DT25"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London : Berkeley, Calif."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0435948105",
+            "0520039157"
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10005876"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003888",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc E 84-288"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc E 84-288",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433021813997"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc E 84-288"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433021813997"
+                    ],
+                    "idBarcode": [
+                      "33433021813997"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc E 84-000288"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003889",
+                    "status": [
+                      {
+                        "id": "status:m",
+                        "label": "Missing"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:m||Missing"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "*R-BK 90-2407"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*R-BK 90-2407",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*R-BK 90-2407"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:-",
+                        "label": "No restrictions"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:-||No restrictions"
+                    ],
+                    "shelfMark_sort": "a*R-BK 90-002407"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005898",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Creole dialects, French",
+            "Creole dialects, French -- Haiti",
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers",
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers -- French"
+          ],
+          "publisherLiteral": [
+            "I.L.A. de Port-au-Prince,"
+          ],
+          "language": [
+            {
+              "id": "lang:crp",
+              "label": "Creoles and Pidgins (Other)"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Leson kreyòl pou etranje ki pale franse \\"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .M468"
+          ],
+          "creatorLiteral": [
+            "Mirville, Ernst."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Collection Coucoville",
+            "Siwolin; \\t.2"
+          ],
+          "contributorLiteral": [
+            "Institut de linguistique appliquée de Port-au-Prince."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .M468"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005898"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507113"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205888"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1144290",
+              "shelfMark": [
+                "Sc Ser.-M .M468"
+              ]
+            }
+          ],
+          "updatedAt": 1636113236627,
+          "publicationStatement": [
+            "Port-au-Prince : I.L.A. de Port-au-Prince, 1984-"
+          ],
+          "identifier": [
+            "urn:bnum:10005898",
+            "urn:undefined:NNSZ00507113",
+            "urn:undefined:(WaOLN)nyp0205888"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers -- French."
+          ],
+          "titleDisplay": [
+            "Leson kreyòl pou etranje ki pale franse \\ Ernst Mirville."
+          ],
+          "uri": "b10005898",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Port-au-Prince :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10005898"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900486",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .M468 t. 2, ptie 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .M468 t. 2, ptie 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017863220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .M468"
+                    ],
+                    "enumerationChronology": [
+                      "t. 2, ptie 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017863220"
+                    ],
+                    "idBarcode": [
+                      "33433017863220"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .M468 t. 2, ptie 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005902",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "76 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sacred songs, English",
+            "Sacred songs, English -- Caribbean Area",
+            "Sacred songs, English -- Caribbean Area -- Texts",
+            "Sacred songs, English -- Jamaica",
+            "Sacred songs, English -- Jamaica -- Texts"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Modern Jamaican-Caribbean religious folk music."
+          ],
+          "shelfMark": [
+            "Sc D 84-602"
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-602"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005902"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507117"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205892"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636116687148,
+          "publicationStatement": [
+            "[S.l. : s.n., 19--]"
+          ],
+          "identifier": [
+            "urn:bnum:10005902",
+            "urn:undefined:NNSZ00507117",
+            "urn:undefined:(WaOLN)nyp0205892"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sacred songs, English -- Caribbean Area -- Texts.",
+            "Sacred songs, English -- Jamaica -- Texts."
+          ],
+          "titleDisplay": [
+            "Modern Jamaican-Caribbean religious folk music."
+          ],
+          "uri": "b10005902",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10005902"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900490",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-602"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-602",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058825831"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-602"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058825831"
+                    ],
+                    "idBarcode": [
+                      "33433058825831"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000602"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005905",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "52 p. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tchiè dans tchiè : les angoisses du coeur : recueil de poèmes \\"
+          ],
+          "shelfMark": [
+            "Sc C 85-2"
+          ],
+          "creatorLiteral": [
+            "Passavant, Camille."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc C 85-2"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005905"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507120"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205895"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636132396392,
+          "publicationStatement": [
+            "[Fort-de-France? Martinique : s.n., 19--] 52"
+          ],
+          "identifier": [
+            "urn:bnum:10005905",
+            "urn:undefined:NNSZ00507120",
+            "urn:undefined:(WaOLN)nyp0205895"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Tchiè dans tchiè : les angoisses du coeur : recueil de poèmes \\ Camille Passavant."
+          ],
+          "uri": "b10005905",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Fort-de-France? Martinique :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 x 21 cm."
+          ]
+        },
+        "sort": [
+          "b10005905"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900493",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc C 85-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc C 85-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036604563"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc C 85-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036604563"
+                    ],
+                    "idBarcode": [
+                      "33433036604563"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc C 85-000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005907",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Discography: p. 115-122.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jazz",
+            "Jazz -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Producciones Don Pedro,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "En torno al jazz"
+          ],
+          "shelfMark": [
+            "Sc Ser.-L .V354"
+          ],
+          "creatorLiteral": [
+            "Vélez, Ana."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-L .V354"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005907"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507122"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205897"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636093384929,
+          "publicationStatement": [
+            "San Juan, P.R. : Producciones Don Pedro, 1978-"
+          ],
+          "identifier": [
+            "urn:bnum:10005907",
+            "urn:undefined:NNSZ00507122",
+            "urn:undefined:(WaOLN)nyp0205897"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jazz -- History and criticism."
+          ],
+          "titleDisplay": [
+            "En torno al jazz / Ana Vélez."
+          ],
+          "uri": "b10005907",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "San Juan, P.R. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1. Musica de nuestro siglo -- v. 2. Impacto social y trascendencia."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10005907"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900496",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V354 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V354 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017895651"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V354"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017895651"
+                    ],
+                    "idBarcode": [
+                      "33433017895651"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V354 v. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900495",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V354 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V354 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030890481"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V354"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030890481"
+                    ],
+                    "idBarcode": [
+                      "33433030890481"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V354 v. 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005910",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 99 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 99.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Universities and colleges",
+            "Universities and colleges -- Africa",
+            "Universities and colleges -- Zambia"
+          ],
+          "publisherLiteral": [
+            "Published on behalf of the Institute for African Studies, University of Zambia, by National Educational Co. of Zambia,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The African university : issues and perspectives : speeches"
+          ],
+          "shelfMark": [
+            "Sc D 84-502"
+          ],
+          "creatorLiteral": [
+            "Goma, L. K. H."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "idLccn": [
+            "84980558"
+          ],
+          "seriesStatement": [
+            "Zambian papers ; no. 14"
+          ],
+          "contributorLiteral": [
+            "Tembo, L. P.",
+            "University of Zambia. Institute for African Studies."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-502"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005910"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84980558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205900"
+            }
+          ],
+          "updatedAt": 1636133189056,
+          "publicationStatement": [
+            "Lusaka, Zambia : Published on behalf of the Institute for African Studies, University of Zambia, by National Educational Co. of Zambia, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10005910",
+            "urn:lccn:84980558",
+            "urn:undefined:(WaOLN)nyp0205900"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Universities and colleges -- Africa.",
+            "Universities and colleges -- Zambia."
+          ],
+          "titleDisplay": [
+            "The African university : issues and perspectives : speeches / by L.H.K. [i.e. L.K.H.] Goma ; selected and edited by L.P. Tembo."
+          ],
+          "uri": "b10005910",
+          "lccClassification": [
+            "DT963.A3 Z3 no. 14 LA1503"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Lusaka, Zambia :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10005910"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433021791029"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-502"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000502",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003896",
+                    "shelfMark": [
+                      "Sc D 84-502"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Sc D 84-502"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433021791029"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "idBarcode": [
+                      "33433021791029"
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003630815"
+                    ],
+                    "physicalLocation": [
+                      "JFK 86-224"
+                    ],
+                    "shelfMark_sort": "aJFK 86-224 v. 000014",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003897",
+                    "shelfMark": [
+                      "JFK 86-224 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFK 86-224 v. 14"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003630815"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "idBarcode": [
+                      "33433003630815"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 microfilm reels ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes biographical notes, scope and contents note and indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm of Mss.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Washington, Fredi, 1903-1994",
+            "African American actresses",
+            "African American actresses -- Correspondence",
+            "African American women journalists",
+            "African American women journalists -- Correspondence",
+            "African Americans in the performing arts",
+            "African American actors",
+            "African American journalists"
+          ],
+          "publisherLiteral": [
+            "Amistad Research Center"
+          ],
+          "description": [
+            "Contains approximately one hundred pieces of correspondence, news clippings containing reviews of productions in which Fredi Washington appeared, and Washington's columns for The People's voice. Other groups in the collection are theatre programs, scripts, photographs and documentation of honors conferred on Fredi Washington."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Fredi Washington papers, 1925-1979."
+          ],
+          "shelfMark": [
+            "Sc Micro R-4205"
+          ],
+          "creatorLiteral": [
+            "Washington, Fredi, 1903-1994."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "Amistad Research Center."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro R-4205"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006007"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11780064"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11780064"
+            }
+          ],
+          "idOclc": [
+            "11780064"
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1651087265505,
+          "publicationStatement": [
+            "New Orleans, La. : Amistad Research Center, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10006007",
+            "urn:oclc:11780064",
+            "urn:undefined:(OCoLC)11780064"
+          ],
+          "genreForm": [
+            "Personal correspondence."
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Washington, Fredi, 1903-1994.",
+            "African American actresses -- Correspondence.",
+            "African American women journalists -- Correspondence.",
+            "African Americans in the performing arts.",
+            "African American actors.",
+            "African American journalists."
+          ],
+          "titleDisplay": [
+            "Fredi Washington papers, 1925-1979."
+          ],
+          "uri": "b10006007",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "New Orleans, La."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 mm"
+          ]
+        },
+        "sort": [
+          "b10006007"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900582",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4205 r. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4205 r. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031242500"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4205"
+                    ],
+                    "enumerationChronology": [
+                      "r. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433031242500"
+                    ],
+                    "idBarcode": [
+                      "33433031242500"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-4205 r. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900581",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4205 r. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4205 r. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031242492"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4205"
+                    ],
+                    "enumerationChronology": [
+                      "r. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433031242492"
+                    ],
+                    "idBarcode": [
+                      "33433031242492"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-4205 r. 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tem language"
+          ],
+          "publisherLiteral": [
+            "Experiment in International Living,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tem"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .T425"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Peace Corps language handbook series"
+          ],
+          "contributorLiteral": [
+            "Der-Houssikian, Haig."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .T425"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206003"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636132578775,
+          "publicationStatement": [
+            "Brattleboro, vt. : Experiment in International Living, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10006011",
+            "urn:undefined:NNSZ00507231",
+            "urn:undefined:(WaOLN)nyp0206003"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tem language."
+          ],
+          "titleDisplay": [
+            "Tem / developed by the Experiment in International Living...for ACTION/Peace Corps."
+          ],
+          "uri": "b10006011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Brattleboro, vt. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Communication and culture handbook/by Haig Der-Houssikian.--"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006011"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23169346",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .T425"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .T425",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076233265"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .T425"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076233265"
+                    ],
+                    "idBarcode": [
+                      "33433076233265"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .T000425"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kabre language"
+          ],
+          "publisherLiteral": [
+            "Experiment in International Living,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kabiye"
+          ],
+          "shelfMark": [
+            "Sc F 84-135"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Peace Corps language handbook series"
+          ],
+          "contributorLiteral": [
+            "Experiment in International Living.",
+            "Jassor, Essogoye.",
+            "Sedlak, Philip Alan Stephen, 1939-"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc F 84-135"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507232"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206004"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108841395,
+          "publicationStatement": [
+            "Brattleboro, Vt. : Experiment in International Living, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10006012",
+            "urn:undefined:NNSZ00507232",
+            "urn:undefined:(WaOLN)nyp0206004"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kabre language."
+          ],
+          "titleDisplay": [
+            "Kabiye / developed by the Experiment in International Living...for ACTION/Peace Corps."
+          ],
+          "uri": "b10006012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Brattleboro, Vt. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Special skills handbook/compiled by Philip A.S. Sedlak; assisted by Essogoye Jassor.--"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006012"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900585",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 84-135"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 84-135",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036872368"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 84-135"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036872368"
+                    ],
+                    "idBarcode": [
+                      "33433036872368"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 84-000135"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Corrections to volume I\": v. 2, p. 69.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iota Phi Lambda"
+          ],
+          "publisherLiteral": [
+            "The Sorority,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1959
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A History of Iota Phi Lambda Sorority."
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .H592"
+          ],
+          "createdString": [
+            "1959"
+          ],
+          "contributorLiteral": [
+            "Greene, Ethel K.",
+            "Sims, Sarah B."
+          ],
+          "dateStartYear": [
+            1959
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .H592"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507238"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206010"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1142937",
+              "shelfMark": [
+                "Sc Ser.-M .H592"
+              ]
+            }
+          ],
+          "updatedAt": 1636069378411,
+          "publicationStatement": [
+            "Washington : The Sorority, 1959-"
+          ],
+          "identifier": [
+            "urn:bnum:10006018",
+            "urn:undefined:NNSZ00507238",
+            "urn:undefined:(WaOLN)nyp0206010"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1959"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iota Phi Lambda."
+          ],
+          "titleDisplay": [
+            "A History of Iota Phi Lambda Sorority."
+          ],
+          "uri": "b10006018",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Washington :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1929-1958/Ethel K. Greene.--1959-1969/Sarah B. Sims."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006018"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746595",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .H592 v. 1, 2 (1928-19, 1959-69)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .H592 v. 1, 2 (1928-19, 1959-69)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061038323"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .H592"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1, 2 (1928-19, 1959-69)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061038323"
+                    ],
+                    "idBarcode": [
+                      "33433061038323"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .H592 v. 000001, 2 (1928-19, 1959-69)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "79 p. : ill., maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa",
+            "Africa -- Portuguese",
+            "Cão, Diogo, active 15th century",
+            "Dias, Bartolomeu",
+            "Gama, Vasco da, 1469-1524",
+            "Portuguese",
+            "Portuguese -- India",
+            "Portuguese -- India -- History"
+          ],
+          "publisherLiteral": [
+            "Basler Afrika Bibliographien,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Die Portugiesenkreuze in Africa und Indien : eine umfassende Darstellung aller von den portugiesischen Entdeckern Diogo Cão, Bartolomeo Dias und Vasco da Gama errichteten Steinkreuze (Padrões), deren Geschichte und deren Nachbildungen"
+          ],
+          "shelfMark": [
+            "Sc D 84-477"
+          ],
+          "creatorLiteral": [
+            "Kalthammer, Wilhelm."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Beiträge zur Afrikakunde, 0171-1660; 5"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-477"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006034"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507257"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206027"
+            }
+          ],
+          "updatedAt": 1636088600902,
+          "publicationStatement": [
+            "Basel : Basler Afrika Bibliographien, 1978."
+          ],
+          "identifier": [
+            "urn:bnum:10006034",
+            "urn:undefined:NNSZ00507257",
+            "urn:undefined:(WaOLN)nyp0206027"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa -- Portuguese.",
+            "Cão, Diogo, active 15th century.",
+            "Dias, Bartolomeu.",
+            "Gama, Vasco da, 1469-1524.",
+            "Portuguese -- India -- History."
+          ],
+          "titleDisplay": [
+            "Die Portugiesenkreuze in Africa und Indien : eine umfassende Darstellung aller von den portugiesischen Entdeckern Diogo Cão, Bartolomeo Dias und Vasco da Gama errichteten Steinkreuze (Padrões), deren Geschichte und deren Nachbildungen / Wilhelm Kalthammer."
+          ],
+          "uri": "b10006034",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Basel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006034"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900606",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-477"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-477",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036649683"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-477"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036649683"
+                    ],
+                    "idBarcode": [
+                      "33433036649683"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000477"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "205 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa, Sub-Saharan",
+            "Africa, Sub-Saharan -- Relations",
+            "Africa, Sub-Saharan -- Relations -- Arab countries",
+            "Arab countries",
+            "Arab countries -- Relations",
+            "Arab countries -- Relations -- Africa, Sub-Saharan"
+          ],
+          "publisherLiteral": [
+            "Unesco,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Historical and socio-cultural relations between Black Africa and the Arab world from 1935 to the present : report and papers of the symposium organized by Unesco in Paris from 25 to 27 July 1979."
+          ],
+          "shelfMark": [
+            "Sc E 84-236"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "General history of Africa: studies and documents; 7"
+          ],
+          "contributorLiteral": [
+            "Unesco."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc E 84-236"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006043"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206036"
+            }
+          ],
+          "updatedAt": 1636103134727,
+          "publicationStatement": [
+            "Paris : Unesco, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10006043",
+            "urn:undefined:(WaOLN)nyp0206036"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa, Sub-Saharan -- Relations -- Arab countries.",
+            "Arab countries -- Relations -- Africa, Sub-Saharan."
+          ],
+          "titleDisplay": [
+            "Historical and socio-cultural relations between Black Africa and the Arab world from 1935 to the present : report and papers of the symposium organized by Unesco in Paris from 25 to 27 July 1979."
+          ],
+          "uri": "b10006043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10006043"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900614",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc E 84-236"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc E 84-236",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036807315"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc E 84-236"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036807315"
+                    ],
+                    "idBarcode": [
+                      "33433036807315"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc E 84-000236"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006159",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- Civil rights",
+            "Civil rights",
+            "Civil rights -- United States",
+            "Violence",
+            "Violence -- United States"
+          ],
+          "publisherLiteral": [
+            "American Foundation for Negro Affairs,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Law and disorder [microform] : a research position paper"
+          ],
+          "shelfMark": [
+            "Sc Micro R-4202, no. 16"
+          ],
+          "creatorLiteral": [
+            "American Foundation for Negro Affairs. Commission on Judiciary and Law. Subcommittee on National Goals."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro R-4202, no. 16"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006159"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507384"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206150"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636111916018,
+          "publicationStatement": [
+            "Philadelphia, Pa. : American Foundation for Negro Affairs, 1970-"
+          ],
+          "identifier": [
+            "urn:bnum:10006159",
+            "urn:undefined:NNSZ00507384",
+            "urn:undefined:(WaOLN)nyp0206150"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- Civil rights.",
+            "Civil rights -- United States.",
+            "Violence -- United States."
+          ],
+          "titleDisplay": [
+            "Law and disorder [microform] : a research position paper / [Commission on Judiciary and Law, Subcommittee on National Goals]."
+          ],
+          "uri": "b10006159",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Philadelphia, Pa. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 x 28 cm."
+          ]
+        },
+        "sort": [
+          "b10006159"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i24023455",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4202"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4202",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059035760"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4202"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059035760"
+                    ],
+                    "idBarcode": [
+                      "33433059035760"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-004202"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006344",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "11 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Black people",
+            "Black people -- Caribbean Area",
+            "Black people -- Caribbean Area -- Social conditions",
+            "Middle class",
+            "Middle class -- Caribbean Area"
+          ],
+          "publisherLiteral": [
+            "s.n."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1999"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The making of a middle class"
+          ],
+          "shelfMark": [
+            "Sc Micro F-10459"
+          ],
+          "creatorLiteral": [
+            "Franks, W. Stanley."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro F-10459"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006344"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507572"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206335"
+            }
+          ],
+          "dateEndYear": [
+            1999
+          ],
+          "updatedAt": 1657974959186,
+          "publicationStatement": [
+            "[S.l. : s.n., 19--]"
+          ],
+          "identifier": [
+            "urn:bnum:10006344",
+            "urn:undefined:NNSZ00507572",
+            "urn:undefined:(WaOLN)nyp0206335"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Black people -- Caribbean Area -- Social conditions.",
+            "Middle class -- Caribbean Area."
+          ],
+          "titleDisplay": [
+            "The making of a middle class [microform] / by W. S. Franks ; with a foreword by Lee Llewellyn Moore."
+          ],
+          "uri": "b10006344",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "sort": [
+          "b10006344"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540203",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:26",
+                        "label": "microfiche"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:26||microfiche"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff3",
+                        "label": "Schomburg Center - Research & Reference - Desk"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff3||Schomburg Center - Research & Reference - Desk"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro F-10459"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro F-10459",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058831748"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro F-10459"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058831748"
+                    ],
+                    "idBarcode": [
+                      "33433058831748"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro F-010459"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006540",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 issued without edition statement has imprint date 1972.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and indexes.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Germany",
+            "Germany -- History",
+            "Germany -- History -- Allied occupation, 1945-",
+            "World War, 1939-1945",
+            "World War, 1939-1945 -- Germany"
+          ],
+          "publisherLiteral": [
+            "Selbstverlag,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Was geschah nach 1945?"
+          ],
+          "shelfMark": [
+            "JFK 84-184"
+          ],
+          "creatorLiteral": [
+            "Roth, Heinz."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "seriesStatement": [
+            "Auf der Suche nach der Wahrheit / Heinz Roth ; Bd. 4-5",
+            "Roth, Heinz. Auf der Suche nach der Wahrheit ; \\Bd. 4-5."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 84-184"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006540"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507771"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206529"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636143161690,
+          "publicationStatement": [
+            "Odenhausen/Lumda : Selbstverlag, [197-?-"
+          ],
+          "identifier": [
+            "urn:bnum:10006540",
+            "urn:undefined:NNSZ00507771",
+            "urn:undefined:(WaOLN)nyp0206529"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Germany -- History -- Allied occupation, 1945-",
+            "World War, 1939-1945 -- Germany."
+          ],
+          "titleDisplay": [
+            "Was geschah nach 1945? / Heinz Roth."
+          ],
+          "uri": "b10006540",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Odenhausen/Lumda :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Was geschah nach neunzehnhundertfünfundvierzig."
+          ],
+          "tableOfContents": [
+            "T.1. Der Zusammenbruch -- T.2. Kriegsverbrecherprozesse u.a."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006540"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003841073"
+                    ],
+                    "physicalLocation": [
+                      "JFK 84-184"
+                    ],
+                    "shelfMark_sort": "aJFK 84-184 v. 000001-2",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003927",
+                    "shelfMark": [
+                      "JFK 84-184 v. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFK 84-184 v. 1-2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003841073"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-2"
+                    ],
+                    "idBarcode": [
+                      "33433003841073"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006622",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Caldas (Colombia : Department)",
+            "Caldas (Colombia : Department) -- History"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Biblioteca de Escritores Caldenses"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Historia del Gran Caldas"
+          ],
+          "shelfMark": [
+            "HDK 84-1693"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "creatorLiteral": [
+            "Ríos Tobón, Ricardo de los."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "HDK 84-1693"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006622"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG005000779-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507853"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206611"
+            }
+          ],
+          "idOclc": [
+            "NYPG005000779-B"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1676385946742,
+          "publicationStatement": [
+            "Manizales, Colombia : Biblioteca de Escritores Caldenses, 1933-"
+          ],
+          "identifier": [
+            "urn:bnum:10006622",
+            "urn:oclc:NYPG005000779-B",
+            "urn:undefined:NNSZ00507853",
+            "urn:undefined:(WaOLN)nyp0206611"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Caldas (Colombia : Department) -- History."
+          ],
+          "titleDisplay": [
+            "Historia del Gran Caldas / Ricardo de los Ríos Tobón."
+          ],
+          "uri": "b10006622",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Manizales, Colombia"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1. Origenes y colonización hasta 1850."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006622"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746647",
+                    "status": [
+                      {
+                        "id": "status:co",
+                        "label": "Loaned"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:co||Loaned"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "HDK 84-1693 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "HDK 84-1693 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433097665214"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "HDK 84-1693"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433097665214"
+                    ],
+                    "idBarcode": [
+                      "33433097665214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dueDate": [
+                      "2023-02-15"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aHDK 84-1693 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006645",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "a, 257 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Translation of: Algoritmy upravlen︠i︡a rabotami-manipul︠i︡atorami.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"JPRS 59717.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 245-252.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Photocopy.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Manipulators (Mechanism)",
+            "Robots, Industrial"
+          ],
+          "publisherLiteral": [
+            "Joint Publications Research Service,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1973"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Robot-manipulator control algorithms"
+          ],
+          "shelfMark": [
+            "JSF 83-552"
+          ],
+          "creatorLiteral": [
+            "Ignatʹev, M. B. (Mikhail Borisovich)"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "contributorLiteral": [
+            "Kulakov, F. M. (Feliks Mikhaĭlovich)",
+            "Pokrovskiĭ, A. M."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JSF 83-552"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006645"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206634"
+            }
+          ],
+          "uniformTitle": [
+            "Algoritmy upravleni︠i︠a rabotami-manipul︠i︠atorami. English"
+          ],
+          "dateEndYear": [
+            1973
+          ],
+          "updatedAt": 1636073144930,
+          "publicationStatement": [
+            "Arlington, Va. : Joint Publications Research Service, 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10006645",
+            "urn:undefined:(WaOLN)nyp0206634"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Manipulators (Mechanism)",
+            "Robots, Industrial."
+          ],
+          "titleDisplay": [
+            "Robot-manipulator control algorithms / by M.B. Ignatʹyev, F.M. Kulakov, A.M. Pokrovskiy."
+          ],
+          "uri": "b10006645",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Arlington, Va. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Algoritmy upravleni︠i︠a rabotami-manipul︠i︠atorami."
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10006645"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433037693748"
+                    ],
+                    "physicalLocation": [
+                      "JSF 83-552"
+                    ],
+                    "shelfMark_sort": "aJSF 83-000552",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i12540383",
+                    "shelfMark": [
+                      "JSF 83-552"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JSF 83-552"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433037693748"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433037693748"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006687",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., ports, ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Skiđuhreppur (Iceland)",
+            "Öxnadalshreppur (Iceland)"
+          ],
+          "publisherLiteral": [
+            "Bókaútgáfan Skjaldborg,"
+          ],
+          "language": [
+            {
+              "id": "lang:ice",
+              "label": "Icelandic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ritsafn"
+          ],
+          "shelfMark": [
+            "JFL 84-217"
+          ],
+          "creatorLiteral": [
+            "Eiður Guðmundsson, 1888-1984."
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 84-217"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006687"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507920"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206676"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127047675,
+          "publicationStatement": [
+            "Akureyri : Bókaútgáfan Skjaldborg, 1982-"
+          ],
+          "identifier": [
+            "urn:bnum:10006687",
+            "urn:undefined:NNSZ00507920",
+            "urn:undefined:(WaOLN)nyp0206676"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Skiđuhreppur (Iceland)",
+            "Öxnadalshreppur (Iceland)"
+          ],
+          "titleDisplay": [
+            "Ritsafn / Eidur Gudmundsson Púfnav;ollum."
+          ],
+          "uri": "b10006687",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Akureyri :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Mannfelliviun mikli -- 2. Búskaparsaga i Skriđuhreppi forna."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10006687"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069567"
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-217"
+                    ],
+                    "shelfMark_sort": "aJFL 84-217 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003946",
+                    "shelfMark": [
+                      "JFL 84-217 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFL 84-217 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069567"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433004069567"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069559"
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-217"
+                    ],
+                    "shelfMark_sort": "aJFL 84-217 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003945",
+                    "shelfMark": [
+                      "JFL 84-217 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFL 84-217 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069559"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433004069559"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006688",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iceland",
+            "Iceland -- Economic conditions",
+            "Iceland -- History",
+            "Iceland -- Social conditions"
+          ],
+          "publisherLiteral": [
+            "Mál og Menning,"
+          ],
+          "language": [
+            {
+              "id": "lang:ice",
+              "label": "Icelandic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ritsafn"
+          ],
+          "shelfMark": [
+            "JFL 84-216"
+          ],
+          "creatorLiteral": [
+            "Sverrir Kristjánsson, 1908-"
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 84-216"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006688"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507921"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206677"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127047675,
+          "publicationStatement": [
+            "Reykjavík : Mál og Menning, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10006688",
+            "urn:undefined:NNSZ00507921",
+            "urn:undefined:(WaOLN)nyp0206677"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iceland -- Economic conditions.",
+            "Iceland -- History.",
+            "Iceland -- Social conditions."
+          ],
+          "titleDisplay": [
+            "Ritsafn / Sverrir Kristjánsson."
+          ],
+          "uri": "b10006688",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Reykjavík :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10006688"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069542"
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-216"
+                    ],
+                    "shelfMark_sort": "aJFL 84-216 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003948",
+                    "shelfMark": [
+                      "JFL 84-216 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFL 84-216 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069542"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433004069542"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069534"
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-216"
+                    ],
+                    "shelfMark_sort": "aJFL 84-216 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003947",
+                    "shelfMark": [
+                      "JFL 84-216 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFL 84-216 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069534"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433004069534"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006699",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "483 p. : ill., ports ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 476-483.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dominican literature",
+            "Dominican literature -- Manuals, handbooks, etc",
+            "Latin American literature",
+            "Latin American literature -- Study and teaching",
+            "Latin American literature -- Study and teaching -- Handbooks, manuals, etc"
+          ],
+          "publisherLiteral": [
+            "s.n.],"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Manual de literatura dominicana y americana : para el 4to teórico del bachillerato tradicional de la educación media"
+          ],
+          "shelfMark": [
+            "JFF 84-820"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "contributorLiteral": [
+            "Gómez de Michel, Fiume."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 84-820"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006699"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507932"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206688"
+            }
+          ],
+          "updatedAt": 1636114816670,
+          "publicationStatement": [
+            "[Santo Domingo, R. D. : s.n.], 1984"
+          ],
+          "identifier": [
+            "urn:bnum:10006699",
+            "urn:undefined:NNSZ00507932",
+            "urn:undefined:(WaOLN)nyp0206688"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dominican literature -- Manuals, handbooks, etc.",
+            "Latin American literature -- Study and teaching -- Handbooks, manuals, etc."
+          ],
+          "titleDisplay": [
+            "Manual de literatura dominicana y americana : para el 4to teórico del bachillerato tradicional de la educación media / [compilación] Fiumé Gómez de Michel."
+          ],
+          "uri": "b10006699",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Santo Domingo, R. D. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10006699"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784848",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 84-820"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 84-820",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050352214"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 84-820"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050352214"
+                    ],
+                    "idBarcode": [
+                      "33433050352214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFF 84-000820"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006705",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. (some col.);"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vernacular architecture",
+            "Vernacular architecture -- Greece",
+            "Architecture, Domestic",
+            "Architecture, Domestic -- Greece"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ekdot. Oikos \"Melissa,\""
+          ],
+          "language": [
+            {
+              "id": "lang:gre",
+              "label": "Greek, Modern (1453- )"
+            }
+          ],
+          "numItemsTotal": [
+            7
+          ],
+          "createdYear": [
+            1982
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Hellēnikē paradosiakē architektonikē"
+          ],
+          "shelfMark": [
+            "3-MQW+ 84-2551"
+          ],
+          "numItemVolumesParsed": [
+            7
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "idLccn": [
+            "83177376"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Philippidēs, Dēmētrēs."
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "3-MQW+ 84-2551"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006705"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83177376"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG005000864-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206694"
+            }
+          ],
+          "idOclc": [
+            "NYPG005000864-B"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1675271456381,
+          "publicationStatement": [
+            "Athēna : Ekdot. Oikos \"Melissa,\" c1982-"
+          ],
+          "identifier": [
+            "urn:bnum:10006705",
+            "urn:lccn:83177376",
+            "urn:oclc:NYPG005000864-B",
+            "urn:undefined:(WaOLN)nyp0206694"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vernacular architecture -- Greece.",
+            "Architecture, Domestic -- Greece."
+          ],
+          "titleDisplay": [
+            "Hellēnikē paradosiakē architektonikē / symvoulos kai syntonistēs tēs ekdosēs, Dēmētrēs Philippidēs ; [phōtographies, V. Voutsas]."
+          ],
+          "uri": "b10006705",
+          "lccClassification": [
+            "NA1091 .H44 1982"
+          ],
+          "numItems": [
+            7
+          ],
+          "numAvailable": [
+            7
+          ],
+          "placeOfPublication": [
+            "Athēna"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "t. 1. Anatoliko Aigaio. Sporades. Heptanēsa -- t. 2. Kyklades -- t. 3. Dōdekanēsa-Krētē -- t. 4. Peloponnēsos I -- t. 5 Peloponnesos II, Sterea Hellada -- t. 6. Thessalia-Ēpeiros -- t. 7. Makedonia I."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10006705"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 7,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746675",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160679"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160679"
+                    ],
+                    "idBarcode": [
+                      "33433105160679"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 7,
+                        "lte": 7
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         7-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000007"
+                  },
+                  "sort": [
+                    "         7-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746674",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160661"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160661"
+                    ],
+                    "idBarcode": [
+                      "33433105160661"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 6,
+                        "lte": 6
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         6-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000006"
+                  },
+                  "sort": [
+                    "         6-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746673",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160653"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160653"
+                    ],
+                    "idBarcode": [
+                      "33433105160653"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 5
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000005"
+                  },
+                  "sort": [
+                    "         5-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746672",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160646"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160646"
+                    ],
+                    "idBarcode": [
+                      "33433105160646"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 4,
+                        "lte": 4
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         4-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000004"
+                  },
+                  "sort": [
+                    "         4-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746671",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160638"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160638"
+                    ],
+                    "idBarcode": [
+                      "33433105160638"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 3,
+                        "lte": 3
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         3-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000003"
+                  },
+                  "sort": [
+                    "         3-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746670",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160620"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160620"
+                    ],
+                    "idBarcode": [
+                      "33433105160620"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000002"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746669",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160612"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160612"
+                    ],
+                    "idBarcode": [
+                      "33433105160612"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006715",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. (some ed.);"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on spine: 2222.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Austria",
+            "Austria -- Relations",
+            "Austria -- Relations -- United States",
+            "United States",
+            "United States -- Relations",
+            "United States -- Relations -- Austria"
+          ],
+          "publisherLiteral": [
+            "The author,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Quadruple 2"
+          ],
+          "shelfMark": [
+            "ICM (Austria) 85-584"
+          ],
+          "creatorLiteral": [
+            "Humes, John P."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "ICM (Austria) 85-584"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006715"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507948"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206704"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636124417162,
+          "publicationStatement": [
+            "[S.l. : The author, 197-]"
+          ],
+          "identifier": [
+            "urn:bnum:10006715",
+            "urn:undefined:NNSZ00507948",
+            "urn:undefined:(WaOLN)nyp0206704"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Austria -- Relations -- United States.",
+            "United States -- Relations -- Austria."
+          ],
+          "titleDisplay": [
+            "Quadruple 2 / by John P. Humes."
+          ],
+          "uri": "b10006715",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "2222.",
+            "Quadruple two."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006715"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746681",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "ICM (Austria) 85-584 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "ICM (Austria) 85-584 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433090390752"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "ICM (Austria) 85-584"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433090390752"
+                    ],
+                    "idBarcode": [
+                      "33433090390752"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aICM (Austria) 85-584 v. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006720",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[24] p. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Issued in portfolio.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Delius, Frederick, 1862-1934"
+          ],
+          "publisherLiteral": [
+            "The Trust,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Delius, 1862-1934"
+          ],
+          "shelfMark": [
+            "JMF 84-424"
+          ],
+          "creatorLiteral": [
+            "Delius Trust."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 84-424"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006720"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507953"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0000020"
+            }
+          ],
+          "updatedAt": 1636086826287,
+          "publicationStatement": [
+            "London : The Trust, [1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10006720",
+            "urn:undefined:NNSZ00507953",
+            "urn:undefined:(WaOLN)nyp0000020"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Delius, Frederick, 1862-1934."
+          ],
+          "titleDisplay": [
+            "Delius, 1862-1934 / compiled by the Delius Trust to mark the 50th anniversary of his death."
+          ],
+          "uri": "b10006720",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "A short biography -- A select bibliography -- A select discography -- List of works -- The collected edition. -- Calendar of performances and events, 1984."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10006720"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032723599"
+                    ],
+                    "shelfMark_sort": "aJMF 84-000424",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10942253",
+                    "shelfMark": [
+                      "JMF 84-424"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032723599"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433032723599"
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-c239af7554297bafb75d7c8ef1e0bca5.json
+++ b/test/fixtures/query-c239af7554297bafb75d7c8ef1e0bca5.json
@@ -1,0 +1,218 @@
+{
+  "took": 476,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 109.62506,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b12709113",
+        "_score": 109.62506,
+        "_source": {
+          "extent": [
+            "iv, 350 p. : ill., port. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Washington County (Neb.)",
+            "Washington County (Neb.) -- History"
+          ],
+          "publisherLiteral": [
+            "Magic city printing co.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1937
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A history of Washington county, Nebraska"
+          ],
+          "shelfMark": [
+            "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+          ],
+          "creatorLiteral": [
+            "Shrader, Forrest B."
+          ],
+          "createdString": [
+            "1937"
+          ],
+          "dateStartYear": [
+            1937
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12709113"
+            }
+          ],
+          "updatedAt": 1636332069027,
+          "publicationStatement": [
+            "[Omaha, : Magic city printing co., 1937]"
+          ],
+          "identifier": [
+            "urn:bnum:12709113"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1937"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Washington County (Neb.) -- History."
+          ],
+          "titleDisplay": [
+            "A history of Washington county, Nebraska / by Forrest B. Shrader."
+          ],
+          "uri": "b12709113",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Omaha, :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16202472",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099509238"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "IWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099509238"
+                    ],
+                    "idBarcode": [
+                      "33433099509238"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aIWD (Washington co.) (Shrader, F. B. History of Washington county, Nebraska)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-c43865d8fe1e1e7bea4e1ee96004c947.json
+++ b/test/fixtures/query-c43865d8fe1e1e7bea4e1ee96004c947.json
@@ -1,0 +1,14078 @@
+{
+  "took": 583,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 18415692,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Stauffenburg"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Gmelin, Hermann, 1900-1958.",
+            "Baum, Richard.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGNYPG-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "idOclc": [
+            "NYPGNYPG-B"
+          ],
+          "updatedAt": 1678937667178,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:oclc:NYPGNYPG-B",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen"
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "3923721544"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000003",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. : col. ill. maps ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrides (Scotland)",
+            "Hebrides (Scotland) -- Pictorial works"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Constable"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1989
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Scottish islands"
+          ],
+          "shelfMark": [
+            "JFF 89-526"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Waite, Charlie."
+          ],
+          "createdString": [
+            "1989"
+          ],
+          "idLccn": [
+            "gb 89012970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1989
+          ],
+          "donor": [
+            "Gift of the Drue Heinz Book Fund for English Literature"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 89-526"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000003"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0094675708 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "gb 89012970"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGUKBPGP8917-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200002"
+            }
+          ],
+          "idOclc": [
+            "NYPGUKBPGP8917-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Constable, 1989."
+          ],
+          "identifier": [
+            "urn:bnum:10000003",
+            "urn:isbn:0094675708 :",
+            "urn:lccn:gb 89012970",
+            "urn:oclc:NYPGUKBPGP8917-B",
+            "urn:undefined:(WaOLN)nyp0200002"
+          ],
+          "idIsbn": [
+            "0094675708 "
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1989"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrides (Scotland) -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Scottish islands / Charlie Waite."
+          ],
+          "uri": "b10000003",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0094675708"
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000003"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 89-526"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 89-526",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050409147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 89-526"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050409147"
+                    ],
+                    "idBarcode": [
+                      "33433050409147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFF 89-000526"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000004",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "23, 216 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1956.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mutaṟkuṟaḷ uvamai."
+          ],
+          "shelfMark": [
+            "*OLB 84-1934"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kothandapani Pillai, K., 1896-"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "74915265"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1247"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1934"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000004"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74915265"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200003"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tirunelvēli, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1965."
+          ],
+          "identifier": [
+            "urn:bnum:10000004",
+            "urn:lccn:74915265",
+            "urn:oclc:NYPG001000001-B",
+            "urn:undefined:NNSZ00100001",
+            "urn:undefined:(WaOLN)nyp0200003"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Mutaṟkuṟaḷ uvamai. Āciriyar Ku. Kōtaṇṭapāṇi Piḷḷai."
+          ],
+          "uri": "b10000004",
+          "lccClassification": [
+            "PL4758.9.T5 K6 1965"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirunelvēli"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000004"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783781",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1934",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1934"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301556"
+                    ],
+                    "idBarcode": [
+                      "33433061301556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001934"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000005",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (43 p.) + 1 part (12 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Acc. arr. for piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Soch. 22\"--Caption.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: 11049.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Concertos (Violin)",
+            "Concertos (Violin) -- Solo with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muzyka"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom"
+          ],
+          "shelfMark": [
+            "JMF 83-336"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Wieniawski, Henri, 1835-1880."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-336"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000005"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "11049. Muzyka"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100551"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200004"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-C"
+          ],
+          "uniformTitle": [
+            "Concertos, violin, orchestra, no. 2, op. 22, D minor; arranged"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Moskva : Muzyka, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000005",
+            "urn:oclc:NYPG001000001-C",
+            "urn:undefined:11049. Muzyka",
+            "urn:undefined:NNSZ00100551",
+            "urn:undefined:(WaOLN)nyp0200004"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Concertos (Violin) -- Solo with piano."
+          ],
+          "titleDisplay": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom / G. Ven︠i︡avskiĭ ; klavir."
+          ],
+          "uri": "b10000005",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Moskva"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Concertos, no. 2, op. 22"
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10000005"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942022",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-336"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-336",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032711909"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-336"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032711909"
+                    ],
+                    "idBarcode": [
+                      "33433032711909"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000336"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000006",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "227 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of The reconstruction of religious thought in Islam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām"
+          ],
+          "shelfMark": [
+            "*OGC 84-1984"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Iqbal, Muhammad, Sir, 1877-1938."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75962707"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Maḥmūd, ʻAbbās."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1984"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000006"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75962707"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100002"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200005"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "al-Qāhirah, Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000006",
+            "urn:lccn:75962707",
+            "urn:oclc:NYPG001000002-B",
+            "urn:undefined:NNSZ00100002",
+            "urn:undefined:(WaOLN)nyp0200005"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām, taʼlif Muhammad Iqbāl. Tarjamat ʻAbbās Maḥmūd. Rājaʻa muqaddimatahu wa-al-faṣl al-awwal minhu ʻAbd al-ʻAzīz al-Maraghī, wa-rājaʻa baqīyat al-Kitāb Mahdī ʻAllām."
+          ],
+          "uri": "b10000006",
+          "lccClassification": [
+            "BP161 .I712 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000006"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691665"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1984"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691665"
+                    ],
+                    "idBarcode": [
+                      "33433022691665"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001984"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 7:35.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: Z.8917.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Guitar music",
+            "Guitar",
+            "Guitar -- Studies and exercises"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Editio Musica"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Due studi per chitarra"
+          ],
+          "shelfMark": [
+            "JMG 83-276"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Patachich, Iván."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000007"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Z.8917. Editio Musica"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100552"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200006"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-C"
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Budapest : Editio Musica, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000007",
+            "urn:oclc:NYPG001000002-C",
+            "urn:undefined:Z.8917. Editio Musica",
+            "urn:undefined:NNSZ00100552",
+            "urn:undefined:(WaOLN)nyp0200006"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Guitar music.",
+            "Guitar -- Studies and exercises."
+          ],
+          "titleDisplay": [
+            "Due studi per chitarra / Patachich Iván."
+          ],
+          "uri": "b10000007",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Budapest"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies"
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000007"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942023",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-276"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-276",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883591"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-276"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883591"
+                    ],
+                    "idBarcode": [
+                      "33433032883591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000276"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000008",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "351 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Parimaḷam Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṇṇāviṉ ciṟukataikaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1986"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Annadurai, C. N., 1909-1969."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913998"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1986"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000008"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913998"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100003"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200007"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Parimaḷam Patippakam [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000008",
+            "urn:lccn:72913998",
+            "urn:oclc:NYPG001000003-B",
+            "urn:undefined:NNSZ00100003",
+            "urn:undefined:(WaOLN)nyp0200007"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Aṇṇāviṉ ciṟukataikaḷ. [Eḻutiyavar] Ci. Eṉ. Aṇṇāturai."
+          ],
+          "uri": "b10000008",
+          "lccClassification": [
+            "PL4758.9.A5 A84"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000008"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783782",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1986",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301689"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1986"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301689"
+                    ],
+                    "idBarcode": [
+                      "33433061301689"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001986"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000009",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "30 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Edition Peters Nr. 5489.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: E.P. 13028.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Edition Peters ; C.F. Peters"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Miniaturen II : 13 kleine Klavierstücke"
+          ],
+          "shelfMark": [
+            "JMG 83-278"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Golle, Jürgen, 1942-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-278"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000009"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters Nr. 5489 Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "E.P. 13028. Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200008"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-C"
+          ],
+          "uniformTitle": [
+            "Miniaturen, no. 2"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Leipzig : Edition Peters ; New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000009",
+            "urn:oclc:NYPG001000003-C",
+            "urn:undefined:Edition Peters Nr. 5489 Edition Peters",
+            "urn:undefined:E.P. 13028. Edition Peters",
+            "urn:undefined:NNSZ00100553",
+            "urn:undefined:(WaOLN)nyp0200008"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Miniaturen II : 13 kleine Klavierstücke / Jürgen Golle."
+          ],
+          "uri": "b10000009",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig : New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen, no. 2"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000009"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942024",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-278"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-278",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883617"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-278"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883617"
+                    ],
+                    "idBarcode": [
+                      "33433032883617"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000278"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000010",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "110 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cēkkiḻār, active 12th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaikkaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1938"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Irācamāṇikkaṉār, Mā., 1907-1967."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913466"
+          ],
+          "seriesStatement": [
+            "Corṇammāḷ corpoḻivu varicai, 6"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1938"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100004"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200009"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Aṇṇāmalainakar, Aṇṇāmalaip Palkalaikkaḻakam, 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000010",
+            "urn:lccn:72913466",
+            "urn:oclc:NYPG001000004-B",
+            "urn:undefined:NNSZ00100004",
+            "urn:undefined:(WaOLN)nyp0200009"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cēkkiḻār, active 12th century."
+          ],
+          "titleDisplay": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ. [Āṟṟiyavar] Mā. Irācamāṇikkaṉār."
+          ],
+          "uri": "b10000010",
+          "lccClassification": [
+            "PL4758.9.C385 Z8"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Aṇṇāmalainakar"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000010"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783783",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1938",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301598"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1938"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301598"
+                    ],
+                    "idBarcode": [
+                      "33433061301598"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001938"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "46 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)",
+            "Easter music (Organ)",
+            "Passion music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Boeijenga"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1982"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Passie en pasen : suite voor orgel, opus 50"
+          ],
+          "shelfMark": [
+            "JMG 83-279"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Berg, Jan J. van den."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-279"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000011"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200010"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-C"
+          ],
+          "dateEndYear": [
+            1982
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Sneek [Netherlands] : Boeijenga, [between 1976 and 1982]."
+          ],
+          "identifier": [
+            "urn:bnum:10000011",
+            "urn:oclc:NYPG001000004-C",
+            "urn:undefined:(WaOLN)nyp0200010"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)",
+            "Easter music (Organ)",
+            "Passion music."
+          ],
+          "titleDisplay": [
+            "Passie en pasen : suite voor orgel, opus 50 / door Jan J. van den Berg."
+          ],
+          "uri": "b10000011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Sneek [Netherlands]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Passie. I. Psalm 22. II. Leer mij O Heer. III. \"Mijn Verlosser hangt aan 't kruis.\" IV. \"O hoofd vol bloed en wonden.\" V. \"O kostbaar kruis.\" VI. \"Jezus, leven van mijn leven\" -- Pasen. VII. Toccata over \"Christus is opgestanden.\" VIII. Canon: \"Jesus unser Trost und Leben.\" IX. Trio: Ik zeg het allen dat Hij leeft.\" X. Trio: \"Staakt Uw rouwen Magdalene.\" XI. Postludium over \"Jesus leeft en wij met Hem\" (met \"Christus onze Heer verrees\" als tegenstem)."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000011"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942025",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-279"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-279",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883625"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-279"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883625"
+                    ],
+                    "idBarcode": [
+                      "33433032883625"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000279"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "223 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p.221.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Thaqāfah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi"
+          ],
+          "shelfMark": [
+            "*OFS 84-1997"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ḥāwī, Īlīyā Salīm."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 84-1997"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200011"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Thaqāfah, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000012",
+            "urn:oclc:NYPG001000005-B",
+            "urn:undefined:NNSZ00100005",
+            "urn:undefined:(WaOLN)nyp0200011"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "titleDisplay": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi / bi-qalam Īlīyā Ḥāwī."
+          ],
+          "uri": "b10000012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000012"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000003",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 84-1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514719"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 84-1997"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514719"
+                    ],
+                    "idBarcode": [
+                      "33433014514719"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFS 84-001997"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000013",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "32 p. of music : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Popular music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Arr. for piano with chord symbols; superlinear German words.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Popular music -- Germany (East)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Harth Musik Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "shelfMark": [
+            "JMF 83-366"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-366"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000013"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100555"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200012"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Leipzig : Harth Musik Verlag, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000013",
+            "urn:oclc:NYPG001000005-C",
+            "urn:undefined:NNSZ00100555",
+            "urn:undefined:(WaOLN)nyp0200012"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Popular music -- Germany (East)"
+          ],
+          "titleDisplay": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "uri": "b10000013",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Disko Treff eins."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000013"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942026",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-366"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-366",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032712204"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-366"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032712204"
+                    ],
+                    "idBarcode": [
+                      "33433032712204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000366"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000014",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "520 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on cover: Islamic unity or the Mutual approach among Muslim sects.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Panislamism",
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muʼassasat al-Aʻlamī lil-Maṭbūʻāt"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah"
+          ],
+          "shelfMark": [
+            "*OGC 84-1996"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Shīrāzī, ʻAbd al-Karīm Bī Āzār."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1996"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000014"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100006"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200013"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Muʼassasat al-Aʻlamī lil-Maṭbūʻāt, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000014",
+            "urn:oclc:NYPG001000006-B",
+            "urn:undefined:NNSZ00100006",
+            "urn:undefined:(WaOLN)nyp0200013"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Panislamism.",
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah / Jamʻ wa-tartīb ʻAbd al-Karīm Bī Āzār al-Shīrāzī."
+          ],
+          "uri": "b10000014",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Islamic unity."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000014"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691780"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1996"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691780"
+                    ],
+                    "idBarcode": [
+                      "33433022691780"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001996"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000015",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "25 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For organ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"A McAfee Music Publication.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: DM 220.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Belwin-Mills"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Suite no. 1 : 1977"
+          ],
+          "shelfMark": [
+            "JNG 83-102"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hampton, Calvin."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNG 83-102"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000015"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "DM 220. Belwin-Mills"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100556"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200014"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-C"
+          ],
+          "uniformTitle": [
+            "Suite, organ, no. 1"
+          ],
+          "updatedAt": 1678726416948,
+          "publicationStatement": [
+            "Melville, NY : Belwin-Mills, [1980?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000015",
+            "urn:oclc:NYPG001000006-C",
+            "urn:undefined:DM 220. Belwin-Mills",
+            "urn:undefined:NNSZ00100556",
+            "urn:undefined:(WaOLN)nyp0200014"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)"
+          ],
+          "titleDisplay": [
+            "Suite no. 1 : 1977 / Calvin Hampton."
+          ],
+          "uri": "b10000015",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Melville, NY"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Suite, no. 1"
+          ],
+          "tableOfContents": [
+            "Fanfares -- Antiphon -- Toccata."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000015"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000016",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "111 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuṟuntokai"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Manṅkaḷa Nūlakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nalla Kuṟuntokaiyil nāṉilam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1937"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Cellappaṉ, Cilampoli, 1929-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "74913402"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1937"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000016"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74913402"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200015"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Ceṉṉai, Manṅkaḷa Nūlakam, 1959 [i.e. 1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000016",
+            "urn:lccn:74913402",
+            "urn:oclc:NYPG001000007-B",
+            "urn:undefined:NNSZ00100007",
+            "urn:undefined:(WaOLN)nyp0200015"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuṟuntokai."
+          ],
+          "titleDisplay": [
+            "Nalla Kuṟuntokaiyil nāṉilam. [Eḻutiyavar] Cu. Cellappaṉ."
+          ],
+          "uri": "b10000016",
+          "lccClassification": [
+            "PL4758.9.K794 Z6 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000016"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783785",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1937",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301580"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1937"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301580"
+                    ],
+                    "idBarcode": [
+                      "33433061301580"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001937"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000017",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (17 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For baritone and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Words printed also as text.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 3:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Corbière, Tristan, 1845-1875",
+            "Corbière, Tristan, 1845-1875 -- Musical settings",
+            "Songs (Medium voice) with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lettre du Mexique : pour baryton et piano, 1942"
+          ],
+          "shelfMark": [
+            "JMG 83-395"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Escher, Rudolf."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Corbière, Tristan, 1845-1875."
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000017"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100557"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200016"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000017",
+            "urn:oclc:NYPG001000007-C",
+            "urn:undefined:NNSZ00100557",
+            "urn:undefined:(WaOLN)nyp0200016"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Corbière, Tristan, 1845-1875 -- Musical settings.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "Lettre du Mexique : pour baryton et piano, 1942 / Rudolf Escher ; poème de Tristan Corbière."
+          ],
+          "uri": "b10000017",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000017"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-395"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-395",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032735007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-395"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032735007"
+                    ],
+                    "idBarcode": [
+                      "33433032735007"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000395"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "68 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Lebanon"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Ṭalīʻah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā"
+          ],
+          "shelfMark": [
+            "*OFX 84-1995"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Bashshūr, Najlāʼ Naṣīr."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "78970449"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1995"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000018"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78970449"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100008"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200017"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Ṭalīʻah, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000018",
+            "urn:lccn:78970449",
+            "urn:oclc:NYPG001000008-B",
+            "urn:undefined:NNSZ00100008",
+            "urn:undefined:(WaOLN)nyp0200017"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Lebanon."
+          ],
+          "titleDisplay": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā / Najlāʼ Naṣīr Bashshūr."
+          ],
+          "uri": "b10000018",
+          "lccClassification": [
+            "HQ1728 .B37"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000018"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000004",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1995"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031718"
+                    ],
+                    "idBarcode": [
+                      "33433002031718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001995"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000019",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: M 18.487.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Waltzes (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zwölf Walzer und ein Epilog : für Klavier"
+          ],
+          "shelfMark": [
+            "JMG 83-111"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Benary, Peter."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-111"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000019"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Möseler M 18.487."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200018"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-C"
+          ],
+          "uniformTitle": [
+            "Walzer und ein Epilog"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000019",
+            "urn:oclc:NYPG001000008-C",
+            "urn:undefined:Möseler M 18.487.",
+            "urn:undefined:NNSZ00100558",
+            "urn:undefined:(WaOLN)nyp0200018"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Waltzes (Piano)"
+          ],
+          "titleDisplay": [
+            "Zwölf Walzer und ein Epilog : für Klavier / Peter Benary."
+          ],
+          "uri": "b10000019",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Walzer und ein Epilog",
+            "Walzer und ein Epilog."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000019"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942028",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-111"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-111",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-111"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845053"
+                    ],
+                    "idBarcode": [
+                      "33433032845053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000111"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000020",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 172, 320 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tolkāppiyar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaik Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tolkāppiyam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1936"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "creatorLiteral": [
+            "Veḷḷaivāraṇaṉ, Ka."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "74914844"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1936"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000020"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74914844"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200019"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "[Aṇṇāmalainakar] Aṇṇāmalaip Palkalaik Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000020",
+            "urn:lccn:74914844",
+            "urn:oclc:NYPG001000009-B",
+            "urn:undefined:NNSZ00100009",
+            "urn:undefined:(WaOLN)nyp0200019"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tolkāppiyar."
+          ],
+          "titleDisplay": [
+            "Tolkāppiyam. [Eḻutiyavar] Ka. Veḷḷaivāraṇaṉ."
+          ],
+          "uri": "b10000020",
+          "lccClassification": [
+            "PL4754.T583 V4 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Aṇṇāmalainakar]"
+          ],
+          "titleAlt": [
+            "Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Tolkāppiyam.--Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000020"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783786",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1936 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1936 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301572"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1936"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301572"
+                    ],
+                    "idBarcode": [
+                      "33433061301572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-1936 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000021",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (51 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: NM 384.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Verlag Neue Musik"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aurora : sinfonischer Prolog : Partitur"
+          ],
+          "shelfMark": [
+            "JMG 83-113"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Weitzendorf, Heinz."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-113"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000021"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NM 384. Verlag Neue Musik"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100559"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200020"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-C"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Berlin : Verlag Neue Musik, c1978."
+          ],
+          "identifier": [
+            "urn:bnum:10000021",
+            "urn:oclc:NYPG001000009-C",
+            "urn:undefined:NM 384. Verlag Neue Musik",
+            "urn:undefined:NNSZ00100559",
+            "urn:undefined:(WaOLN)nyp0200020"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "Aurora : sinfonischer Prolog : Partitur / Heinz Weitzendorf."
+          ],
+          "uri": "b10000021",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Berlin"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000021"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942029",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-113"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-113",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845079"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-113"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845079"
+                    ],
+                    "idBarcode": [
+                      "33433032845079"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000113"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000022",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "19, 493 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1942.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Grammar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1935"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Puttamittiraṉār, active 11th century."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "73913714"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1388"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Peruntēvaṉār, active 11th century.",
+            "Kōvintarāja Mutaliyār, Kā. Ra., 1874-1952."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1935"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73913714"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100010"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200021"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000022",
+            "urn:lccn:73913714",
+            "urn:oclc:NYPG001000010-B",
+            "urn:undefined:NNSZ00100010",
+            "urn:undefined:(WaOLN)nyp0200021"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ. Patippāciriyar Kā. Ra. Kōvintarāca Mutaliyār."
+          ],
+          "uri": "b10000022",
+          "lccClassification": [
+            "PL4754 .P8 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "titleAlt": [
+            "Viracōḻiyam."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000022"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783787",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1935",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301564"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1935"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301564"
+                    ],
+                    "idBarcode": [
+                      "33433061301564"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001935"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000023",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (18 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For band or wind ensemble.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Based on the composer's Veni creator spiritus.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: KC913.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Band music",
+            "Band music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Shawnee Press"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Musica sacra"
+          ],
+          "shelfMark": [
+            "JMF 83-38"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Zaninelli, Luigi."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-38"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000023"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "KC913 Shawnee Press"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100560"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200022"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-C"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Delaware Water Gap, Pa. : Shawnee Press, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000023",
+            "urn:oclc:NYPG001000010-C",
+            "urn:undefined:KC913 Shawnee Press",
+            "urn:undefined:NNSZ00100560",
+            "urn:undefined:(WaOLN)nyp0200022"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Band music -- Scores."
+          ],
+          "titleDisplay": [
+            "Musica sacra / Luigi Zaninelli."
+          ],
+          "uri": "b10000023",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Delaware Water Gap, Pa."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10000023"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942030",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-38"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-38",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709028"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-38"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709028"
+                    ],
+                    "idBarcode": [
+                      "33433032709028"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000038"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000024",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bahrain",
+            "Bahrain -- History",
+            "Bahrain -- History -- 20th century",
+            "Bahrain -- Economic conditions",
+            "Bahrain -- Social conditions"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār Ibn Khaldūn"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī"
+          ],
+          "shelfMark": [
+            "*OFK 84-1944"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rumayḥī, Muḥammad Ghānim."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "79971032"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFK 84-1944"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000024"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79971032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200023"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[Bayrūt] : Dār Ibn Khaldūn, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000024",
+            "urn:lccn:79971032",
+            "urn:oclc:NYPG001000011-B",
+            "urn:undefined:NNSZ00100011",
+            "urn:undefined:(WaOLN)nyp0200023"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bahrain -- History -- 20th century.",
+            "Bahrain -- Economic conditions.",
+            "Bahrain -- Social conditions."
+          ],
+          "titleDisplay": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī / Muḥammad al-Rumayḥī."
+          ],
+          "uri": "b10000024",
+          "lccClassification": [
+            "DS247.B28 R85"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000024"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000005",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK 84-1944",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005548676"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK 84-1944"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005548676"
+                    ],
+                    "idBarcode": [
+                      "33433005548676"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFK 84-001944"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000025",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei Sonatinen für Klavier"
+          ],
+          "shelfMark": [
+            "JMF 83-107"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stockmeier, Wolfgang."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 179"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-107"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000025"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100561"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200024"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-C"
+          ],
+          "uniformTitle": [
+            "Sonatinas, piano"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000025",
+            "urn:oclc:NYPG001000011-C",
+            "urn:undefined:NNSZ00100561",
+            "urn:undefined:(WaOLN)nyp0200024"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Drei Sonatinen für Klavier / Wolfgang Stockmeier."
+          ],
+          "uri": "b10000025",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatinas"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000025"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-107"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-107",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709697"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-107"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709697"
+                    ],
+                    "idBarcode": [
+                      "33433032709697"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000107"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000026",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "222 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 217-220.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Syria"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975"
+          ],
+          "shelfMark": [
+            "*OFX 84-1953"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Razzāz, Nabīlah."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76960987"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1953"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000026"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960987"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200025"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Dimashq : Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000026",
+            "urn:lccn:76960987",
+            "urn:oclc:NYPG001000012-B",
+            "urn:undefined:NNSZ00100012",
+            "urn:undefined:(WaOLN)nyp0200025"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Syria."
+          ],
+          "titleDisplay": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975 / Nabīlah al-Razzāz."
+          ],
+          "uri": "b10000026",
+          "lccClassification": [
+            "HQ402 .R39"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10000026"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000006",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1953",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031700"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1953"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031700"
+                    ],
+                    "idBarcode": [
+                      "33433002031700"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001953"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000027",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Violin)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei kleine Sonaten : für Violine solo"
+          ],
+          "shelfMark": [
+            "JMF 83-95"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Köhler, Friedemann."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 172"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-95"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000027"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100562"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200026"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-C"
+          ],
+          "uniformTitle": [
+            "Kleine Sonaten, violin"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler Verlag, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000027",
+            "urn:oclc:NYPG001000012-C",
+            "urn:undefined:NNSZ00100562",
+            "urn:undefined:(WaOLN)nyp0200026"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Violin)"
+          ],
+          "titleDisplay": [
+            "Drei kleine Sonaten : für Violine solo / Friedemann Köhler."
+          ],
+          "uri": "b10000027",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Kleine Sonaten"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000027"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-95"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-95",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-95"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709572"
+                    ],
+                    "idBarcode": [
+                      "33433032709572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000095"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000028",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "9, 3, 3, 324 p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Prastuta śodha-prabandha Rājasthāna Viśvavidyālaya, Jayapura kī Pī-eca.Ḍī-upāthi ke nimitta viśvavidyālaya anudāna āyoga kī risarca phailośipa ke antargata likhā gayā thā.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [321]-324.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sūryamalla Miśraṇa, 1815-1868"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Rājasthāna Sāhitya Akādamī (Saṅgama)"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vaṃśabhāskara : eka adhyayana"
+          ],
+          "shelfMark": [
+            "*OKTM 84-1945"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Khāna, Ālama Śāha, 1936-2003."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75903689"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000028"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75903689"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200027"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Udayapura : Rājasthāna Sāhitya Akādamī (Saṅgama), 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000028",
+            "urn:lccn:75903689",
+            "urn:oclc:NYPG001000013-B",
+            "urn:undefined:NNSZ00100013",
+            "urn:undefined:(WaOLN)nyp0200027"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sūryamalla Miśraṇa, 1815-1868."
+          ],
+          "titleDisplay": [
+            "Vaṃśabhāskara : eka adhyayana / lekhaka Ālamaśāha Khāna."
+          ],
+          "uri": "b10000028",
+          "lccClassification": [
+            "PK2708.9.S9 V334"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Udayapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000028"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-1945",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011094210"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-1945"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011094210"
+                    ],
+                    "idBarcode": [
+                      "33433011094210"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-001945"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000029",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Wilhelm Hansen edition no. 4372.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: 29589.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Organ music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "W. Hansen ; Distribution, Magnamusic-Baton"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cruor : for organ solo, 1977"
+          ],
+          "shelfMark": [
+            "JMF 83-93"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lorentzen, Bent."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82771131"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-93"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000029"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82771131"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Wilhelm Hansen edition no. 4372."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "29589."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100563"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200028"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Copenhagen ; New York : W. Hansen ; [s.l.] : Distribution, Magnamusic-Baton, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000029",
+            "urn:lccn:82771131",
+            "urn:oclc:NYPG001000013-C",
+            "urn:undefined:Wilhelm Hansen edition no. 4372.",
+            "urn:undefined:29589.",
+            "urn:undefined:NNSZ00100563",
+            "urn:undefined:(WaOLN)nyp0200028"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Organ music."
+          ],
+          "titleDisplay": [
+            "Cruor : for organ solo, 1977 / B. Lorentzen."
+          ],
+          "uri": "b10000029",
+          "lccClassification": [
+            "M11 .L"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Copenhagen ; New York : [s.l.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000029"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942034",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-93"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-93",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-93"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709556"
+                    ],
+                    "idBarcode": [
+                      "33433032709556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000093"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000030",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21, 264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Āryasamāja-śatābdī-saṃskaraṇam.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Authorship uncertain. Attributed variously to Āpiśali, Pānini and Śākaṭāyana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit: introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Suffixes and prefixes"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; prāptisthānam, Rāmalāla Kapūra Ṭrasṭa"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Uṇādi-koṣaḥ"
+          ],
+          "shelfMark": [
+            "*OKA 84-1931"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902275"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Āpiśali.",
+            "Pāṇini.",
+            "Śākatāyana.",
+            "Dayananda Sarasvati, Swami, 1824-1883.",
+            "Yudhiṣṭhira Mīmāṃsaka, 1909-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKA 84-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000030"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902275"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200029"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-B"
+          ],
+          "uniformTitle": [
+            "Uṇādisūtra."
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Karanāla : Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; Bahālagaḍha, Harayāṇa : prāptisthānam, Rāmalāla Kapūra Ṭrasṭa, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000030",
+            "urn:lccn:75902275",
+            "urn:oclc:NYPG001000014-B",
+            "urn:undefined:NNSZ00100014",
+            "urn:undefined:(WaOLN)nyp0200029"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Suffixes and prefixes."
+          ],
+          "titleDisplay": [
+            "Uṇādi-koṣaḥ / Dayānanda Sarasvatī Svāminā viracitayā Vaidika-laukika-koṣābhidhayā vyākhyayā sahitaḥ vividhābhi-ṣṭippaṇībhiḥ sūcībhiśca saṃyutaḥ ; sampādakaḥ Yudhiṣṭhiro Mīmāṃsakaḥ."
+          ],
+          "uri": "b10000030",
+          "lccClassification": [
+            "PK551 .U73"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Karanāla : Bahālagaḍha, Harayāṇa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000030"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000007",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKA 84-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012968222"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKA 84-1931"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012968222"
+                    ],
+                    "idBarcode": [
+                      "33433012968222"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKA 84-001931"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000031",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "W. Müller"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Neun Miniaturen : für Klavier : op. 52"
+          ],
+          "shelfMark": [
+            "JMG 83-17"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Petersen, Wilhelm, 1890-1957."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-17"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000031"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "W. Müller WM 1713 SM."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200030"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-C"
+          ],
+          "uniformTitle": [
+            "Miniaturen"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Heidelberg : W. Müller, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000031",
+            "urn:oclc:NYPG001000014-C",
+            "urn:undefined:W. Müller WM 1713 SM.",
+            "urn:undefined:NNSZ00100564",
+            "urn:undefined:(WaOLN)nyp0200030"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Neun Miniaturen : für Klavier : op. 52 / Wilhelm Petersen."
+          ],
+          "uri": "b10000031",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Heidelberg"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen",
+            "Miniaturen."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000031"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942035",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-17"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-17",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841631"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841631"
+                    ],
+                    "idBarcode": [
+                      "33433032841631"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000017"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000032",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14, 405, 7 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jahrom (Iran : Province)",
+            "Jahrom (Iran : Province) -- Biography",
+            "Khafr (Iran)",
+            "Khafr (Iran) -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kitābfurūshī-i Khayyām"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr"
+          ],
+          "shelfMark": [
+            "*OMP 84-2007"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ishrāq, Muḥammad Karīm."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2007"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200031"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tihrān : Kitābfurūshī-i Khayyām, 1351 [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000032",
+            "urn:oclc:NYPG001000015-B",
+            "urn:undefined:NNSZ00100015",
+            "urn:undefined:(WaOLN)nyp0200031"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jahrom (Iran : Province) -- Biography.",
+            "Khafr (Iran) -- Biography."
+          ],
+          "titleDisplay": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr / taʼlīf-i Muḥammad Karīm Ishrāq."
+          ],
+          "uri": "b10000032",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm"
+          ]
+        },
+        "sort": [
+          "b10000032"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2007",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173012"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2007"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173012"
+                    ],
+                    "idBarcode": [
+                      "33433013173012"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002007"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000033",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (20 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For voice and organ.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sacred songs (Medium voice) with organ",
+            "Psalms (Music)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Agápe"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Psalm settings"
+          ],
+          "shelfMark": [
+            "JMG 83-59"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Nelhybel, Vaclav."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-59"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000033"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100565"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200032"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Carol Stream, Ill. : Agápe, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000033",
+            "urn:oclc:NYPG001000015-C",
+            "urn:undefined:NNSZ00100565",
+            "urn:undefined:(WaOLN)nyp0200032"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sacred songs (Medium voice) with organ.",
+            "Psalms (Music)"
+          ],
+          "titleDisplay": [
+            "Psalm settings / Vaclav Nelhybel."
+          ],
+          "uri": "b10000033",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Carol Stream, Ill."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Hear me when I call -- Be not far from me -- Hear my voice -- The Lord is my rock."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000033"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942037",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-59",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-59"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942036",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-59",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842035"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-59"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842035"
+                    ],
+                    "idBarcode": [
+                      "33433032842035"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "366 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Brhatkathāślokasaṁgrahaḥ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Colophon: Iti Śrībhaṭṭabudhasvāminā krte ślokasaṁgrahe Brhatkathāyāṁ--",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Text in Sanskrit; apparatus in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Prithivi Prakashan"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brhatkathāślokasaṁgraha : a study"
+          ],
+          "shelfMark": [
+            "*OKR 84-2006"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Budhasvāmin."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903273"
+          ],
+          "seriesStatement": [
+            "Indian civilization series ; no. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Guṇāḍhya.",
+            "Agrawala, Vasudeva Sharana.",
+            "Agrawala, Prithvi Kumar."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKR 84-2006"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000034"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903273"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100016"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200033"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Varanasi : Prithivi Prakashan, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000034",
+            "urn:lccn:74903273",
+            "urn:oclc:NYPG001000016-B",
+            "urn:undefined:NNSZ00100016",
+            "urn:undefined:(WaOLN)nyp0200033"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Brhatkathāślokasaṁgraha : a study / by V.S. Agrawala ; with Sanskrit text, edited by P.K. Agrawala."
+          ],
+          "uri": "b10000034",
+          "lccClassification": [
+            "PK3794.B84 B7 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Varanasi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000034"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKR 84-2006",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011528696"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKR 84-2006"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011528696"
+                    ],
+                    "idBarcode": [
+                      "33433011528696"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKR 84-002006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000035",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "22 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Suite.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 12:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Serenade voor piano : 1980"
+          ],
+          "shelfMark": [
+            "JMG 83-6"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kasbergen, Marinus, 1936-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000035"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100566"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200034"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-C"
+          ],
+          "uniformTitle": [
+            "Serenade, piano"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000035",
+            "urn:oclc:NYPG001000016-C",
+            "urn:undefined:NNSZ00100566",
+            "urn:undefined:(WaOLN)nyp0200034"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Piano)"
+          ],
+          "titleDisplay": [
+            "Serenade voor piano : 1980 / Marinus Kasbergen."
+          ],
+          "uri": "b10000035",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Serenade"
+          ],
+          "tableOfContents": [
+            "Varianten -- Nocturne -- Toccata I -- Intermezzo -- Toccata II."
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000035"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942038",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841490"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-6"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841490"
+                    ],
+                    "idBarcode": [
+                      "33433032841490"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-6",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-6"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000036",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "viii, 38 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; prefatory matter in Sanskrit or Telegu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nārāyaṇatīrtha, 17th cent",
+            "Nārāyaṇatīrtha, 17th cent -- In literature"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic]"
+          ],
+          "shelfMark": [
+            "*OKB 84-1928"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75902755"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKB 84-1928"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000036"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902755"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200035"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[s.1. : s.n.], 1972"
+          ],
+          "identifier": [
+            "urn:bnum:10000036",
+            "urn:lccn:75902755",
+            "urn:oclc:NYPG001000017-B",
+            "urn:undefined:NNSZ00100017",
+            "urn:undefined:(WaOLN)nyp0200035"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nārāyaṇatīrtha, 17th cent -- In literature."
+          ],
+          "titleDisplay": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic] / praṇetā Garikapāṭi Lakṣmīkāntaḥ."
+          ],
+          "uri": "b10000036",
+          "lccClassification": [
+            "PK3799.L28 S68"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[s.1."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000036"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKB 84-1928"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKB 84-1928",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058548433"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKB 84-1928"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058548433"
+                    ],
+                    "idBarcode": [
+                      "33433058548433"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKB 84-001928"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000037",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13a p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 15:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Guitar)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Eight studies for guitar : in form of a suite : 1979"
+          ],
+          "shelfMark": [
+            "JMG 83-5"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hekster, Walter."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000037"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100567"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200036"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-C"
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000037",
+            "urn:oclc:NYPG001000017-C",
+            "urn:undefined:NNSZ00100567",
+            "urn:undefined:(WaOLN)nyp0200036"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Guitar)"
+          ],
+          "titleDisplay": [
+            "Eight studies for guitar : in form of a suite : 1979 / Walter Hekster."
+          ],
+          "uri": "b10000037",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies"
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000037"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841482"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-5"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841482"
+                    ],
+                    "idBarcode": [
+                      "33433032841482"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000005"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000038",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 160 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit, with verse and prose translations in Hindi; prefatory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit poetry",
+            "Sanskrit poetry -- Himachal Pradesh"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Himācala Kalā-Saṃskrti-Bhāṣā Akādamī"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana"
+          ],
+          "shelfMark": [
+            "*OKP 84-1932"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900772"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Prarthi, Lall Chand, 1916-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 84-1932"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000038"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900772"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200037"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Śimalā : Himācala Kalā-Saṃskrti-Bhāṣā Akādamī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000038",
+            "urn:lccn:76900772",
+            "urn:oclc:NYPG001000018-B",
+            "urn:undefined:NNSZ00100018",
+            "urn:undefined:(WaOLN)nyp0200037"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit poetry -- Himachal Pradesh."
+          ],
+          "titleDisplay": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana / mukhya sampādaka Lāla Canda Prārthī ; sampādaka maṇḍala, Manasā Rāma Śarmā 'Arūṇa'...[et al.]."
+          ],
+          "uri": "b10000038",
+          "lccClassification": [
+            "PK3800.H52 R7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Śimalā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000038"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783788",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 84-1932",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 84-1932"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153572"
+                    ],
+                    "idBarcode": [
+                      "33433058153572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKP 84-001932"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000039",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "49 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "C.F. Peters"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Five sonatas for pianoforte"
+          ],
+          "shelfMark": [
+            "JMG 83-66"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hässler, Johann Wilhelm, 1747-1822."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Oberdoerffer, Fritz."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000039"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters no. 66799. C.F. Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100568"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200038"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-C"
+          ],
+          "uniformTitle": [
+            "Sonatas, piano. Selections"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000039",
+            "urn:oclc:NYPG001000018-C",
+            "urn:undefined:Edition Peters no. 66799. C.F. Peters",
+            "urn:undefined:NNSZ00100568",
+            "urn:undefined:(WaOLN)nyp0200038"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Five sonatas for pianoforte / Johann Wilhelm Hässler ; edited by Fritz Oberdoerffer."
+          ],
+          "uri": "b10000039",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatas"
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000039"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842100"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-66"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842100"
+                    ],
+                    "idBarcode": [
+                      "33433032842100"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000066"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000040",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "146 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār."
+          ],
+          "shelfMark": [
+            "*OLB 84-1947"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Pulavar Arasu, 1900-"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "78913375"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 672"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1947"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000040"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78913375"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200039"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000040",
+            "urn:lccn:78913375",
+            "urn:oclc:NYPG001000019-B",
+            "urn:undefined:NNSZ00100019",
+            "urn:undefined:(WaOLN)nyp0200039"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953."
+          ],
+          "titleDisplay": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār. Āciriyar Pulavar Aracu."
+          ],
+          "uri": "b10000040",
+          "lccClassification": [
+            "PL4758.9.K223 Z83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000040"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783789",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1947",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301622"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1947"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301622"
+                    ],
+                    "idBarcode": [
+                      "33433061301622"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001947"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000041",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (23 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 5 clarinets.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Woodwind quintets (Clarinets (5))",
+            "Woodwind quintets (Clarinets (5)) -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Primavera"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Encounter"
+          ],
+          "shelfMark": [
+            "JMF 83-66"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Usher, Julia."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "81770739"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000041"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770739"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100569"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200040"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Primavera, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000041",
+            "urn:lccn:81770739",
+            "urn:oclc:NYPG001000019-C",
+            "urn:undefined:NNSZ00100569",
+            "urn:undefined:(WaOLN)nyp0200040"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Woodwind quintets (Clarinets (5)) -- Scores."
+          ],
+          "titleDisplay": [
+            "Encounter / Julia Usher."
+          ],
+          "uri": "b10000041",
+          "lccClassification": [
+            "M557.2.U8 E5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Greeting -- Circular argument -- Escape."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000041"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709291"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-66"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709291"
+                    ],
+                    "idBarcode": [
+                      "33433032709291"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000066"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000042",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 108 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit: pref. in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Advaita",
+            "Vedanta"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Devabhāṣā Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "dateEndString": [
+            "1972"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita."
+          ],
+          "shelfMark": [
+            "*OKN 84-1926"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902870"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Brahmashram, Śwami, 1915-"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 84-1926"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000042"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902870"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100020"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200041"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-B"
+          ],
+          "uniformTitle": [
+            "Mahābhārata. Sanatsugātīya."
+          ],
+          "dateEndYear": [
+            1972
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Prayāga, Devabhāṣā Prakāśana, Samvat 2028, i.e. 1971 or 2]"
+          ],
+          "identifier": [
+            "urn:bnum:10000042",
+            "urn:lccn:72902870",
+            "urn:oclc:NYPG001000020-B",
+            "urn:undefined:NNSZ00100020",
+            "urn:undefined:(WaOLN)nyp0200041"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Advaita.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita. Vyākhyātā Svāmī Brahmāśrama."
+          ],
+          "uri": "b10000042",
+          "lccClassification": [
+            "B132.V3 M264"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Prayāga"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000042"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783790",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 84-1926"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 84-1926",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618392"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKN 84-1926"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618392"
+                    ],
+                    "idBarcode": [
+                      "33433058618392"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 84-001926"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (28 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 2 flutes, 2 oboes, 2 clarinets, 2 horns, and 2 bassoons.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 5:00-6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: D.15 579.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Wind ensembles",
+            "Wind ensembles -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Verlag Doblinger"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Capriccio : für 10 Blasinstrumente"
+          ],
+          "shelfMark": [
+            "JMC 83-9"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Eröd, Iván."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Doblingers Studienpartituren ; Stp. 410"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMC 83-9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000043"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Stp. 410 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "D.15 579 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100570"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200042"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Wien : Verlag Doblinger, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000043",
+            "urn:oclc:NYPG001000020-C",
+            "urn:undefined:Stp. 410 Verlag Doblinger",
+            "urn:undefined:D.15 579 Verlag Doblinger",
+            "urn:undefined:NNSZ00100570",
+            "urn:undefined:(WaOLN)nyp0200042"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Wind ensembles -- Scores."
+          ],
+          "titleDisplay": [
+            "Capriccio : für 10 Blasinstrumente / Iván Eröd."
+          ],
+          "uri": "b10000043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wien"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000043"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMC 83-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMC 83-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004744128"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMC 83-9"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004744128"
+                    ],
+                    "idBarcode": [
+                      "33433004744128"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMC 83-000009"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000044",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[99] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Biographies of Khri-chen Byaṅ-chub-chos-ʼphel and Śel-dkar Bla-ma Saṅs-rgyas-bstan-ʼphel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from prints from blocks from Lhasa and Śel-dkar Dgaʼ-ldan-legs-bśad-gliṅ.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884",
+            "Lamas",
+            "Lamas -- Tibet",
+            "Lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ngawang Sopa"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2361"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rgal-dbaṅ Chos-rje Blo-bzaṅ-ʼphrin-las-rnam-rgyal, active 1840-1860."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77901316"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ngag-dbang-blo-bzang-rgya-mtsho, Dalai Lama V, 1617-1682."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2361"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000044"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77901316"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000021-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100021"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200043"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000021-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "New Delhi : Ngawang Sopa, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000044",
+            "urn:lccn:77901316",
+            "urn:oclc:NYPG001000021-B",
+            "urn:undefined:NNSZ00100021",
+            "urn:undefined:(WaOLN)nyp0200043"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838.",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884.",
+            "Lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel / by Dar-han Mkhan-sprul Blo-bzaṅ-ʼphrin-las-rnam-rgyal. Bkaʼ-gdams bstan-paʼi mdzod-ʼdzin Rje-btsun Bla-ma Saṅs-rgyas-bstan-ʼphel dpal-bzaṅ-poʼi rnam par thar pa dad ldan yid kyi dgaʼ ston : the biography of Saṅs-rgyas-bstan-ʼphel of Śel-dkar / by Śel-dkar Bkaʼ-ʼgyur Bla-ma Ṅag-dbaṅ-blo-bzaṅ-bstan-ʼdzin-tshul-khrims-rgyal-mtshan."
+          ],
+          "uri": "b10000044",
+          "lccClassification": [
+            "BQ942.Y367 R47 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000044"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000011",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2361",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080645"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080645"
+                    ],
+                    "idBarcode": [
+                      "33433015080645"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002361"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000045",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "12 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Violin music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sole selling agents, Or-Tav"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Thoughts & feelings : for violin solo"
+          ],
+          "shelfMark": [
+            "JMG 82-688"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stutschewsky, Joachim, 1891-1982."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "80770813"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 82-688"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000045"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80770813"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000021-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100571"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200044"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000021-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tel-Aviv : Sole selling agents, Or-Tav, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000045",
+            "urn:lccn:80770813",
+            "urn:oclc:NYPG001000021-C",
+            "urn:undefined:NNSZ00100571",
+            "urn:undefined:(WaOLN)nyp0200044"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Violin music."
+          ],
+          "titleDisplay": [
+            "Thoughts & feelings : for violin solo / Joachim Stutschewsky."
+          ],
+          "uri": "b10000045",
+          "lccClassification": [
+            "M42 .S"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tel-Aviv"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000045"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942043",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 82-688"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 82-688",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032707568"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 82-688"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032707568"
+                    ],
+                    "idBarcode": [
+                      "33433032707568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 82-000688"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000046",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[83] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Kye rdor rnam bśad.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from tracing and manuscripts from the library of Mkhan-po Rin-chen by Trayang and Jamyang Samten.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456",
+            "Tripiṭaka.",
+            "Tripiṭaka. -- Commentaries",
+            "Sa-skya-pa lamas",
+            "Sa-skya-pa lamas -- Tibet",
+            "Sa-skya-pa lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Trayang and Jamyang Samten"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2362"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Tshe-dbaṅ-rdo-rje-rig-ʼdzin, Prince of Sde-dge."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77900893"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sangs-rgyas-phun-tshogs, Ngor-chen, 1649-1705."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000046"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77900893"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000022-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100022"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200045"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000022-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "New Delhi : Trayang and Jamyang Samten, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000046",
+            "urn:lccn:77900893",
+            "urn:oclc:NYPG001000022-B",
+            "urn:undefined:NNSZ00100022",
+            "urn:undefined:(WaOLN)nyp0200045"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456.",
+            "Tripiṭaka. -- Commentaries.",
+            "Sa-skya-pa lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra / by Sde-dge Yab-chen Tshe-dbaṅ-rdo-rje-rig-ʼdzin alias Byams-pa-kun-dgaʼ-bstan-paʼi-rgyal-mtshan. Rgyal ba Rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas : the life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po / by Ṅor-chen Saṅs-rgyas-phun-tshogs."
+          ],
+          "uri": "b10000046",
+          "lccClassification": [
+            "BG974.0727 T75"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "titleAlt": [
+            "Rgyal ba rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas.",
+            "Detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra.",
+            "Life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000046"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080413"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080413"
+                    ],
+                    "idBarcode": [
+                      "33433015080413"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002362"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000047",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (30 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"This work was written between 14 March and 1 May, 1979\"--verso t.p.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 15 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vocalises (High voice) with instrumental ensemble",
+            "Vocalises (High voice) with instrumental ensemble -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello"
+          ],
+          "shelfMark": [
+            "JMG 83-79"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "81770634"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-79"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000047"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770634"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000022-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100572"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200046"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000022-C"
+          ],
+          "uniformTitle": [
+            "Vocalise, soprano, instrumental ensemble, op. 38"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London, England (Arlington Park House, London W4) : Redcliffe Edition, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000047",
+            "urn:lccn:81770634",
+            "urn:oclc:NYPG001000022-C",
+            "urn:undefined:NNSZ00100572",
+            "urn:undefined:(WaOLN)nyp0200046"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vocalises (High voice) with instrumental ensemble -- Scores."
+          ],
+          "titleDisplay": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello / Francis Routh."
+          ],
+          "uri": "b10000047",
+          "lccClassification": [
+            "M1613.3 .R8 op.38"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London, England (Arlington Park House, London W4)"
+          ],
+          "titleAlt": [
+            "Vocalise, op. 38"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "38 cm."
+          ]
+        },
+        "sort": [
+          "b10000047"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942044",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-79"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-79",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842233"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-79"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842233"
+                    ],
+                    "idBarcode": [
+                      "33433032842233"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000079"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000048",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[150] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a MS. preserved at Pha-lo-ldiṅ Monastery in Bhutan.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Buddhism",
+            "Buddhism -- Rituals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kunzang Topgey"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2382"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901012"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2382"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000048"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000023-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100023"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200047"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000023-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Thimphu : Kunzang Topgey, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000048",
+            "urn:lccn:76901012",
+            "urn:oclc:NYPG001000023-B",
+            "urn:undefined:NNSZ00100023",
+            "urn:undefined:(WaOLN)nyp0200047"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Buddhism -- Rituals."
+          ],
+          "titleDisplay": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "uri": "b10000048",
+          "lccClassification": [
+            "BQ7695 .B55"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Thimphu"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 38 cm."
+          ]
+        },
+        "sort": [
+          "b10000048"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2382",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080439"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080439"
+                    ],
+                    "idBarcode": [
+                      "33433015080439"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002382"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000049",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (105 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 25 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Symphony, op. 26 : full score"
+          ],
+          "shelfMark": [
+            "JMG 83-80"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "81770641"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-80"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000049"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770641"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000023-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100573"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200048"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000023-C"
+          ],
+          "uniformTitle": [
+            "Symphony, op. 26"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "London (Arlington Park House, London W4 4HD) : Redcliffe Edition, c1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000049",
+            "urn:lccn:81770641",
+            "urn:oclc:NYPG001000023-C",
+            "urn:undefined:NNSZ00100573",
+            "urn:undefined:(WaOLN)nyp0200048"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "Symphony, op. 26 : full score / Francis Routh."
+          ],
+          "uri": "b10000049",
+          "lccClassification": [
+            "M1001 .R8615 op.26"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London (Arlington Park House, London W4 4HD)"
+          ],
+          "titleAlt": [
+            "Symphony, op. 26"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000049"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942045",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-80"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-80",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842241"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-80"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842241"
+                    ],
+                    "idBarcode": [
+                      "33433032842241"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000080"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000050",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[188] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a print from the early 16th century western Tibetan blocks by Urgyan Dorje.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?",
+            "Bkaʼ-brgyud-pa lamas",
+            "Bkaʼ-brgyud-pa lamas -- Tibet",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography",
+            "Spiritual life",
+            "Spiritual life -- Buddhism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Urgyan Dorje"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2381"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901747"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2381"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000050"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901747"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000024-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100024"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200049"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000024-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "New Delhi : Urgyan Dorje, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000050",
+            "urn:lccn:76901747",
+            "urn:oclc:NYPG001000024-B",
+            "urn:undefined:NNSZ00100024",
+            "urn:undefined:(WaOLN)nyp0200049"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography.",
+            "Spiritual life -- Buddhism."
+          ],
+          "titleDisplay": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "uri": "b10000050",
+          "lccClassification": [
+            "BQ942.A187 A35 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000050"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2381",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080421"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080421"
+                    ],
+                    "idBarcode": [
+                      "33433015080421"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002381"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000051",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "score (64 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Samfundet til udgivelse af dansk musik"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972"
+          ],
+          "shelfMark": [
+            "JMG 83-75"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Christiansen, Henning."
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "idLccn": [
+            "78770955"
+          ],
+          "seriesStatement": [
+            "[Publikation] - Samfundet til udgivelse af dansk musik : 3. serie, nr. 264"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-75"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000051"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78770955"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000024-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100574"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200050"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000024-C"
+          ],
+          "uniformTitle": [
+            "Symphony, no. 2, op. 69c",
+            "Samfundet til udgivelse af dansk musik (Series) ; 3. ser., nr. 264."
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "København : Samfundet til udgivelse af dansk musik, 1977."
+          ],
+          "identifier": [
+            "urn:bnum:10000051",
+            "urn:lccn:78770955",
+            "urn:oclc:NYPG001000024-C",
+            "urn:undefined:NNSZ00100574",
+            "urn:undefined:(WaOLN)nyp0200050"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972 / Henning Christiansen."
+          ],
+          "uri": "b10000051",
+          "lccClassification": [
+            "M1001 .C533 op.69c"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "København"
+          ],
+          "titleAlt": [
+            "Symphony, no. 2, op. 69c",
+            "Den forsvundne."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "37 cm."
+          ]
+        },
+        "sort": [
+          "b10000051"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942046",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-75"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-75",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842191"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-75"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842191"
+                    ],
+                    "idBarcode": [
+                      "33433032842191"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000075"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-c59ca0803a5c622b04490d99bc1a50d4.json
+++ b/test/fixtures/query-c59ca0803a5c622b04490d99bc1a50d4.json
@@ -1,0 +1,15346 @@
+{
+  "took": 1174,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 9399288,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Stauffenburg"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Gmelin, Hermann, 1900-1958.",
+            "Baum, Richard.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGNYPG-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "idOclc": [
+            "NYPGNYPG-B"
+          ],
+          "updatedAt": 1678937667178,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:oclc:NYPGNYPG-B",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen"
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "3923721544"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000003",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. : col. ill. maps ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrides (Scotland)",
+            "Hebrides (Scotland) -- Pictorial works"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Constable"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1989
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Scottish islands"
+          ],
+          "shelfMark": [
+            "JFF 89-526"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Waite, Charlie."
+          ],
+          "createdString": [
+            "1989"
+          ],
+          "idLccn": [
+            "gb 89012970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1989
+          ],
+          "donor": [
+            "Gift of the Drue Heinz Book Fund for English Literature"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 89-526"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000003"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0094675708 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "gb 89012970"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGUKBPGP8917-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200002"
+            }
+          ],
+          "idOclc": [
+            "NYPGUKBPGP8917-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Constable, 1989."
+          ],
+          "identifier": [
+            "urn:bnum:10000003",
+            "urn:isbn:0094675708 :",
+            "urn:lccn:gb 89012970",
+            "urn:oclc:NYPGUKBPGP8917-B",
+            "urn:undefined:(WaOLN)nyp0200002"
+          ],
+          "idIsbn": [
+            "0094675708 "
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1989"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrides (Scotland) -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Scottish islands / Charlie Waite."
+          ],
+          "uri": "b10000003",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0094675708"
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000003"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 89-526"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 89-526",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050409147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 89-526"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050409147"
+                    ],
+                    "idBarcode": [
+                      "33433050409147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFF 89-000526"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000109",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxii, 321 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [305]-321).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Americans",
+            "Americans -- History",
+            "Americans -- History -- China",
+            "Americans -- History -- China -- 19th century",
+            "Public opinion",
+            "Public opinion -- United States",
+            "Public opinion -- United States -- History",
+            "Public opinion -- United States -- History -- 19th century",
+            "United States",
+            "United States -- Chinese influences",
+            "United States -- Intellectual life",
+            "United States -- Intellectual life -- 19th century",
+            "China",
+            "China -- History",
+            "China -- History -- 19th century",
+            "China -- Description and travel",
+            "China -- In popular culture",
+            "United States -- Relations",
+            "United States -- Relations -- China",
+            "China -- Relations",
+            "China -- Relations -- United States"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Columbia University Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            2008
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The romance of China : excursions to China in U.S. culture, 1776-1876"
+          ],
+          "shelfMark": [
+            "JFE 09-1362"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Haddad, John Rogers."
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "idLccn": [
+            "2008037637"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2008
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 09-1362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000109"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780231130943 (cloth : alk. paper)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0231130945 (cloth : alk. paper)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2008037637"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "184821618"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "184821618"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)184821618"
+            }
+          ],
+          "idOclc": [
+            "184821618"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "New York : Columbia University Press, c2008."
+          ],
+          "identifier": [
+            "urn:bnum:10000109",
+            "urn:isbn:9780231130943 (cloth : alk. paper)",
+            "urn:isbn:0231130945 (cloth : alk. paper)",
+            "urn:lccn:2008037637",
+            "urn:oclc:184821618",
+            "urn:undefined:(OCoLC)184821618"
+          ],
+          "idIsbn": [
+            "9780231130943 (cloth : alk. paper)",
+            "0231130945 (cloth : alk. paper)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Americans -- History -- China -- 19th century.",
+            "Public opinion -- United States -- History -- 19th century.",
+            "United States -- Chinese influences.",
+            "United States -- Intellectual life -- 19th century.",
+            "China -- History -- 19th century.",
+            "China -- Description and travel.",
+            "China -- In popular culture.",
+            "United States -- Relations -- China.",
+            "China -- Relations -- United States."
+          ],
+          "titleDisplay": [
+            "The romance of China : excursions to China in U.S. culture, 1776-1876 / John Rogers Haddad."
+          ],
+          "uri": "b10000109",
+          "lccClassification": [
+            "E183.8.C5 H175 2008"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Xanadu : an envoy at the throne of a monarch -- Romantic domesticity : a Chinese world invented at home -- Pursuing the China effect : a country described through marketing -- China in miniature : Nathan Dunn's Chinese museum -- A floating ethnology : the strange voyage of the Chinese junk Keying -- God's China : the Middle Kingdom of Samuel Wells Williams -- The cultural fruits of diplomacy : Chinese museum and panorama -- The ugly face of China : Bayard Taylor's travels in Asia -- Traditional China and Chinese Yankees : the Centennial Exposition of 1876."
+          ],
+          "idIsbn_clean": [
+            "9780231130943",
+            "0231130945"
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000109"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23117386",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 09-1362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 09-1362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084847221"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 09-1362"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084847221"
+                    ],
+                    "idBarcode": [
+                      "33433084847221"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFE 09-001362"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783799",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLF 82-5145"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLF 82-5145",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061318089"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLF 82-5145"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061318089"
+                    ],
+                    "idBarcode": [
+                      "33433061318089"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLF 82-005145"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000432",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "94 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Amīr Kabīr"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mānilī va khānah-ʼi Sarīvaylī : du manẓūmah"
+          ],
+          "shelfMark": [
+            "*OMO 84-1527"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Yūshīj, Nīmā."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMO 84-1527"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000432"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000386-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100386"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200431"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000386-B"
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1674870767447,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Amīr Kabīr, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10000432",
+            "urn:oclc:NYPG001000386-B",
+            "urn:undefined:NNSZ00100386",
+            "urn:undefined:(WaOLN)nyp0200431"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Mānilī va khānah-ʼi Sarīvaylī : du manẓūmah / az Nīmā yūshīj."
+          ],
+          "uri": "b10000432",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Khānah-ʼi Sarīvaylī."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000432"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000245",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMO 84-1527"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMO 84-1527",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001898497"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMO 84-1527"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001898497"
+                    ],
+                    "idBarcode": [
+                      "33433001898497"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMO 84-001527"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001333",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., folded maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Geomorphology",
+            "Geomorphology -- Libya"
+          ],
+          "publisherLiteral": [
+            "al-Jāmiʻah al-Lībīyah, Kullīyat al-Ādāb,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Abḥāth fī zhiyūmūrfūlūzhīyat al-arāḍī al-Lībīyah"
+          ],
+          "shelfMark": [
+            "*OFO 82-5116"
+          ],
+          "creatorLiteral": [
+            "Jawdah, Jawdah Ḥasanayn."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75960642"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFO 82-5116"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001333"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960642"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201348"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201331"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636070536203,
+          "publicationStatement": [
+            "[Binghāzī] : al-Jāmiʻah al-Lībīyah, Kullīyat al-Ādāb, 1973-"
+          ],
+          "identifier": [
+            "urn:bnum:10001333",
+            "urn:lccn:75960642",
+            "urn:undefined:NNSZ00201348",
+            "urn:undefined:(WaOLN)nyp0201331"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Geomorphology -- Libya."
+          ],
+          "titleDisplay": [
+            "Abḥāth fī zhiyūmūrfūlūzhīyat al-arāḍī al-Lībīyah / Jawdah Ḥasanayn Jawdah."
+          ],
+          "uri": "b10001333",
+          "lccClassification": [
+            "GB440.L5 J38"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Binghāzī] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24cm."
+          ]
+        },
+        "sort": [
+          "b10001333"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586197"
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5116 al-Juzʼān 1-2."
+                    ],
+                    "shelfMark_sort": "a*OFO 82-5116 al-Juzʼān 1-2. v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10000872",
+                    "shelfMark": [
+                      "*OFO 82-5116 al-Juzʼān 1-2. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFO 82-5116 al-Juzʼān 1-2. v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586197"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433005586197"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586189"
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5116 al-Juzʼān 1-2."
+                    ],
+                    "shelfMark_sort": "a*OFO 82-5116 al-Juzʼān 1-2. v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10000871",
+                    "shelfMark": [
+                      "*OFO 82-5116 al-Juzʼān 1-2. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFO 82-5116 al-Juzʼān 1-2. v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586189"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433005586189"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001377",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "71 p. : ill., music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. 69).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Silbermann, Gottfried, 1683-1753",
+            "Organ (Musical instrument)",
+            "Organ (Musical instrument) -- Instruction and study",
+            "Improvisation (Music)",
+            "Improvisation (Music) -- Instruction and study",
+            "Organ music",
+            "Organ music -- Interpretation (Phrasing, dynamics, etc.)",
+            "Organ builders",
+            "Organ builders -- Germany"
+          ],
+          "publisherLiteral": [
+            "Verlag Klaus-Jürgen Kamprad"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            2007
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Choralimprovisation auf Orgeln Gottfried Silbermanns"
+          ],
+          "shelfMark": [
+            "JMG 09-710"
+          ],
+          "creatorLiteral": [
+            "Wagler, Dietrich, 1940-"
+          ],
+          "createdString": [
+            "2007"
+          ],
+          "seriesStatement": [
+            "Freiberger Studien zur Orgel ; 10"
+          ],
+          "contributorLiteral": [
+            "Gottfried-Silbermann-Gesellschaft."
+          ],
+          "dateStartYear": [
+            2007
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 09-710"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001377"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783930550494 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3930550490 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "439765611"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)439765611"
+            }
+          ],
+          "idOclc": [
+            "439765611"
+          ],
+          "updatedAt": 1652323426362,
+          "publicationStatement": [
+            "[Altenburg] : Verlag Klaus-Jürgen Kamprad, c2007."
+          ],
+          "identifier": [
+            "urn:bnum:10001377",
+            "urn:isbn:9783930550494 (pbk.)",
+            "urn:isbn:3930550490 (pbk.)",
+            "urn:oclc:439765611",
+            "urn:undefined:(OCoLC)439765611"
+          ],
+          "idIsbn": [
+            "9783930550494 (pbk.)",
+            "3930550490 (pbk.)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2007"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Silbermann, Gottfried, 1683-1753.",
+            "Organ (Musical instrument) -- Instruction and study.",
+            "Improvisation (Music) -- Instruction and study.",
+            "Organ music -- Interpretation (Phrasing, dynamics, etc.)",
+            "Organ builders -- Germany."
+          ],
+          "titleDisplay": [
+            "Choralimprovisation auf Orgeln Gottfried Silbermanns / Dietrich Wagler ; [Hrsg.: Gottfried-Silbermann-Gesellschaft]."
+          ],
+          "uri": "b10001377",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Altenburg]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "9783930550494",
+            "3930550490"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10001377"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433089337251"
+                    ],
+                    "physicalLocation": [
+                      "JMG 09-710"
+                    ],
+                    "shelfMark_sort": "aJMG 09-000710",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i24299761",
+                    "shelfMark": [
+                      "JMG 09-710"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JMG 09-710"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433089337251"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433089337251"
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001657",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on p. [4] of cover: Village gazetteer.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Bar asās-i natāyij-i sarshumārī-i ʻumūmī-i Ābānʼmāh-i 1345.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "English and Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Gazetteers",
+            "Villages",
+            "Villages -- Iran",
+            "Villages -- Iran -- Statistics"
+          ],
+          "publisherLiteral": [
+            "Markaz-i Āmār-i Īrān,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Farhang-i ābādīhā-yi kishvar."
+          ],
+          "shelfMark": [
+            "Map Div. 84-146"
+          ],
+          "creatorLiteral": [
+            "Markaz-i Āmār-i Īrān."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "81464564"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Map Div. 84-146"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001657"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81464564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201692"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201655"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636095534719,
+          "publicationStatement": [
+            "Tihrān : Markaz-i Āmār-i Īrān, 1347- [1969-]"
+          ],
+          "identifier": [
+            "urn:bnum:10001657",
+            "urn:lccn:81464564",
+            "urn:undefined:NNSZ00201692",
+            "urn:undefined:(WaOLN)nyp0201655"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Gazetteers.",
+            "Villages -- Iran -- Statistics."
+          ],
+          "titleDisplay": [
+            "Farhang-i ābādīhā-yi kishvar."
+          ],
+          "uri": "b10001657",
+          "lccClassification": [
+            "DS253 .M37"
+          ],
+          "numItems": [
+            11
+          ],
+          "numAvailable": [
+            11
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Village gazetteer."
+          ],
+          "tableOfContents": [
+            "Jild-i 2. Ustān-i Āẕarbāyjān-i Gharbī--Jild-i 3-5. Ustān-i Khurāsān--Jild-1 6. Ustān-i Kurdistān--Jild-i 9. Farmāndārī-i Kull-i Luristān--Jild-i 10. Farmāndārīhā-yi Kull-i Banādir va Jazāʼir-i Khalīj-i Fārs va Daryā-yi Ummān--Jild-i 11. Ustān-i Māzandarān--Jild-i 14. Ustān-i Markazī--Jild-i 15. Ustān-i Gilān--Jild-i 17. Farmāndārī-i Kull-i Simnān."
+          ],
+          "dimensions": [
+            "42x54 cm."
+          ]
+        },
+        "sort": [
+          "b10001657"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 11,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030870"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000017",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784147",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 17"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 17"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030870"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 17"
+                    ],
+                    "idBarcode": [
+                      "33433057030870"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030862"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000015",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784146",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 15"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 15"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030862"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 15"
+                    ],
+                    "idBarcode": [
+                      "33433057030862"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030854"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000014",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784145",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 14"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030854"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "idBarcode": [
+                      "33433057030854"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030847"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000010",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784144",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 10"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030847"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10"
+                    ],
+                    "idBarcode": [
+                      "33433057030847"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030839"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000009",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784143",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 9"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030839"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9"
+                    ],
+                    "idBarcode": [
+                      "33433057030839"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030821"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000006",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784142",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 6"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030821"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "idBarcode": [
+                      "33433057030821"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030813"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000005",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784141",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 5"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030813"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "idBarcode": [
+                      "33433057030813"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030805"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784140",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030805"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433057030805"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030797"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784139",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030797"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433057030797"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030789"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784138",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030789"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433057030789"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030771"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784137",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030771"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433057030771"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001844",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: The Brahmasūtra Śāṅkarbhāṣya.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindu philosophy",
+            "Vedanta"
+          ],
+          "publisherLiteral": [
+            "Chaukhambā Vidyābhavana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brahmasūtraśāṅkarabhāṣyam. 'Brahmatatvavimarśinī' Hindīvyākhyāsahitam."
+          ],
+          "shelfMark": [
+            "*OKN 82-2276"
+          ],
+          "creatorLiteral": [
+            "Bādarāyaṇa."
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 65007118"
+          ],
+          "seriesStatement": [
+            "Vidyābhavara Saṃskrta granthamālā, 124"
+          ],
+          "contributorLiteral": [
+            "Sastri, Hanumanadas, Swami.",
+            "Śaṅkarācārya."
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 82-2276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001844"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 65007118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201882"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201842"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636079011965,
+          "publicationStatement": [
+            "Vārāṇasī, Chaukhambā Vidyābhavana [1964-"
+          ],
+          "identifier": [
+            "urn:bnum:10001844",
+            "urn:lccn:sa 65007118",
+            "urn:undefined:NNSZ00201882",
+            "urn:undefined:(WaOLN)nyp0201842"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindu philosophy.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Brahmasūtraśāṅkarabhāṣyam. 'Brahmatatvavimarśinī' Hindīvyākhyāsahitam. Vyākhyākāra [sic] Svāmī Hanumānadāsa Shaṭśāstrī. Bhūmikā-lekhaka Vīramaṇi Prasāda Upādhyāya."
+          ],
+          "uri": "b10001844",
+          "lccClassification": [
+            "B132.V3 B22"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasī,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Brahmasūtra Śaṅkarbhāṣya."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10001844"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058617816"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 82-2276"
+                    ],
+                    "shelfMark_sort": "a*OKN 82-002276",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784177",
+                    "shelfMark": [
+                      "*OKN 82-2276"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKN 82-2276"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058617816"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433058617816"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002118",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "204 p. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Wakālat Nāy,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1999"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Awlād bi-al-jumlah"
+          ],
+          "shelfMark": [
+            "*OFD 82-4488"
+          ],
+          "creatorLiteral": [
+            "Gilbreth, Frank B. (Frank Bunker), 1911-2001."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "contributorLiteral": [
+            "Carey, Ernestine Moller, 1908-",
+            "Ṭāhā, Aḥmad."
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFD 82-4488"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202160"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202114"
+            }
+          ],
+          "uniformTitle": [
+            "Cheaper by the dozen. Arabic"
+          ],
+          "dateEndYear": [
+            1999
+          ],
+          "updatedAt": 1636076222810,
+          "publicationStatement": [
+            "Dimashq : Wakālat Nāy, 19--."
+          ],
+          "identifier": [
+            "urn:bnum:10002118",
+            "urn:undefined:NNSZ00202160",
+            "urn:undefined:(WaOLN)nyp0202114"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Awlād bi-al-jumlah / taʼlīf Firānk Bi. Jīlbrith wa-Irnistin Jīlbrith Kārī ; tarjumat Aḥmad Ṭaha."
+          ],
+          "uri": "b10002118",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Cheaper by the dozen."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10002118"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001997497"
+                    ],
+                    "physicalLocation": [
+                      "*OFD 82-4488"
+                    ],
+                    "shelfMark_sort": "a*OFD 82-004488",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10001459",
+                    "shelfMark": [
+                      "*OFD 82-4488"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFD 82-4488"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001997497"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001997497"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002297",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Politics and government",
+            "Iran -- Politics and government -- 20th century"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Firdawsī,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Khāṭirāt-i Sayyid Àlī Muḥammad Dawlatābādī : līdir-i Ìtidālīyūn."
+          ],
+          "shelfMark": [
+            "*OMZ 84-1529"
+          ],
+          "creatorLiteral": [
+            "Dawlatābādī, Àlī Muḥammad."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-1529"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002297"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202345"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202293"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636109324448,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Firdawsī, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10002297",
+            "urn:undefined:NNSZ00202345",
+            "urn:undefined:(WaOLN)nyp0202293"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Politics and government -- 20th century."
+          ],
+          "titleDisplay": [
+            "Khāṭirāt-i Sayyid Àlī Muḥammad Dawlatābādī : līdir-i Ìtidālīyūn."
+          ],
+          "uri": "b10002297",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10002297"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539872"
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-1529"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-001529",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10942128",
+                    "shelfMark": [
+                      "*OMZ 84-1529"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMZ 84-1529"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539872"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433014539872"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10002303",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "280 p. : facsim. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Politics and government",
+            "Iran -- Politics and government -- 20th century",
+            "Political prisoners",
+            "Political prisoners -- Iran",
+            "Political prisoners -- Iran -- Biography"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Haftah,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Panjāh nafar... va sih nafar : asrār-i paydāyish, sāzmān va dastgīrī-i gurūh-i sīyāsī-i 53 nafar kih barā-yi avvalīn bār ifshā mīshavad"
+          ],
+          "shelfMark": [
+            "*OMZ 84-1538"
+          ],
+          "creatorLiteral": [
+            "Khāmahʼī, Anvar."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-1538"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10002303"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00202351"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0202299"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636121044994,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Haftah, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10002303",
+            "urn:undefined:NNSZ00202351",
+            "urn:undefined:(WaOLN)nyp0202299"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Politics and government -- 20th century.",
+            "Political prisoners -- Iran -- Biography."
+          ],
+          "titleDisplay": [
+            "Panjāh nafar... va sih nafar : asrār-i paydāyish, sāzmān va dastgīrī-i gurūh-i sīyāsī-i 53 nafar kih barā-yi avvalīn bār ifshā mīshavad / khāṭirāt-i Anvar Khāmah'ī."
+          ],
+          "uri": "b10002303",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10002303"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539880"
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-1538"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-001538",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10942130",
+                    "shelfMark": [
+                      "*OMZ 84-1538"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMZ 84-1538"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539880"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433014539880"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003134",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "397 p. : ill., port., facsim. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- History",
+            "Iran -- History -- Qajar dynasty, 1794-1925",
+            "Statesmen",
+            "Statesmen -- Iran",
+            "Statesmen -- Iran -- Biography"
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Amīr Kabīr,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Khāṭirāt-i Mumtaḥin al-Dawlah : zindigīnāmah-ʼi Mīrzā Mahdī Khān Mumtaḥin al-Dawlah Shaqāqī"
+          ],
+          "shelfMark": [
+            "*OMZ 84-1427"
+          ],
+          "creatorLiteral": [
+            "Mumtaḥin al-Dawlah Shaqāqī, Mahdī Khān."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "seriesStatement": [
+            "Majmūʻah-ʼi guzashtah-ʼi Īrān dar nivishtah-ʼi pīshīnīyān, 1"
+          ],
+          "contributorLiteral": [
+            "Khānshaqāqī, Ḥusaynqulī."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-1427"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003134"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303485"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203127"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636109324448,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Amīr Kabīr, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10003134",
+            "urn:undefined:NNSZ00303485",
+            "urn:undefined:(WaOLN)nyp0203127"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- History -- Qajar dynasty, 1794-1925.",
+            "Statesmen -- Iran -- Biography."
+          ],
+          "titleDisplay": [
+            "Khāṭirāt-i Mumtaḥin al-Dawlah : zindigīnāmah-ʼi Mīrzā Mahdī Khān Mumtaḥin al-Dawlah Shaqāqī / bi-kūshish-i Ḥusaynqulī Khānshaqāqī."
+          ],
+          "uri": "b10003134",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24cm."
+          ]
+        },
+        "sort": [
+          "b10003134"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539856"
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-1427"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-001427",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10942159",
+                    "shelfMark": [
+                      "*OMZ 84-1427"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMZ 84-1427"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539856"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433014539856"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003171",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "412 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Nashr-i Naw"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Āvāz-i kushtigān"
+          ],
+          "shelfMark": [
+            "*OMP 84-2030"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Baraheni, Reza, 1935-2022."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2030"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003171"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG003000626-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303522"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203164"
+            }
+          ],
+          "idOclc": [
+            "NYPG003000626-B"
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1675110792889,
+          "publicationStatement": [
+            "Tihrān : Nashr-i Naw, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10003171",
+            "urn:oclc:NYPG003000626-B",
+            "urn:undefined:NNSZ00303522",
+            "urn:undefined:(WaOLN)nyp0203164"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Āvāz-i kushtigān / Rizā Barāhinī."
+          ],
+          "uri": "b10003171",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm."
+          ]
+        },
+        "sort": [
+          "b10003171"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002196",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2030"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2030",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173038"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2030"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173038"
+                    ],
+                    "idBarcode": [
+                      "33433013173038"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002030"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003179",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "101 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Nashr-i Naw"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Chāh bih chāh"
+          ],
+          "shelfMark": [
+            "*OMP 84-2039"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Baraheni, Reza, 1935-2022."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2039"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003179"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG003000634-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303530"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203172"
+            }
+          ],
+          "idOclc": [
+            "NYPG003000634-B"
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1675110792235,
+          "publicationStatement": [
+            "Tihrān : Nashr-i Naw, 1362 [1983 or 1984]"
+          ],
+          "identifier": [
+            "urn:bnum:10003179",
+            "urn:oclc:NYPG003000634-B",
+            "urn:undefined:NNSZ00303530",
+            "urn:undefined:(WaOLN)nyp0203172"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Chāh bih chāh / Rizā Barāhinī."
+          ],
+          "uri": "b10003179",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10003179"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10002203",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2039"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2039",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2039"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173053"
+                    ],
+                    "idBarcode": [
+                      "33433013173053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002039"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003180",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "235 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam and state",
+            "Islam and state -- Iran",
+            "Khomeini, Ruhollah"
+          ],
+          "publisherLiteral": [
+            "Org. of Act. Constitutionalist Iranians,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "1989"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Qizāvat"
+          ],
+          "shelfMark": [
+            "*OMZ 84-965"
+          ],
+          "creatorLiteral": [
+            "ʻAbd al-Raḥmān."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMZ 84-965"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003180"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303531"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203173"
+            }
+          ],
+          "dateEndYear": [
+            1989
+          ],
+          "updatedAt": 1636124389229,
+          "publicationStatement": [
+            "Los Angeles : Org. of Act. Constitutionalist Iranians, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10003180",
+            "urn:undefined:NNSZ00303531",
+            "urn:undefined:(WaOLN)nyp0203173"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam and state -- Iran.",
+            "Khomeini, Ruhollah."
+          ],
+          "titleDisplay": [
+            "Qizāvat / ʻAbd al-Raḥmān..."
+          ],
+          "uri": "b10003180",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Los Angeles :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10003180"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014539666"
+                    ],
+                    "physicalLocation": [
+                      "*OMZ 84-965"
+                    ],
+                    "shelfMark_sort": "a*OMZ 84-000965",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10942161",
+                    "shelfMark": [
+                      "*OMZ 84-965"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OMZ 84-965"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014539666"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433014539666"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003410",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. facsims."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Imam Ṭaḥāwī's Disagreement of jurists (Ikhtilāf al-fuqahāʼ)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Introd. in Arabic and English ; text in Arabic.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: v. 1, p. [313]-314.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islamic law"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ikhtilāf al-fuqahāʼ,"
+          ],
+          "shelfMark": [
+            "*OGM 84-702"
+          ],
+          "creatorLiteral": [
+            "Ṭaḥāwī, Aḥmad ibn Muḥammad, 852?-933."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72930954"
+          ],
+          "seriesStatement": [
+            "Maṭbūʻāt Maʻhad al-Abḥāth al-Islāmīyāh. Publication no. 23"
+          ],
+          "contributorLiteral": [
+            "Maʻṣūmī, M. Ṣaghīr Ḥasan (Muḥammad Ṣaghīr Ḥasan)"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGM 84-702"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003410"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72930954"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303765"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203402"
+            }
+          ],
+          "uniformTitle": [
+            "Publication (Islamic Research Institute (Pakistan)) ; \\no.23."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636104747880,
+          "publicationStatement": [
+            "Islām Ābād [1971-"
+          ],
+          "identifier": [
+            "urn:bnum:10003410",
+            "urn:lccn:72930954",
+            "urn:undefined:NNSZ00303765",
+            "urn:undefined:(WaOLN)nyp0203402"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islamic law."
+          ],
+          "titleDisplay": [
+            "Ikhtilāf al-fuqahāʼ, lil-Imām Abī Jaʻfar Aḥmad ibn Muḥammad al-Ṭaḥāwī. Ḥaqqaqahu wa-ʻallaqa ʻalayhi Muḥammad Ṣaghīr Ḥasan al-Maʻṣūmī."
+          ],
+          "uri": "b10003410",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Islām Ābād"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003410"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001944960"
+                    ],
+                    "physicalLocation": [
+                      "*OGM 84-702"
+                    ],
+                    "shelfMark_sort": "a*OGM 84-000702",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002358",
+                    "shelfMark": [
+                      "*OGM 84-702"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OGM 84-702"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001944960"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001944960"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003414",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Skandamahāpurāṇam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added t.p. in English or Hindi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 1:2. Saṃskaraṇam; v. 2-: 1. Saṃskaraṇam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Manasukharāya Mora,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Skandamahāpurāṇam"
+          ],
+          "shelfMark": [
+            "*OKOK 84-641"
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "73902099"
+          ],
+          "seriesStatement": [
+            "Gurumaṇḍalagranthamālāyāḥ ; puṣpam 20"
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKOK 84-641"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003414"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73902099"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303769"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203406"
+            }
+          ],
+          "uniformTitle": [
+            "Puranas Skanda Purāṇa."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636124303127,
+          "publicationStatement": [
+            "Kalakattā : Manasukharāya Mora, 1960-"
+          ],
+          "identifier": [
+            "urn:bnum:10003414",
+            "urn:lccn:73902099",
+            "urn:undefined:NNSZ00303769",
+            "urn:undefined:(WaOLN)nyp0203406"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Skandamahāpurāṇam  / Śrāmanmaharṣikrṣṇadvaipāyanavyāsaviracitam."
+          ],
+          "uri": "b10003414",
+          "lccClassification": [
+            "PK3621 .S5 1960"
+          ],
+          "numItems": [
+            6
+          ],
+          "numAvailable": [
+            6
+          ],
+          "placeOfPublication": [
+            "Kalakattā :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Skanda-Purāṇam."
+          ],
+          "tableOfContents": [
+            "1. Māheśvarakhaṇḍātmakaḥ.--2. Vaiṣṇavakhaṇḍātmakaḥ.--3. Brahmakhandātmakaḥ.--4. Kāśīkhaṇḍātmakaḥ.--5. Avantīkhaṇḍātmakah. 2 pts."
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10003414"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 6,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221423"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000005 pt 2",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002364",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 5 pt 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 5 pt 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221423"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt 2"
+                    ],
+                    "idBarcode": [
+                      "33433013221423"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221415"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000005 pt 1",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002363",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 5 pt 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 5 pt 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221415"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt 1"
+                    ],
+                    "idBarcode": [
+                      "33433013221415"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221407"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002362",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221407"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433013221407"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221399"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002365",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221399"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433013221399"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221381"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002361",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221381"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433013221381"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221373"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002360",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221373"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433013221373"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003502",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Partly translations from German poetry (with German texts included).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally published in 1856, under title: Dziesmiņas latviešu valodai pārtulkotas; original t.p. included.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Liesma,"
+          ],
+          "language": [
+            {
+              "id": "lang:lav",
+              "label": "Latvian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dziesmiņas"
+          ],
+          "shelfMark": [
+            "*QYN 82-2046"
+          ],
+          "creatorLiteral": [
+            "Alunāns, Juris, 1832-1864."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "seriesStatement": [
+            "Literārā mantojuma mazā bibliotēka"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*QYN 82-2046"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003502"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303857"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203494"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636091475285,
+          "publicationStatement": [
+            "Riga : Liesma, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10003502",
+            "urn:undefined:NNSZ00303857",
+            "urn:undefined:(WaOLN)nyp0203494"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Dziesmiņas / Juris Alunāns."
+          ],
+          "uri": "b10003502",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Riga :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "17 cm."
+          ]
+        },
+        "sort": [
+          "b10003502"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013501782"
+                    ],
+                    "physicalLocation": [
+                      "*QYN 82-2046 Dala 1."
+                    ],
+                    "shelfMark_sort": "a*QYN 82-2046 Dala 1.",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002421",
+                    "shelfMark": [
+                      "*QYN 82-2046 Dala 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*QYN 82-2046 Dala 1."
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013501782"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013501782"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003671",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Egypt",
+            "Egypt -- Politics and government",
+            "Egypt -- Politics and government -- 640-1882"
+          ],
+          "publisherLiteral": [
+            "Maktabat al-Anjlū al-Miṣrīyah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nuẓum al-Fāṭimīyīn wa-rusūmuhum fī Miṣr. Institutions et cérémonial des Faṭimides en Égypte."
+          ],
+          "shelfMark": [
+            "*OFP 82-1931"
+          ],
+          "creatorLiteral": [
+            "Mājid, ʻAbd al-Munʻim."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "73960873"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFP 82-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003671"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73960873"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304029"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203663"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636119319155,
+          "publicationStatement": [
+            "al-Qāhirah, Maktabat al-Anjlū al-Miṣrīyah, 1973-"
+          ],
+          "identifier": [
+            "urn:bnum:10003671",
+            "urn:lccn:73960873",
+            "urn:undefined:NNSZ00304029",
+            "urn:undefined:(WaOLN)nyp0203663"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Egypt -- Politics and government -- 640-1882."
+          ],
+          "titleDisplay": [
+            "Nuẓum al-Fāṭimīyīn wa-rusūmuhum fī Miṣr. Institutions et cérémonial des Faṭimides en Égypte. Taʼlīf ʻAbd al-Munʻim Mājid."
+          ],
+          "uri": "b10003671",
+          "lccClassification": [
+            "JQ3824 .M34 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Institutions et cérémonial des Fatimides en Égypte."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003671"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001937121"
+                    ],
+                    "physicalLocation": [
+                      "*OFP 82-1931"
+                    ],
+                    "shelfMark_sort": "a*OFP 82-001931",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002566",
+                    "shelfMark": [
+                      "*OFP 82-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFP 82-1931"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001937121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001937121"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003719",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 2 & 4: pariṣkarta Puripanda.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Telugu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Telugu literature",
+            "Telugu literature -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Āndhrapradēś Sāhitya Akāḍami"
+          ],
+          "language": [
+            {
+              "id": "lang:tel",
+              "label": "Telugu"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sārasvata vyāsamulu; Telumgu kavitvapu tīru tennulu."
+          ],
+          "shelfMark": [
+            "*OLC 83-35"
+          ],
+          "creatorLiteral": [
+            "Subrahmanyam, G. V., 1935-"
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "71912553"
+          ],
+          "contributorLiteral": [
+            "Appalaswamy, Puripanda, 1904-",
+            "Āndhra Pradēśa Sāhitya Akāḍami."
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLC 83-35"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003719"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "71912553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304078"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203711"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636132209400,
+          "publicationStatement": [
+            "Haidrābādu, Āndhrapradēś Sāhitya Akāḍami [1969-"
+          ],
+          "identifier": [
+            "urn:bnum:10003719",
+            "urn:lccn:71912553",
+            "urn:undefined:NNSZ00304078",
+            "urn:undefined:(WaOLN)nyp0203711"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Telugu literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Sārasvata vyāsamulu; Telumgu kavitvapu tīru tennulu. Saṅkalanakarta Ji. Vi. Subrahmaṇyaṃ."
+          ],
+          "uri": "b10003719",
+          "lccClassification": [
+            "PL4780.05 S79"
+          ],
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            5
+          ],
+          "placeOfPublication": [
+            "Haidrābādu,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10003719"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197476"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000005",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002605",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 5"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197476"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "idBarcode": [
+                      "33433011197476"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197468"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002604",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197468"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433011197468"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197450"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002603",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197450"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433011197450"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197443"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002602",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197443"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433011197443"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197435"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002601",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197435"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433011197435"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003958",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "39, 18, 83, 3 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Version",
+              "label": "Reprint of the 1910 ? ed.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Logic",
+            "Logic -- Early works to 1800"
+          ],
+          "publisherLiteral": [
+            "Maktabat Āyat Allāh al-ʻUẓmá al-Najafī al-Marʻashī,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "1910"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Qaṣīdah al-muzdawijah fī al-manṭiq wa-manṭiq al-mashriqīyīn,"
+          ],
+          "shelfMark": [
+            "*OGL 83-2455"
+          ],
+          "creatorLiteral": [
+            "Avicenna, 980-1037."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "idLccn": [
+            "73960850"
+          ],
+          "contributorLiteral": [
+            "Avicenna, 980-1037."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGL 83-2455"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003958"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73960850"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304319"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203950"
+            }
+          ],
+          "dateEndYear": [
+            1910
+          ],
+          "updatedAt": 1636072413178,
+          "publicationStatement": [
+            "Qum : Maktabat Āyat Allāh al-ʻUẓmá al-Najafī al-Marʻashī, 1405 [1984 or 1985]"
+          ],
+          "identifier": [
+            "urn:bnum:10003958",
+            "urn:lccn:73960850",
+            "urn:undefined:NNSZ00304319",
+            "urn:undefined:(WaOLN)nyp0203950"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Logic -- Early works to 1800."
+          ],
+          "titleDisplay": [
+            "al-Qaṣīdah al-muzdawijah fī al-manṭiq wa-manṭiq al-mashriqīyīn, taṣnīf Abī ʻAlī ibn Sīnā."
+          ],
+          "uri": "b10003958",
+          "lccClassification": [
+            "B751 .M4 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Qum :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10003958"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058069919"
+                    ],
+                    "physicalLocation": [
+                      "*OGL 83-2455"
+                    ],
+                    "shelfMark_sort": "a*OGL 83-002455",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i12858216",
+                    "shelfMark": [
+                      "*OGL 83-2455"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OGL 83-2455"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058069919"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433058069919"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004373",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 3- have imprint: Mysore : Sahyādri Prakāśana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuvempu, 1904-1994"
+          ],
+          "publisherLiteral": [
+            "Karnāṭaka Sahakārī Prakāśana Mandira"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 83-3417"
+          ],
+          "creatorLiteral": [
+            "Javare Gowda, Deve Gowda, 1918-"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902119"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-3417"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004373"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902119"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304738"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204365"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636109940889,
+          "publicationStatement": [
+            "Beṅgaḷūru] Karnāṭaka Sahakārī Prakāśana Mandira [1971]-"
+          ],
+          "identifier": [
+            "urn:bnum:10004373",
+            "urn:lccn:72902119",
+            "urn:undefined:NNSZ00304738",
+            "urn:undefined:(WaOLN)nyp0204365"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "titleDisplay": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu. [Lēkhaka] Dējagau."
+          ],
+          "uri": "b10004373",
+          "lccClassification": [
+            "PL4659.P797 S7934"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004373"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001707623"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "shelfMark_sort": "a*OLA 83-3417 Library has: Vol. 1, 3.",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003188",
+                    "shelfMark": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-3417 Library has: Vol. 1, 3."
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001707623"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001707623"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057523718"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-341"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-341 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i12858227",
+                    "shelfMark": [
+                      "*OLA 83-341 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-341 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057523718"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433057523718"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004788",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "277 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Plon"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Le château du soleil couchant : roman"
+          ],
+          "shelfMark": [
+            "JFE 84-3450"
+          ],
+          "creatorLiteral": [
+            "Grey, Marina."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "La saga de l'exil / Marina Grey ; [3]",
+            "Grey, Marina. Saga de l'exil ; \\[3]"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 84-3450"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004788"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "2259011187 :"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00405900"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204778"
+            }
+          ],
+          "updatedAt": 1652324535423,
+          "publicationStatement": [
+            "Paris : Plon, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10004788",
+            "urn:isbn:2259011187 :",
+            "urn:undefined:NNSZ00405900",
+            "urn:undefined:(WaOLN)nyp0204778"
+          ],
+          "idIsbn": [
+            "2259011187 "
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Le château du soleil couchant : roman / Marina Grey."
+          ],
+          "uri": "b10004788",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "2259011187"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10004788"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858280",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 84-3450"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 84-3450",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113944"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 84-3450"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113944"
+                    ],
+                    "idBarcode": [
+                      "33433046113944"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFE 84-003450"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004816",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Martins Livreiro-Editor,"
+          ],
+          "language": [
+            {
+              "id": "lang:por",
+              "label": "Portuguese"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A outra face de J. Simões Lopes Neto"
+          ],
+          "shelfMark": [
+            "JFK 84-291"
+          ],
+          "creatorLiteral": [
+            "Lopes Neto, J. Simões (João Simões), 1865-1916."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "idLccn": [
+            "84227211"
+          ],
+          "contributorLiteral": [
+            "Moreira, Angelo Pires."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 84-291"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004816"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84227211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204806"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636069640817,
+          "publicationStatement": [
+            "Porto Alegre, RGSul [i.e. Rio Grande do Sul], Brasil : Martins Livreiro-Editor, 1983-"
+          ],
+          "identifier": [
+            "urn:bnum:10004816",
+            "urn:lccn:84227211",
+            "urn:undefined:(WaOLN)nyp0204806"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "A outra face de J. Simões Lopes Neto / [editor] Angelo Pires Moreira."
+          ],
+          "uri": "b10004816",
+          "lccClassification": [
+            "PQ9697.L7223 A6 1983"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Porto Alegre, RGSul [i.e. Rio Grande do Sul], Brasil :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004816"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003418559"
+                    ],
+                    "physicalLocation": [
+                      "JFK 84-291"
+                    ],
+                    "shelfMark_sort": "aJFK 84-291 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003383",
+                    "shelfMark": [
+                      "JFK 84-291 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFK 84-291 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003418559"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433003418559"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004947",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Geografi︠i︡a.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 170.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts",
+            "Geography",
+            "Geography -- Textbooks"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1926
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cografija [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-221 no. 8"
+          ],
+          "creatorLiteral": [
+            "Räshad, Gafyr."
+          ],
+          "createdString": [
+            "1926"
+          ],
+          "dateStartYear": [
+            1926
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-221 no. 8"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004947"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406058"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204937"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636082403668,
+          "publicationStatement": [
+            "Baqï : Azärnäshr, 1926-"
+          ],
+          "identifier": [
+            "urn:bnum:10004947",
+            "urn:undefined:NNSZ00406058",
+            "urn:undefined:(WaOLN)nyp0204937"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1926"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts.",
+            "Geography -- Textbooks."
+          ],
+          "titleDisplay": [
+            "Cografija [microform] / Gafyr Räshad."
+          ],
+          "uri": "b10004947",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Baqï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Geografi︠i︡a."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10004947"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673499"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-221"
+                    ],
+                    "shelfMark_sort": "a*ZO-221 11 Azerbaijani monographs",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30081242",
+                    "shelfMark": [
+                      "*ZO-221 11 Azerbaijani monographs"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZO-221 11 Azerbaijani monographs"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673499"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "11 Azerbaijani monographs"
+                    ],
+                    "idBarcode": [
+                      "33433105673499"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005127",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of cover title: Zähmät mäqtäbläri uçun tädris vä pedagozhi qitablarï.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Cover colophon title in Russian: Nachalʹnyĭ kurs geografii.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 151.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts",
+            "Geography",
+            "Geography -- Textbooks"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1928
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cografija [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-216 no. 15"
+          ],
+          "creatorLiteral": [
+            "Ivanov, G."
+          ],
+          "createdString": [
+            "1928"
+          ],
+          "dateStartYear": [
+            1928
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-216 no. 15"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005127"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406243"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205116"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636082403606,
+          "publicationStatement": [
+            "Baqï : Azärnäshr, 1928-"
+          ],
+          "identifier": [
+            "urn:bnum:10005127",
+            "urn:undefined:NNSZ00406243",
+            "urn:undefined:(WaOLN)nyp0205116"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1928"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts.",
+            "Geography -- Textbooks."
+          ],
+          "titleDisplay": [
+            "Cografija [microform] / Ivanof ; çäviräni Äsädylla Äbdurrähim-zadä."
+          ],
+          "uri": "b10005127",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Baqï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Nachalʹnyĭ kurs geografii."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10005127"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005211",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Khaos.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 586.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1929
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Xaos [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-220 no. 9"
+          ],
+          "creatorLiteral": [
+            "Shirvanzade, 1858-1935."
+          ],
+          "createdString": [
+            "1929"
+          ],
+          "dateStartYear": [
+            1929
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-220 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406328"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205200"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636144501921,
+          "publicationStatement": [
+            "Bagï : Azärnäshr, 1929"
+          ],
+          "identifier": [
+            "urn:bnum:10005211",
+            "urn:undefined:NNSZ00406328",
+            "urn:undefined:(WaOLN)nyp0205200"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1929"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts."
+          ],
+          "titleDisplay": [
+            "Xaos [microform] / Shirvanzada ; ermeni dilinden ceviräni F. Ismixanov ; tärcimäsinin redaktory Säid Mirkasïmzada."
+          ],
+          "uri": "b10005211",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bagï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Khaos."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10005211"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105674059"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-220"
+                    ],
+                    "shelfMark_sort": "a*ZO-220 collection of 10 titles (monographs)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30087469",
+                    "shelfMark": [
+                      "*ZO-220 collection of 10 titles (monographs)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZO-220 collection of 10 titles (monographs)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105674059"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "collection of 10 titles (monographs)"
+                    ],
+                    "idBarcode": [
+                      "33433105674059"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005860",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Swahili.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Swahili language",
+            "Swahili language -- Texts"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:swa",
+              "label": "Swahili"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mfuatano wa muundo na kazi za vyombo vya Serikali ya mapinduzi ya Zanzibar."
+          ],
+          "shelfMark": [
+            "Sc Ser.-N .Z288"
+          ],
+          "creatorLiteral": [
+            "Zanzibar."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-N .Z288"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005860"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507074"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205850"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636116169694,
+          "publicationStatement": [
+            "[Zanzibar : s.n., 1980-    ]"
+          ],
+          "identifier": [
+            "urn:bnum:10005860",
+            "urn:undefined:NNSZ00507074",
+            "urn:undefined:(WaOLN)nyp0205850"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Swahili language -- Texts."
+          ],
+          "titleDisplay": [
+            "Mfuatano wa muundo na kazi za vyombo vya Serikali ya mapinduzi ya Zanzibar."
+          ],
+          "uri": "b10005860",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Zanzibar :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Kitabu cha 1-9."
+          ],
+          "dimensions": [
+            "13-31 cm."
+          ]
+        },
+        "sort": [
+          "b10005860"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942241",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-N .Z288 Kituba cha 1-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-N .Z288 Kituba cha 1-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030859007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-N .Z288"
+                    ],
+                    "enumerationChronology": [
+                      "Kituba cha 1-9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030859007"
+                    ],
+                    "idBarcode": [
+                      "33433030859007"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-N .Z288 Kituba cha 1-000009"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005862",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Editor: Gerald A. McWorter.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- Study and teaching",
+            "African Americans -- Study and teaching -- Congresses",
+            "Black people",
+            "Black people -- Study and teaching",
+            "Black people -- Study and teaching -- Congresses"
+          ],
+          "publisherLiteral": [
+            "Afro-American Studies and Research Program, University of Illinois,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Proceedings"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .N3674"
+          ],
+          "creatorLiteral": [
+            "National Council for Black Studies (U.S.). Conference (6th : 1982 : Chicago, Ill.)"
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "contributorLiteral": [
+            "McWorter, Gerald A."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .N3674"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005862"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507076"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205852"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1144093",
+              "shelfMark": [
+                "Sc Ser.-M .N3674"
+              ]
+            }
+          ],
+          "updatedAt": 1643270732538,
+          "publicationStatement": [
+            "Urbana, Ill. : Afro-American Studies and Research Program, University of Illinois, [1983?-]"
+          ],
+          "identifier": [
+            "urn:bnum:10005862",
+            "urn:undefined:NNSZ00507076",
+            "urn:undefined:(WaOLN)nyp0205852"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- Study and teaching -- Congresses.",
+            "Black people -- Study and teaching -- Congresses."
+          ],
+          "titleDisplay": [
+            "Proceedings / National Council for Black Studies, 6th annual national conference."
+          ],
+          "uri": "b10005862",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Urbana, Ill. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "no. 1. Race/class.--no. 2. Studies on Black children and their families.--no. 3. Philosophical perspectives in Black studies.--no. 4. Black liberation movement.--no. 5. Social science and the Black experience."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10005862"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447316",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .N3674: 6th. 1982 no. 3-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .N3674: 6th. 1982 no. 3-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072219805"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .N3674: 6th. 1982"
+                    ],
+                    "enumerationChronology": [
+                      "no. 3-5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072219805"
+                    ],
+                    "idBarcode": [
+                      "33433072219805"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .N3674: 6th. 1982 no. 000003-5"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746590",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .N3674: 6th. 1982 no. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .N3674: 6th. 1982 no. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072219797"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .N3674: 6th. 1982"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072219797"
+                    ],
+                    "idBarcode": [
+                      "33433072219797"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .N3674: 6th. 1982 no. 000001-2"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005870",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "71 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"D'après le livre et le montage audiovisual 'L'Evolution de l'amour' por D. Sonet, légèrement adapté avec l'aimable autorisation de l'auteur.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sex instruction",
+            "Sex instruction -- Haiti",
+            "Sonet, D"
+          ],
+          "publisherLiteral": [
+            "Action familiale d'Haïti,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A quel age peut-on aimer? : pour une éducation à l'amour responsable"
+          ],
+          "shelfMark": [
+            "Sc D 84-595"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "Action familiale d'Haïti."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-595"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005870"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507084"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205860"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636069688379,
+          "publicationStatement": [
+            "Port-au-Prince : Action familiale d'Haïti, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10005870",
+            "urn:undefined:NNSZ00507084",
+            "urn:undefined:(WaOLN)nyp0205860"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sex instruction -- Haiti.",
+            "Sonet, D."
+          ],
+          "titleDisplay": [
+            "A quel age peut-on aimer? : pour une éducation à l'amour responsable / Action familiale d'Haïti."
+          ],
+          "uri": "b10005870",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Port-au-Prince :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10005870"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900461",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-595"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-595",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036649329"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-595"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036649329"
+                    ],
+                    "idBarcode": [
+                      "33433036649329"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000595"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005876",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxvii, 751 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of title: Unesco International Scientific Committee for the Drafting of a General History of Africa.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 692-733.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa",
+            "Africa -- History",
+            "Africa -- History -- To 1884"
+          ],
+          "publisherLiteral": [
+            "Heinemann ; University of California Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Africa from the twelfth to the sixteenth century"
+          ],
+          "shelfMark": [
+            "Sc E 84-288"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "idLccn": [
+            "84256508 //r86"
+          ],
+          "seriesStatement": [
+            "General history of Africa ; 4"
+          ],
+          "contributorLiteral": [
+            "Niane, Djibril Tamsir.",
+            "Unesco. International Scientific Committee for the Drafting of a General History of Africa."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc E 84-288"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005876"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0435948105"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0520039157 (University of California Press)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84256508 //r86"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205866"
+            }
+          ],
+          "updatedAt": 1652323261637,
+          "publicationStatement": [
+            "London : Heinemann ; Berkeley, Calif. : University of California Press, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10005876",
+            "urn:isbn:0435948105",
+            "urn:isbn:0520039157 (University of California Press)",
+            "urn:lccn:84256508 //r86",
+            "urn:undefined:(WaOLN)nyp0205866"
+          ],
+          "idIsbn": [
+            "0435948105",
+            "0520039157 (University of California Press)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa -- History -- To 1884."
+          ],
+          "titleDisplay": [
+            "Africa from the twelfth to the sixteenth century / editor, D.T. Niane."
+          ],
+          "uri": "b10005876",
+          "lccClassification": [
+            "DT20 .G45 1981 vol. 4 DT25"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London : Berkeley, Calif."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0435948105",
+            "0520039157"
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10005876"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003888",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc E 84-288"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc E 84-288",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433021813997"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc E 84-288"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433021813997"
+                    ],
+                    "idBarcode": [
+                      "33433021813997"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc E 84-000288"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10003889",
+                    "status": [
+                      {
+                        "id": "status:m",
+                        "label": "Missing"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:m||Missing"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "*R-BK 90-2407"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*R-BK 90-2407",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*R-BK 90-2407"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:-",
+                        "label": "No restrictions"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:-||No restrictions"
+                    ],
+                    "shelfMark_sort": "a*R-BK 90-002407"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005898",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Creole dialects, French",
+            "Creole dialects, French -- Haiti",
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers",
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers -- French"
+          ],
+          "publisherLiteral": [
+            "I.L.A. de Port-au-Prince,"
+          ],
+          "language": [
+            {
+              "id": "lang:crp",
+              "label": "Creoles and Pidgins (Other)"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Leson kreyòl pou etranje ki pale franse \\"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .M468"
+          ],
+          "creatorLiteral": [
+            "Mirville, Ernst."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Collection Coucoville",
+            "Siwolin; \\t.2"
+          ],
+          "contributorLiteral": [
+            "Institut de linguistique appliquée de Port-au-Prince."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .M468"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005898"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507113"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205888"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1144290",
+              "shelfMark": [
+                "Sc Ser.-M .M468"
+              ]
+            }
+          ],
+          "updatedAt": 1636113236627,
+          "publicationStatement": [
+            "Port-au-Prince : I.L.A. de Port-au-Prince, 1984-"
+          ],
+          "identifier": [
+            "urn:bnum:10005898",
+            "urn:undefined:NNSZ00507113",
+            "urn:undefined:(WaOLN)nyp0205888"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers -- French."
+          ],
+          "titleDisplay": [
+            "Leson kreyòl pou etranje ki pale franse \\ Ernst Mirville."
+          ],
+          "uri": "b10005898",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Port-au-Prince :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10005898"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900486",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .M468 t. 2, ptie 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .M468 t. 2, ptie 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017863220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .M468"
+                    ],
+                    "enumerationChronology": [
+                      "t. 2, ptie 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017863220"
+                    ],
+                    "idBarcode": [
+                      "33433017863220"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .M468 t. 2, ptie 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005902",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "76 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sacred songs, English",
+            "Sacred songs, English -- Caribbean Area",
+            "Sacred songs, English -- Caribbean Area -- Texts",
+            "Sacred songs, English -- Jamaica",
+            "Sacred songs, English -- Jamaica -- Texts"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Modern Jamaican-Caribbean religious folk music."
+          ],
+          "shelfMark": [
+            "Sc D 84-602"
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-602"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005902"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507117"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205892"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636116687148,
+          "publicationStatement": [
+            "[S.l. : s.n., 19--]"
+          ],
+          "identifier": [
+            "urn:bnum:10005902",
+            "urn:undefined:NNSZ00507117",
+            "urn:undefined:(WaOLN)nyp0205892"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sacred songs, English -- Caribbean Area -- Texts.",
+            "Sacred songs, English -- Jamaica -- Texts."
+          ],
+          "titleDisplay": [
+            "Modern Jamaican-Caribbean religious folk music."
+          ],
+          "uri": "b10005902",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10005902"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900490",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-602"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-602",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058825831"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-602"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058825831"
+                    ],
+                    "idBarcode": [
+                      "33433058825831"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000602"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005905",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "52 p. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tchiè dans tchiè : les angoisses du coeur : recueil de poèmes \\"
+          ],
+          "shelfMark": [
+            "Sc C 85-2"
+          ],
+          "creatorLiteral": [
+            "Passavant, Camille."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc C 85-2"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005905"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507120"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205895"
+            }
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1636132396392,
+          "publicationStatement": [
+            "[Fort-de-France? Martinique : s.n., 19--] 52"
+          ],
+          "identifier": [
+            "urn:bnum:10005905",
+            "urn:undefined:NNSZ00507120",
+            "urn:undefined:(WaOLN)nyp0205895"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Tchiè dans tchiè : les angoisses du coeur : recueil de poèmes \\ Camille Passavant."
+          ],
+          "uri": "b10005905",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Fort-de-France? Martinique :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 x 21 cm."
+          ]
+        },
+        "sort": [
+          "b10005905"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900493",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc C 85-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc C 85-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036604563"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc C 85-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036604563"
+                    ],
+                    "idBarcode": [
+                      "33433036604563"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc C 85-000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005907",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Discography: p. 115-122.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jazz",
+            "Jazz -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Producciones Don Pedro,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "En torno al jazz"
+          ],
+          "shelfMark": [
+            "Sc Ser.-L .V354"
+          ],
+          "creatorLiteral": [
+            "Vélez, Ana."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-L .V354"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005907"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507122"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205897"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636093384929,
+          "publicationStatement": [
+            "San Juan, P.R. : Producciones Don Pedro, 1978-"
+          ],
+          "identifier": [
+            "urn:bnum:10005907",
+            "urn:undefined:NNSZ00507122",
+            "urn:undefined:(WaOLN)nyp0205897"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jazz -- History and criticism."
+          ],
+          "titleDisplay": [
+            "En torno al jazz / Ana Vélez."
+          ],
+          "uri": "b10005907",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "San Juan, P.R. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1. Musica de nuestro siglo -- v. 2. Impacto social y trascendencia."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10005907"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900496",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V354 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V354 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017895651"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V354"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017895651"
+                    ],
+                    "idBarcode": [
+                      "33433017895651"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V354 v. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900495",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V354 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V354 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030890481"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V354"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030890481"
+                    ],
+                    "idBarcode": [
+                      "33433030890481"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V354 v. 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005910",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 99 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 99.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Universities and colleges",
+            "Universities and colleges -- Africa",
+            "Universities and colleges -- Zambia"
+          ],
+          "publisherLiteral": [
+            "Published on behalf of the Institute for African Studies, University of Zambia, by National Educational Co. of Zambia,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The African university : issues and perspectives : speeches"
+          ],
+          "shelfMark": [
+            "Sc D 84-502"
+          ],
+          "creatorLiteral": [
+            "Goma, L. K. H."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "idLccn": [
+            "84980558"
+          ],
+          "seriesStatement": [
+            "Zambian papers ; no. 14"
+          ],
+          "contributorLiteral": [
+            "Tembo, L. P.",
+            "University of Zambia. Institute for African Studies."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-502"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005910"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84980558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205900"
+            }
+          ],
+          "updatedAt": 1636133189056,
+          "publicationStatement": [
+            "Lusaka, Zambia : Published on behalf of the Institute for African Studies, University of Zambia, by National Educational Co. of Zambia, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10005910",
+            "urn:lccn:84980558",
+            "urn:undefined:(WaOLN)nyp0205900"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Universities and colleges -- Africa.",
+            "Universities and colleges -- Zambia."
+          ],
+          "titleDisplay": [
+            "The African university : issues and perspectives : speeches / by L.H.K. [i.e. L.K.H.] Goma ; selected and edited by L.P. Tembo."
+          ],
+          "uri": "b10005910",
+          "lccClassification": [
+            "DT963.A3 Z3 no. 14 LA1503"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Lusaka, Zambia :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10005910"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433021791029"
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-502"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000502",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003896",
+                    "shelfMark": [
+                      "Sc D 84-502"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Sc D 84-502"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433021791029"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "idBarcode": [
+                      "33433021791029"
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003630815"
+                    ],
+                    "physicalLocation": [
+                      "JFK 86-224"
+                    ],
+                    "shelfMark_sort": "aJFK 86-224 v. 000014",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003897",
+                    "shelfMark": [
+                      "JFK 86-224 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFK 86-224 v. 14"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003630815"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "idBarcode": [
+                      "33433003630815"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 microfilm reels ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes biographical notes, scope and contents note and indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm of Mss.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Washington, Fredi, 1903-1994",
+            "African American actresses",
+            "African American actresses -- Correspondence",
+            "African American women journalists",
+            "African American women journalists -- Correspondence",
+            "African Americans in the performing arts",
+            "African American actors",
+            "African American journalists"
+          ],
+          "publisherLiteral": [
+            "Amistad Research Center"
+          ],
+          "description": [
+            "Contains approximately one hundred pieces of correspondence, news clippings containing reviews of productions in which Fredi Washington appeared, and Washington's columns for The People's voice. Other groups in the collection are theatre programs, scripts, photographs and documentation of honors conferred on Fredi Washington."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1984"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Fredi Washington papers, 1925-1979."
+          ],
+          "shelfMark": [
+            "Sc Micro R-4205"
+          ],
+          "creatorLiteral": [
+            "Washington, Fredi, 1903-1994."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "contributorLiteral": [
+            "Amistad Research Center."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro R-4205"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006007"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "11780064"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)11780064"
+            }
+          ],
+          "idOclc": [
+            "11780064"
+          ],
+          "dateEndYear": [
+            1984
+          ],
+          "updatedAt": 1651087265505,
+          "publicationStatement": [
+            "New Orleans, La. : Amistad Research Center, [198-?]"
+          ],
+          "identifier": [
+            "urn:bnum:10006007",
+            "urn:oclc:11780064",
+            "urn:undefined:(OCoLC)11780064"
+          ],
+          "genreForm": [
+            "Personal correspondence."
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Washington, Fredi, 1903-1994.",
+            "African American actresses -- Correspondence.",
+            "African American women journalists -- Correspondence.",
+            "African Americans in the performing arts.",
+            "African American actors.",
+            "African American journalists."
+          ],
+          "titleDisplay": [
+            "Fredi Washington papers, 1925-1979."
+          ],
+          "uri": "b10006007",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "New Orleans, La."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "35 mm"
+          ]
+        },
+        "sort": [
+          "b10006007"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900582",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4205 r. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4205 r. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031242500"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4205"
+                    ],
+                    "enumerationChronology": [
+                      "r. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433031242500"
+                    ],
+                    "idBarcode": [
+                      "33433031242500"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-4205 r. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900581",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4205 r. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4205 r. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433031242492"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4205"
+                    ],
+                    "enumerationChronology": [
+                      "r. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433031242492"
+                    ],
+                    "idBarcode": [
+                      "33433031242492"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-4205 r. 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tem language"
+          ],
+          "publisherLiteral": [
+            "Experiment in International Living,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tem"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .T425"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Peace Corps language handbook series"
+          ],
+          "contributorLiteral": [
+            "Der-Houssikian, Haig."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .T425"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206003"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636132578775,
+          "publicationStatement": [
+            "Brattleboro, vt. : Experiment in International Living, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10006011",
+            "urn:undefined:NNSZ00507231",
+            "urn:undefined:(WaOLN)nyp0206003"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tem language."
+          ],
+          "titleDisplay": [
+            "Tem / developed by the Experiment in International Living...for ACTION/Peace Corps."
+          ],
+          "uri": "b10006011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Brattleboro, vt. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Communication and culture handbook/by Haig Der-Houssikian.--"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006011"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23169346",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .T425"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .T425",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076233265"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .T425"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076233265"
+                    ],
+                    "idBarcode": [
+                      "33433076233265"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .T000425"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kabre language"
+          ],
+          "publisherLiteral": [
+            "Experiment in International Living,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kabiye"
+          ],
+          "shelfMark": [
+            "Sc F 84-135"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Peace Corps language handbook series"
+          ],
+          "contributorLiteral": [
+            "Experiment in International Living.",
+            "Jassor, Essogoye.",
+            "Sedlak, Philip Alan Stephen, 1939-"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc F 84-135"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507232"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206004"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108841395,
+          "publicationStatement": [
+            "Brattleboro, Vt. : Experiment in International Living, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10006012",
+            "urn:undefined:NNSZ00507232",
+            "urn:undefined:(WaOLN)nyp0206004"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kabre language."
+          ],
+          "titleDisplay": [
+            "Kabiye / developed by the Experiment in International Living...for ACTION/Peace Corps."
+          ],
+          "uri": "b10006012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Brattleboro, Vt. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Special skills handbook/compiled by Philip A.S. Sedlak; assisted by Essogoye Jassor.--"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006012"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900585",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 84-135"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 84-135",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036872368"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 84-135"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036872368"
+                    ],
+                    "idBarcode": [
+                      "33433036872368"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 84-000135"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Corrections to volume I\": v. 2, p. 69.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iota Phi Lambda"
+          ],
+          "publisherLiteral": [
+            "The Sorority,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1959
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A History of Iota Phi Lambda Sorority."
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .H592"
+          ],
+          "createdString": [
+            "1959"
+          ],
+          "contributorLiteral": [
+            "Greene, Ethel K.",
+            "Sims, Sarah B."
+          ],
+          "dateStartYear": [
+            1959
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .H592"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507238"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206010"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1142937",
+              "shelfMark": [
+                "Sc Ser.-M .H592"
+              ]
+            }
+          ],
+          "updatedAt": 1636069378411,
+          "publicationStatement": [
+            "Washington : The Sorority, 1959-"
+          ],
+          "identifier": [
+            "urn:bnum:10006018",
+            "urn:undefined:NNSZ00507238",
+            "urn:undefined:(WaOLN)nyp0206010"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1959"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iota Phi Lambda."
+          ],
+          "titleDisplay": [
+            "A History of Iota Phi Lambda Sorority."
+          ],
+          "uri": "b10006018",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Washington :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1929-1958/Ethel K. Greene.--1959-1969/Sarah B. Sims."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006018"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746595",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .H592 v. 1, 2 (1928-19, 1959-69)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .H592 v. 1, 2 (1928-19, 1959-69)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061038323"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .H592"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1, 2 (1928-19, 1959-69)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061038323"
+                    ],
+                    "idBarcode": [
+                      "33433061038323"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .H592 v. 000001, 2 (1928-19, 1959-69)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "79 p. : ill., maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa",
+            "Africa -- Portuguese",
+            "Cão, Diogo, active 15th century",
+            "Dias, Bartolomeu",
+            "Gama, Vasco da, 1469-1524",
+            "Portuguese",
+            "Portuguese -- India",
+            "Portuguese -- India -- History"
+          ],
+          "publisherLiteral": [
+            "Basler Afrika Bibliographien,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Die Portugiesenkreuze in Africa und Indien : eine umfassende Darstellung aller von den portugiesischen Entdeckern Diogo Cão, Bartolomeo Dias und Vasco da Gama errichteten Steinkreuze (Padrões), deren Geschichte und deren Nachbildungen"
+          ],
+          "shelfMark": [
+            "Sc D 84-477"
+          ],
+          "creatorLiteral": [
+            "Kalthammer, Wilhelm."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Beiträge zur Afrikakunde, 0171-1660; 5"
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc D 84-477"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006034"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507257"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206027"
+            }
+          ],
+          "updatedAt": 1636088600902,
+          "publicationStatement": [
+            "Basel : Basler Afrika Bibliographien, 1978."
+          ],
+          "identifier": [
+            "urn:bnum:10006034",
+            "urn:undefined:NNSZ00507257",
+            "urn:undefined:(WaOLN)nyp0206027"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa -- Portuguese.",
+            "Cão, Diogo, active 15th century.",
+            "Dias, Bartolomeu.",
+            "Gama, Vasco da, 1469-1524.",
+            "Portuguese -- India -- History."
+          ],
+          "titleDisplay": [
+            "Die Portugiesenkreuze in Africa und Indien : eine umfassende Darstellung aller von den portugiesischen Entdeckern Diogo Cão, Bartolomeo Dias und Vasco da Gama errichteten Steinkreuze (Padrões), deren Geschichte und deren Nachbildungen / Wilhelm Kalthammer."
+          ],
+          "uri": "b10006034",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Basel :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006034"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900606",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc D 84-477"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc D 84-477",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036649683"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc D 84-477"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036649683"
+                    ],
+                    "idBarcode": [
+                      "33433036649683"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc D 84-000477"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "205 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Africa, Sub-Saharan",
+            "Africa, Sub-Saharan -- Relations",
+            "Africa, Sub-Saharan -- Relations -- Arab countries",
+            "Arab countries",
+            "Arab countries -- Relations",
+            "Arab countries -- Relations -- Africa, Sub-Saharan"
+          ],
+          "publisherLiteral": [
+            "Unesco,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Historical and socio-cultural relations between Black Africa and the Arab world from 1935 to the present : report and papers of the symposium organized by Unesco in Paris from 25 to 27 July 1979."
+          ],
+          "shelfMark": [
+            "Sc E 84-236"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "General history of Africa: studies and documents; 7"
+          ],
+          "contributorLiteral": [
+            "Unesco."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc E 84-236"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006043"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206036"
+            }
+          ],
+          "updatedAt": 1636103134727,
+          "publicationStatement": [
+            "Paris : Unesco, 1984."
+          ],
+          "identifier": [
+            "urn:bnum:10006043",
+            "urn:undefined:(WaOLN)nyp0206036"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Africa, Sub-Saharan -- Relations -- Arab countries.",
+            "Arab countries -- Relations -- Africa, Sub-Saharan."
+          ],
+          "titleDisplay": [
+            "Historical and socio-cultural relations between Black Africa and the Arab world from 1935 to the present : report and papers of the symposium organized by Unesco in Paris from 25 to 27 July 1979."
+          ],
+          "uri": "b10006043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10006043"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900614",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc E 84-236"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc E 84-236",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036807315"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc E 84-236"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036807315"
+                    ],
+                    "idBarcode": [
+                      "33433036807315"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc E 84-000236"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006159",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- Civil rights",
+            "Civil rights",
+            "Civil rights -- United States",
+            "Violence",
+            "Violence -- United States"
+          ],
+          "publisherLiteral": [
+            "American Foundation for Negro Affairs,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Law and disorder [microform] : a research position paper"
+          ],
+          "shelfMark": [
+            "Sc Micro R-4202, no. 16"
+          ],
+          "creatorLiteral": [
+            "American Foundation for Negro Affairs. Commission on Judiciary and Law. Subcommittee on National Goals."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro R-4202, no. 16"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006159"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507384"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206150"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636111916018,
+          "publicationStatement": [
+            "Philadelphia, Pa. : American Foundation for Negro Affairs, 1970-"
+          ],
+          "identifier": [
+            "urn:bnum:10006159",
+            "urn:undefined:NNSZ00507384",
+            "urn:undefined:(WaOLN)nyp0206150"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- Civil rights.",
+            "Civil rights -- United States.",
+            "Violence -- United States."
+          ],
+          "titleDisplay": [
+            "Law and disorder [microform] : a research position paper / [Commission on Judiciary and Law, Subcommittee on National Goals]."
+          ],
+          "uri": "b10006159",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Philadelphia, Pa. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 x 28 cm."
+          ]
+        },
+        "sort": [
+          "b10006159"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i24023455",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4202"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4202",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059035760"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4202"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059035760"
+                    ],
+                    "idBarcode": [
+                      "33433059035760"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-004202"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006344",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "11 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Black people",
+            "Black people -- Caribbean Area",
+            "Black people -- Caribbean Area -- Social conditions",
+            "Middle class",
+            "Middle class -- Caribbean Area"
+          ],
+          "publisherLiteral": [
+            "s.n."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1999"
+          ],
+          "createdYear": [
+            1900
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The making of a middle class"
+          ],
+          "shelfMark": [
+            "Sc Micro F-10459"
+          ],
+          "creatorLiteral": [
+            "Franks, W. Stanley."
+          ],
+          "createdString": [
+            "1900"
+          ],
+          "dateStartYear": [
+            1900
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro F-10459"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006344"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507572"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206335"
+            }
+          ],
+          "dateEndYear": [
+            1999
+          ],
+          "updatedAt": 1657974959186,
+          "publicationStatement": [
+            "[S.l. : s.n., 19--]"
+          ],
+          "identifier": [
+            "urn:bnum:10006344",
+            "urn:undefined:NNSZ00507572",
+            "urn:undefined:(WaOLN)nyp0206335"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1900"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Black people -- Caribbean Area -- Social conditions.",
+            "Middle class -- Caribbean Area."
+          ],
+          "titleDisplay": [
+            "The making of a middle class [microform] / by W. S. Franks ; with a foreword by Lee Llewellyn Moore."
+          ],
+          "uri": "b10006344",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "sort": [
+          "b10006344"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540203",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:26",
+                        "label": "microfiche"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:26||microfiche"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff3",
+                        "label": "Schomburg Center - Research & Reference - Desk"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff3||Schomburg Center - Research & Reference - Desk"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro F-10459"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro F-10459",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058831748"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro F-10459"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058831748"
+                    ],
+                    "idBarcode": [
+                      "33433058831748"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro F-010459"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006540",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 issued without edition statement has imprint date 1972.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and indexes.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Germany",
+            "Germany -- History",
+            "Germany -- History -- Allied occupation, 1945-",
+            "World War, 1939-1945",
+            "World War, 1939-1945 -- Germany"
+          ],
+          "publisherLiteral": [
+            "Selbstverlag,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Was geschah nach 1945?"
+          ],
+          "shelfMark": [
+            "JFK 84-184"
+          ],
+          "creatorLiteral": [
+            "Roth, Heinz."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "seriesStatement": [
+            "Auf der Suche nach der Wahrheit / Heinz Roth ; Bd. 4-5",
+            "Roth, Heinz. Auf der Suche nach der Wahrheit ; \\Bd. 4-5."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 84-184"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006540"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507771"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206529"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636143161690,
+          "publicationStatement": [
+            "Odenhausen/Lumda : Selbstverlag, [197-?-"
+          ],
+          "identifier": [
+            "urn:bnum:10006540",
+            "urn:undefined:NNSZ00507771",
+            "urn:undefined:(WaOLN)nyp0206529"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Germany -- History -- Allied occupation, 1945-",
+            "World War, 1939-1945 -- Germany."
+          ],
+          "titleDisplay": [
+            "Was geschah nach 1945? / Heinz Roth."
+          ],
+          "uri": "b10006540",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Odenhausen/Lumda :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Was geschah nach neunzehnhundertfünfundvierzig."
+          ],
+          "tableOfContents": [
+            "T.1. Der Zusammenbruch -- T.2. Kriegsverbrecherprozesse u.a."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006540"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003841073"
+                    ],
+                    "physicalLocation": [
+                      "JFK 84-184"
+                    ],
+                    "shelfMark_sort": "aJFK 84-184 v. 000001-2",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003927",
+                    "shelfMark": [
+                      "JFK 84-184 v. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFK 84-184 v. 1-2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003841073"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-2"
+                    ],
+                    "idBarcode": [
+                      "33433003841073"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006622",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Caldas (Colombia : Department)",
+            "Caldas (Colombia : Department) -- History"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Biblioteca de Escritores Caldenses"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Historia del Gran Caldas"
+          ],
+          "shelfMark": [
+            "HDK 84-1693"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "creatorLiteral": [
+            "Ríos Tobón, Ricardo de los."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "HDK 84-1693"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006622"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG005000779-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507853"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206611"
+            }
+          ],
+          "idOclc": [
+            "NYPG005000779-B"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1676385946742,
+          "publicationStatement": [
+            "Manizales, Colombia : Biblioteca de Escritores Caldenses, 1933-"
+          ],
+          "identifier": [
+            "urn:bnum:10006622",
+            "urn:oclc:NYPG005000779-B",
+            "urn:undefined:NNSZ00507853",
+            "urn:undefined:(WaOLN)nyp0206611"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Caldas (Colombia : Department) -- History."
+          ],
+          "titleDisplay": [
+            "Historia del Gran Caldas / Ricardo de los Ríos Tobón."
+          ],
+          "uri": "b10006622",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Manizales, Colombia"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1. Origenes y colonización hasta 1850."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006622"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746647",
+                    "status": [
+                      {
+                        "id": "status:co",
+                        "label": "Loaned"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:co||Loaned"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "HDK 84-1693 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "HDK 84-1693 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433097665214"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "HDK 84-1693"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433097665214"
+                    ],
+                    "idBarcode": [
+                      "33433097665214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dueDate": [
+                      "2023-02-15"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aHDK 84-1693 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006645",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "a, 257 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Translation of: Algoritmy upravlen︠i︡a rabotami-manipul︠i︡atorami.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"JPRS 59717.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 245-252.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Photocopy.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Manipulators (Mechanism)",
+            "Robots, Industrial"
+          ],
+          "publisherLiteral": [
+            "Joint Publications Research Service,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "1973"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Robot-manipulator control algorithms"
+          ],
+          "shelfMark": [
+            "JSF 83-552"
+          ],
+          "creatorLiteral": [
+            "Ignatʹev, M. B. (Mikhail Borisovich)"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "contributorLiteral": [
+            "Kulakov, F. M. (Feliks Mikhaĭlovich)",
+            "Pokrovskiĭ, A. M."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JSF 83-552"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006645"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206634"
+            }
+          ],
+          "uniformTitle": [
+            "Algoritmy upravleni︠i︠a rabotami-manipul︠i︠atorami. English"
+          ],
+          "dateEndYear": [
+            1973
+          ],
+          "updatedAt": 1636073144930,
+          "publicationStatement": [
+            "Arlington, Va. : Joint Publications Research Service, 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10006645",
+            "urn:undefined:(WaOLN)nyp0206634"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Manipulators (Mechanism)",
+            "Robots, Industrial."
+          ],
+          "titleDisplay": [
+            "Robot-manipulator control algorithms / by M.B. Ignatʹyev, F.M. Kulakov, A.M. Pokrovskiy."
+          ],
+          "uri": "b10006645",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Arlington, Va. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Algoritmy upravleni︠i︠a rabotami-manipul︠i︠atorami."
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10006645"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433037693748"
+                    ],
+                    "physicalLocation": [
+                      "JSF 83-552"
+                    ],
+                    "shelfMark_sort": "aJSF 83-000552",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i12540383",
+                    "shelfMark": [
+                      "JSF 83-552"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JSF 83-552"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433037693748"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433037693748"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006687",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., ports, ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Skiđuhreppur (Iceland)",
+            "Öxnadalshreppur (Iceland)"
+          ],
+          "publisherLiteral": [
+            "Bókaútgáfan Skjaldborg,"
+          ],
+          "language": [
+            {
+              "id": "lang:ice",
+              "label": "Icelandic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ritsafn"
+          ],
+          "shelfMark": [
+            "JFL 84-217"
+          ],
+          "creatorLiteral": [
+            "Eiður Guðmundsson, 1888-1984."
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 84-217"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006687"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507920"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206676"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127047675,
+          "publicationStatement": [
+            "Akureyri : Bókaútgáfan Skjaldborg, 1982-"
+          ],
+          "identifier": [
+            "urn:bnum:10006687",
+            "urn:undefined:NNSZ00507920",
+            "urn:undefined:(WaOLN)nyp0206676"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Skiđuhreppur (Iceland)",
+            "Öxnadalshreppur (Iceland)"
+          ],
+          "titleDisplay": [
+            "Ritsafn / Eidur Gudmundsson Púfnav;ollum."
+          ],
+          "uri": "b10006687",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Akureyri :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Mannfelliviun mikli -- 2. Búskaparsaga i Skriđuhreppi forna."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10006687"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069567"
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-217"
+                    ],
+                    "shelfMark_sort": "aJFL 84-217 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003946",
+                    "shelfMark": [
+                      "JFL 84-217 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFL 84-217 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069567"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433004069567"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069559"
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-217"
+                    ],
+                    "shelfMark_sort": "aJFL 84-217 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003945",
+                    "shelfMark": [
+                      "JFL 84-217 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFL 84-217 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069559"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433004069559"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006688",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iceland",
+            "Iceland -- Economic conditions",
+            "Iceland -- History",
+            "Iceland -- Social conditions"
+          ],
+          "publisherLiteral": [
+            "Mál og Menning,"
+          ],
+          "language": [
+            {
+              "id": "lang:ice",
+              "label": "Icelandic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ritsafn"
+          ],
+          "shelfMark": [
+            "JFL 84-216"
+          ],
+          "creatorLiteral": [
+            "Sverrir Kristjánsson, 1908-"
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 84-216"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006688"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507921"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206677"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127047675,
+          "publicationStatement": [
+            "Reykjavík : Mál og Menning, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10006688",
+            "urn:undefined:NNSZ00507921",
+            "urn:undefined:(WaOLN)nyp0206677"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iceland -- Economic conditions.",
+            "Iceland -- History.",
+            "Iceland -- Social conditions."
+          ],
+          "titleDisplay": [
+            "Ritsafn / Sverrir Kristjánsson."
+          ],
+          "uri": "b10006688",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Reykjavík :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10006688"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069542"
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-216"
+                    ],
+                    "shelfMark_sort": "aJFL 84-216 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003948",
+                    "shelfMark": [
+                      "JFL 84-216 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFL 84-216 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069542"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433004069542"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069534"
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-216"
+                    ],
+                    "shelfMark_sort": "aJFL 84-216 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003947",
+                    "shelfMark": [
+                      "JFL 84-216 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFL 84-216 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069534"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433004069534"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006699",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "483 p. : ill., ports ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 476-483.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dominican literature",
+            "Dominican literature -- Manuals, handbooks, etc",
+            "Latin American literature",
+            "Latin American literature -- Study and teaching",
+            "Latin American literature -- Study and teaching -- Handbooks, manuals, etc"
+          ],
+          "publisherLiteral": [
+            "s.n.],"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Manual de literatura dominicana y americana : para el 4to teórico del bachillerato tradicional de la educación media"
+          ],
+          "shelfMark": [
+            "JFF 84-820"
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "contributorLiteral": [
+            "Gómez de Michel, Fiume."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 84-820"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006699"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507932"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206688"
+            }
+          ],
+          "updatedAt": 1636114816670,
+          "publicationStatement": [
+            "[Santo Domingo, R. D. : s.n.], 1984"
+          ],
+          "identifier": [
+            "urn:bnum:10006699",
+            "urn:undefined:NNSZ00507932",
+            "urn:undefined:(WaOLN)nyp0206688"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dominican literature -- Manuals, handbooks, etc.",
+            "Latin American literature -- Study and teaching -- Handbooks, manuals, etc."
+          ],
+          "titleDisplay": [
+            "Manual de literatura dominicana y americana : para el 4to teórico del bachillerato tradicional de la educación media / [compilación] Fiumé Gómez de Michel."
+          ],
+          "uri": "b10006699",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Santo Domingo, R. D. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10006699"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13784848",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 84-820"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 84-820",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050352214"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 84-820"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050352214"
+                    ],
+                    "idBarcode": [
+                      "33433050352214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJFF 84-000820"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-c79aeef10e8f2ffb95001384b25268b3.json
+++ b/test/fixtures/query-c79aeef10e8f2ffb95001384b25268b3.json
@@ -1,0 +1,14078 @@
+{
+  "took": 971,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 18415692,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Stauffenburg"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Gmelin, Hermann, 1900-1958.",
+            "Baum, Richard.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGNYPG-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "idOclc": [
+            "NYPGNYPG-B"
+          ],
+          "updatedAt": 1678937667178,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:oclc:NYPGNYPG-B",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen"
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "3923721544"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000003",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. : col. ill. maps ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrides (Scotland)",
+            "Hebrides (Scotland) -- Pictorial works"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Constable"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1989
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Scottish islands"
+          ],
+          "shelfMark": [
+            "JFF 89-526"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Waite, Charlie."
+          ],
+          "createdString": [
+            "1989"
+          ],
+          "idLccn": [
+            "gb 89012970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1989
+          ],
+          "donor": [
+            "Gift of the Drue Heinz Book Fund for English Literature"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 89-526"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000003"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0094675708 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "gb 89012970"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGUKBPGP8917-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200002"
+            }
+          ],
+          "idOclc": [
+            "NYPGUKBPGP8917-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Constable, 1989."
+          ],
+          "identifier": [
+            "urn:bnum:10000003",
+            "urn:isbn:0094675708 :",
+            "urn:lccn:gb 89012970",
+            "urn:oclc:NYPGUKBPGP8917-B",
+            "urn:undefined:(WaOLN)nyp0200002"
+          ],
+          "idIsbn": [
+            "0094675708 "
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1989"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrides (Scotland) -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Scottish islands / Charlie Waite."
+          ],
+          "uri": "b10000003",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0094675708"
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000003"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 89-526"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 89-526",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050409147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 89-526"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050409147"
+                    ],
+                    "idBarcode": [
+                      "33433050409147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFF 89-000526"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000004",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "23, 216 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1956.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mutaṟkuṟaḷ uvamai."
+          ],
+          "shelfMark": [
+            "*OLB 84-1934"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kothandapani Pillai, K., 1896-"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "74915265"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1247"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1934"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000004"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74915265"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200003"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tirunelvēli, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1965."
+          ],
+          "identifier": [
+            "urn:bnum:10000004",
+            "urn:lccn:74915265",
+            "urn:oclc:NYPG001000001-B",
+            "urn:undefined:NNSZ00100001",
+            "urn:undefined:(WaOLN)nyp0200003"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Mutaṟkuṟaḷ uvamai. Āciriyar Ku. Kōtaṇṭapāṇi Piḷḷai."
+          ],
+          "uri": "b10000004",
+          "lccClassification": [
+            "PL4758.9.T5 K6 1965"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirunelvēli"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000004"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783781",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1934",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1934"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301556"
+                    ],
+                    "idBarcode": [
+                      "33433061301556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001934"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000005",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (43 p.) + 1 part (12 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Acc. arr. for piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Soch. 22\"--Caption.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: 11049.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Concertos (Violin)",
+            "Concertos (Violin) -- Solo with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muzyka"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom"
+          ],
+          "shelfMark": [
+            "JMF 83-336"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Wieniawski, Henri, 1835-1880."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-336"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000005"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "11049. Muzyka"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100551"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200004"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-C"
+          ],
+          "uniformTitle": [
+            "Concertos, violin, orchestra, no. 2, op. 22, D minor; arranged"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Moskva : Muzyka, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000005",
+            "urn:oclc:NYPG001000001-C",
+            "urn:undefined:11049. Muzyka",
+            "urn:undefined:NNSZ00100551",
+            "urn:undefined:(WaOLN)nyp0200004"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Concertos (Violin) -- Solo with piano."
+          ],
+          "titleDisplay": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom / G. Ven︠i︡avskiĭ ; klavir."
+          ],
+          "uri": "b10000005",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Moskva"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Concertos, no. 2, op. 22"
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10000005"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942022",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-336"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-336",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032711909"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-336"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032711909"
+                    ],
+                    "idBarcode": [
+                      "33433032711909"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000336"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000006",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "227 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of The reconstruction of religious thought in Islam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām"
+          ],
+          "shelfMark": [
+            "*OGC 84-1984"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Iqbal, Muhammad, Sir, 1877-1938."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75962707"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Maḥmūd, ʻAbbās."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1984"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000006"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75962707"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100002"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200005"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "al-Qāhirah, Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000006",
+            "urn:lccn:75962707",
+            "urn:oclc:NYPG001000002-B",
+            "urn:undefined:NNSZ00100002",
+            "urn:undefined:(WaOLN)nyp0200005"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām, taʼlif Muhammad Iqbāl. Tarjamat ʻAbbās Maḥmūd. Rājaʻa muqaddimatahu wa-al-faṣl al-awwal minhu ʻAbd al-ʻAzīz al-Maraghī, wa-rājaʻa baqīyat al-Kitāb Mahdī ʻAllām."
+          ],
+          "uri": "b10000006",
+          "lccClassification": [
+            "BP161 .I712 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000006"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691665"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1984"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691665"
+                    ],
+                    "idBarcode": [
+                      "33433022691665"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001984"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 7:35.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: Z.8917.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Guitar music",
+            "Guitar",
+            "Guitar -- Studies and exercises"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Editio Musica"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Due studi per chitarra"
+          ],
+          "shelfMark": [
+            "JMG 83-276"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Patachich, Iván."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000007"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Z.8917. Editio Musica"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100552"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200006"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-C"
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Budapest : Editio Musica, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000007",
+            "urn:oclc:NYPG001000002-C",
+            "urn:undefined:Z.8917. Editio Musica",
+            "urn:undefined:NNSZ00100552",
+            "urn:undefined:(WaOLN)nyp0200006"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Guitar music.",
+            "Guitar -- Studies and exercises."
+          ],
+          "titleDisplay": [
+            "Due studi per chitarra / Patachich Iván."
+          ],
+          "uri": "b10000007",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Budapest"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies"
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000007"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942023",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-276"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-276",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883591"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-276"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883591"
+                    ],
+                    "idBarcode": [
+                      "33433032883591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000276"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000008",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "351 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Parimaḷam Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṇṇāviṉ ciṟukataikaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1986"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Annadurai, C. N., 1909-1969."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913998"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1986"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000008"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913998"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100003"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200007"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Parimaḷam Patippakam [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000008",
+            "urn:lccn:72913998",
+            "urn:oclc:NYPG001000003-B",
+            "urn:undefined:NNSZ00100003",
+            "urn:undefined:(WaOLN)nyp0200007"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Aṇṇāviṉ ciṟukataikaḷ. [Eḻutiyavar] Ci. Eṉ. Aṇṇāturai."
+          ],
+          "uri": "b10000008",
+          "lccClassification": [
+            "PL4758.9.A5 A84"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000008"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783782",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1986",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301689"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1986"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301689"
+                    ],
+                    "idBarcode": [
+                      "33433061301689"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001986"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000009",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "30 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Edition Peters Nr. 5489.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: E.P. 13028.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Edition Peters ; C.F. Peters"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Miniaturen II : 13 kleine Klavierstücke"
+          ],
+          "shelfMark": [
+            "JMG 83-278"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Golle, Jürgen, 1942-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-278"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000009"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters Nr. 5489 Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "E.P. 13028. Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200008"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-C"
+          ],
+          "uniformTitle": [
+            "Miniaturen, no. 2"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Leipzig : Edition Peters ; New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000009",
+            "urn:oclc:NYPG001000003-C",
+            "urn:undefined:Edition Peters Nr. 5489 Edition Peters",
+            "urn:undefined:E.P. 13028. Edition Peters",
+            "urn:undefined:NNSZ00100553",
+            "urn:undefined:(WaOLN)nyp0200008"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Miniaturen II : 13 kleine Klavierstücke / Jürgen Golle."
+          ],
+          "uri": "b10000009",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig : New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen, no. 2"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000009"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942024",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-278"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-278",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883617"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-278"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883617"
+                    ],
+                    "idBarcode": [
+                      "33433032883617"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000278"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000010",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "110 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cēkkiḻār, active 12th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaikkaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1938"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Irācamāṇikkaṉār, Mā., 1907-1967."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913466"
+          ],
+          "seriesStatement": [
+            "Corṇammāḷ corpoḻivu varicai, 6"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1938"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100004"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200009"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Aṇṇāmalainakar, Aṇṇāmalaip Palkalaikkaḻakam, 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000010",
+            "urn:lccn:72913466",
+            "urn:oclc:NYPG001000004-B",
+            "urn:undefined:NNSZ00100004",
+            "urn:undefined:(WaOLN)nyp0200009"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cēkkiḻār, active 12th century."
+          ],
+          "titleDisplay": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ. [Āṟṟiyavar] Mā. Irācamāṇikkaṉār."
+          ],
+          "uri": "b10000010",
+          "lccClassification": [
+            "PL4758.9.C385 Z8"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Aṇṇāmalainakar"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000010"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783783",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1938",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301598"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1938"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301598"
+                    ],
+                    "idBarcode": [
+                      "33433061301598"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001938"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "46 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)",
+            "Easter music (Organ)",
+            "Passion music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Boeijenga"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1982"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Passie en pasen : suite voor orgel, opus 50"
+          ],
+          "shelfMark": [
+            "JMG 83-279"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Berg, Jan J. van den."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-279"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000011"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200010"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-C"
+          ],
+          "dateEndYear": [
+            1982
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Sneek [Netherlands] : Boeijenga, [between 1976 and 1982]."
+          ],
+          "identifier": [
+            "urn:bnum:10000011",
+            "urn:oclc:NYPG001000004-C",
+            "urn:undefined:(WaOLN)nyp0200010"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)",
+            "Easter music (Organ)",
+            "Passion music."
+          ],
+          "titleDisplay": [
+            "Passie en pasen : suite voor orgel, opus 50 / door Jan J. van den Berg."
+          ],
+          "uri": "b10000011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Sneek [Netherlands]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Passie. I. Psalm 22. II. Leer mij O Heer. III. \"Mijn Verlosser hangt aan 't kruis.\" IV. \"O hoofd vol bloed en wonden.\" V. \"O kostbaar kruis.\" VI. \"Jezus, leven van mijn leven\" -- Pasen. VII. Toccata over \"Christus is opgestanden.\" VIII. Canon: \"Jesus unser Trost und Leben.\" IX. Trio: Ik zeg het allen dat Hij leeft.\" X. Trio: \"Staakt Uw rouwen Magdalene.\" XI. Postludium over \"Jesus leeft en wij met Hem\" (met \"Christus onze Heer verrees\" als tegenstem)."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000011"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942025",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-279"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-279",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883625"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-279"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883625"
+                    ],
+                    "idBarcode": [
+                      "33433032883625"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000279"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "223 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p.221.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Thaqāfah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi"
+          ],
+          "shelfMark": [
+            "*OFS 84-1997"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ḥāwī, Īlīyā Salīm."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 84-1997"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200011"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Thaqāfah, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000012",
+            "urn:oclc:NYPG001000005-B",
+            "urn:undefined:NNSZ00100005",
+            "urn:undefined:(WaOLN)nyp0200011"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "titleDisplay": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi / bi-qalam Īlīyā Ḥāwī."
+          ],
+          "uri": "b10000012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000012"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000003",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 84-1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514719"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 84-1997"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514719"
+                    ],
+                    "idBarcode": [
+                      "33433014514719"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFS 84-001997"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000013",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "32 p. of music : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Popular music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Arr. for piano with chord symbols; superlinear German words.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Popular music -- Germany (East)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Harth Musik Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "shelfMark": [
+            "JMF 83-366"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-366"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000013"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100555"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200012"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Leipzig : Harth Musik Verlag, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000013",
+            "urn:oclc:NYPG001000005-C",
+            "urn:undefined:NNSZ00100555",
+            "urn:undefined:(WaOLN)nyp0200012"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Popular music -- Germany (East)"
+          ],
+          "titleDisplay": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "uri": "b10000013",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Disko Treff eins."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000013"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942026",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-366"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-366",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032712204"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-366"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032712204"
+                    ],
+                    "idBarcode": [
+                      "33433032712204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000366"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000014",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "520 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on cover: Islamic unity or the Mutual approach among Muslim sects.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Panislamism",
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muʼassasat al-Aʻlamī lil-Maṭbūʻāt"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah"
+          ],
+          "shelfMark": [
+            "*OGC 84-1996"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Shīrāzī, ʻAbd al-Karīm Bī Āzār."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1996"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000014"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100006"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200013"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Muʼassasat al-Aʻlamī lil-Maṭbūʻāt, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000014",
+            "urn:oclc:NYPG001000006-B",
+            "urn:undefined:NNSZ00100006",
+            "urn:undefined:(WaOLN)nyp0200013"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Panislamism.",
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah / Jamʻ wa-tartīb ʻAbd al-Karīm Bī Āzār al-Shīrāzī."
+          ],
+          "uri": "b10000014",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Islamic unity."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000014"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691780"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1996"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691780"
+                    ],
+                    "idBarcode": [
+                      "33433022691780"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001996"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000015",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "25 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For organ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"A McAfee Music Publication.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: DM 220.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Belwin-Mills"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Suite no. 1 : 1977"
+          ],
+          "shelfMark": [
+            "JNG 83-102"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hampton, Calvin."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNG 83-102"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000015"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "DM 220. Belwin-Mills"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100556"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200014"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-C"
+          ],
+          "uniformTitle": [
+            "Suite, organ, no. 1"
+          ],
+          "updatedAt": 1678726416948,
+          "publicationStatement": [
+            "Melville, NY : Belwin-Mills, [1980?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000015",
+            "urn:oclc:NYPG001000006-C",
+            "urn:undefined:DM 220. Belwin-Mills",
+            "urn:undefined:NNSZ00100556",
+            "urn:undefined:(WaOLN)nyp0200014"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)"
+          ],
+          "titleDisplay": [
+            "Suite no. 1 : 1977 / Calvin Hampton."
+          ],
+          "uri": "b10000015",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Melville, NY"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Suite, no. 1"
+          ],
+          "tableOfContents": [
+            "Fanfares -- Antiphon -- Toccata."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000015"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000016",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "111 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuṟuntokai"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Manṅkaḷa Nūlakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nalla Kuṟuntokaiyil nāṉilam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1937"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Cellappaṉ, Cilampoli, 1929-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "74913402"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1937"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000016"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74913402"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200015"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Ceṉṉai, Manṅkaḷa Nūlakam, 1959 [i.e. 1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000016",
+            "urn:lccn:74913402",
+            "urn:oclc:NYPG001000007-B",
+            "urn:undefined:NNSZ00100007",
+            "urn:undefined:(WaOLN)nyp0200015"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuṟuntokai."
+          ],
+          "titleDisplay": [
+            "Nalla Kuṟuntokaiyil nāṉilam. [Eḻutiyavar] Cu. Cellappaṉ."
+          ],
+          "uri": "b10000016",
+          "lccClassification": [
+            "PL4758.9.K794 Z6 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000016"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783785",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1937",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301580"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1937"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301580"
+                    ],
+                    "idBarcode": [
+                      "33433061301580"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001937"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000017",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (17 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For baritone and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Words printed also as text.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 3:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Corbière, Tristan, 1845-1875",
+            "Corbière, Tristan, 1845-1875 -- Musical settings",
+            "Songs (Medium voice) with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lettre du Mexique : pour baryton et piano, 1942"
+          ],
+          "shelfMark": [
+            "JMG 83-395"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Escher, Rudolf."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Corbière, Tristan, 1845-1875."
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000017"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100557"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200016"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000017",
+            "urn:oclc:NYPG001000007-C",
+            "urn:undefined:NNSZ00100557",
+            "urn:undefined:(WaOLN)nyp0200016"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Corbière, Tristan, 1845-1875 -- Musical settings.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "Lettre du Mexique : pour baryton et piano, 1942 / Rudolf Escher ; poème de Tristan Corbière."
+          ],
+          "uri": "b10000017",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000017"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-395"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-395",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032735007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-395"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032735007"
+                    ],
+                    "idBarcode": [
+                      "33433032735007"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000395"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "68 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Lebanon"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Ṭalīʻah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā"
+          ],
+          "shelfMark": [
+            "*OFX 84-1995"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Bashshūr, Najlāʼ Naṣīr."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "78970449"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1995"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000018"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78970449"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100008"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200017"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Ṭalīʻah, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000018",
+            "urn:lccn:78970449",
+            "urn:oclc:NYPG001000008-B",
+            "urn:undefined:NNSZ00100008",
+            "urn:undefined:(WaOLN)nyp0200017"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Lebanon."
+          ],
+          "titleDisplay": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā / Najlāʼ Naṣīr Bashshūr."
+          ],
+          "uri": "b10000018",
+          "lccClassification": [
+            "HQ1728 .B37"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000018"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000004",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1995"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031718"
+                    ],
+                    "idBarcode": [
+                      "33433002031718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001995"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000019",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: M 18.487.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Waltzes (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zwölf Walzer und ein Epilog : für Klavier"
+          ],
+          "shelfMark": [
+            "JMG 83-111"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Benary, Peter."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-111"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000019"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Möseler M 18.487."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200018"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-C"
+          ],
+          "uniformTitle": [
+            "Walzer und ein Epilog"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000019",
+            "urn:oclc:NYPG001000008-C",
+            "urn:undefined:Möseler M 18.487.",
+            "urn:undefined:NNSZ00100558",
+            "urn:undefined:(WaOLN)nyp0200018"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Waltzes (Piano)"
+          ],
+          "titleDisplay": [
+            "Zwölf Walzer und ein Epilog : für Klavier / Peter Benary."
+          ],
+          "uri": "b10000019",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Walzer und ein Epilog",
+            "Walzer und ein Epilog."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000019"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942028",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-111"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-111",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-111"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845053"
+                    ],
+                    "idBarcode": [
+                      "33433032845053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000111"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000020",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 172, 320 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tolkāppiyar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaik Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tolkāppiyam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1936"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "creatorLiteral": [
+            "Veḷḷaivāraṇaṉ, Ka."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "74914844"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1936"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000020"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74914844"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200019"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "[Aṇṇāmalainakar] Aṇṇāmalaip Palkalaik Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000020",
+            "urn:lccn:74914844",
+            "urn:oclc:NYPG001000009-B",
+            "urn:undefined:NNSZ00100009",
+            "urn:undefined:(WaOLN)nyp0200019"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tolkāppiyar."
+          ],
+          "titleDisplay": [
+            "Tolkāppiyam. [Eḻutiyavar] Ka. Veḷḷaivāraṇaṉ."
+          ],
+          "uri": "b10000020",
+          "lccClassification": [
+            "PL4754.T583 V4 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Aṇṇāmalainakar]"
+          ],
+          "titleAlt": [
+            "Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Tolkāppiyam.--Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000020"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783786",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1936 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1936 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301572"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1936"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301572"
+                    ],
+                    "idBarcode": [
+                      "33433061301572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-1936 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000021",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (51 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: NM 384.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Verlag Neue Musik"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aurora : sinfonischer Prolog : Partitur"
+          ],
+          "shelfMark": [
+            "JMG 83-113"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Weitzendorf, Heinz."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-113"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000021"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NM 384. Verlag Neue Musik"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100559"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200020"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-C"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Berlin : Verlag Neue Musik, c1978."
+          ],
+          "identifier": [
+            "urn:bnum:10000021",
+            "urn:oclc:NYPG001000009-C",
+            "urn:undefined:NM 384. Verlag Neue Musik",
+            "urn:undefined:NNSZ00100559",
+            "urn:undefined:(WaOLN)nyp0200020"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "Aurora : sinfonischer Prolog : Partitur / Heinz Weitzendorf."
+          ],
+          "uri": "b10000021",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Berlin"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000021"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942029",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-113"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-113",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845079"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-113"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845079"
+                    ],
+                    "idBarcode": [
+                      "33433032845079"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000113"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000022",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "19, 493 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1942.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Grammar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1935"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Puttamittiraṉār, active 11th century."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "73913714"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1388"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Peruntēvaṉār, active 11th century.",
+            "Kōvintarāja Mutaliyār, Kā. Ra., 1874-1952."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1935"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73913714"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100010"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200021"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000022",
+            "urn:lccn:73913714",
+            "urn:oclc:NYPG001000010-B",
+            "urn:undefined:NNSZ00100010",
+            "urn:undefined:(WaOLN)nyp0200021"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ. Patippāciriyar Kā. Ra. Kōvintarāca Mutaliyār."
+          ],
+          "uri": "b10000022",
+          "lccClassification": [
+            "PL4754 .P8 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "titleAlt": [
+            "Viracōḻiyam."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000022"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783787",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1935",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301564"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1935"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301564"
+                    ],
+                    "idBarcode": [
+                      "33433061301564"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001935"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000023",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (18 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For band or wind ensemble.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Based on the composer's Veni creator spiritus.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: KC913.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Band music",
+            "Band music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Shawnee Press"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Musica sacra"
+          ],
+          "shelfMark": [
+            "JMF 83-38"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Zaninelli, Luigi."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-38"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000023"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "KC913 Shawnee Press"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100560"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200022"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-C"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Delaware Water Gap, Pa. : Shawnee Press, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000023",
+            "urn:oclc:NYPG001000010-C",
+            "urn:undefined:KC913 Shawnee Press",
+            "urn:undefined:NNSZ00100560",
+            "urn:undefined:(WaOLN)nyp0200022"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Band music -- Scores."
+          ],
+          "titleDisplay": [
+            "Musica sacra / Luigi Zaninelli."
+          ],
+          "uri": "b10000023",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Delaware Water Gap, Pa."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10000023"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942030",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-38"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-38",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709028"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-38"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709028"
+                    ],
+                    "idBarcode": [
+                      "33433032709028"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000038"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000024",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bahrain",
+            "Bahrain -- History",
+            "Bahrain -- History -- 20th century",
+            "Bahrain -- Economic conditions",
+            "Bahrain -- Social conditions"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār Ibn Khaldūn"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī"
+          ],
+          "shelfMark": [
+            "*OFK 84-1944"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rumayḥī, Muḥammad Ghānim."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "79971032"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFK 84-1944"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000024"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79971032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200023"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[Bayrūt] : Dār Ibn Khaldūn, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000024",
+            "urn:lccn:79971032",
+            "urn:oclc:NYPG001000011-B",
+            "urn:undefined:NNSZ00100011",
+            "urn:undefined:(WaOLN)nyp0200023"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bahrain -- History -- 20th century.",
+            "Bahrain -- Economic conditions.",
+            "Bahrain -- Social conditions."
+          ],
+          "titleDisplay": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī / Muḥammad al-Rumayḥī."
+          ],
+          "uri": "b10000024",
+          "lccClassification": [
+            "DS247.B28 R85"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000024"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000005",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK 84-1944",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005548676"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK 84-1944"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005548676"
+                    ],
+                    "idBarcode": [
+                      "33433005548676"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFK 84-001944"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000025",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei Sonatinen für Klavier"
+          ],
+          "shelfMark": [
+            "JMF 83-107"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stockmeier, Wolfgang."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 179"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-107"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000025"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100561"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200024"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-C"
+          ],
+          "uniformTitle": [
+            "Sonatinas, piano"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000025",
+            "urn:oclc:NYPG001000011-C",
+            "urn:undefined:NNSZ00100561",
+            "urn:undefined:(WaOLN)nyp0200024"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Drei Sonatinen für Klavier / Wolfgang Stockmeier."
+          ],
+          "uri": "b10000025",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatinas"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000025"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-107"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-107",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709697"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-107"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709697"
+                    ],
+                    "idBarcode": [
+                      "33433032709697"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000107"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000026",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "222 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 217-220.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Syria"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975"
+          ],
+          "shelfMark": [
+            "*OFX 84-1953"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Razzāz, Nabīlah."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76960987"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1953"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000026"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960987"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200025"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Dimashq : Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000026",
+            "urn:lccn:76960987",
+            "urn:oclc:NYPG001000012-B",
+            "urn:undefined:NNSZ00100012",
+            "urn:undefined:(WaOLN)nyp0200025"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Syria."
+          ],
+          "titleDisplay": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975 / Nabīlah al-Razzāz."
+          ],
+          "uri": "b10000026",
+          "lccClassification": [
+            "HQ402 .R39"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10000026"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000006",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1953",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031700"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1953"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031700"
+                    ],
+                    "idBarcode": [
+                      "33433002031700"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001953"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000027",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Violin)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei kleine Sonaten : für Violine solo"
+          ],
+          "shelfMark": [
+            "JMF 83-95"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Köhler, Friedemann."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 172"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-95"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000027"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100562"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200026"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-C"
+          ],
+          "uniformTitle": [
+            "Kleine Sonaten, violin"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler Verlag, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000027",
+            "urn:oclc:NYPG001000012-C",
+            "urn:undefined:NNSZ00100562",
+            "urn:undefined:(WaOLN)nyp0200026"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Violin)"
+          ],
+          "titleDisplay": [
+            "Drei kleine Sonaten : für Violine solo / Friedemann Köhler."
+          ],
+          "uri": "b10000027",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Kleine Sonaten"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000027"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-95"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-95",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-95"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709572"
+                    ],
+                    "idBarcode": [
+                      "33433032709572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000095"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000028",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "9, 3, 3, 324 p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Prastuta śodha-prabandha Rājasthāna Viśvavidyālaya, Jayapura kī Pī-eca.Ḍī-upāthi ke nimitta viśvavidyālaya anudāna āyoga kī risarca phailośipa ke antargata likhā gayā thā.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [321]-324.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sūryamalla Miśraṇa, 1815-1868"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Rājasthāna Sāhitya Akādamī (Saṅgama)"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vaṃśabhāskara : eka adhyayana"
+          ],
+          "shelfMark": [
+            "*OKTM 84-1945"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Khāna, Ālama Śāha, 1936-2003."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75903689"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000028"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75903689"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200027"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Udayapura : Rājasthāna Sāhitya Akādamī (Saṅgama), 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000028",
+            "urn:lccn:75903689",
+            "urn:oclc:NYPG001000013-B",
+            "urn:undefined:NNSZ00100013",
+            "urn:undefined:(WaOLN)nyp0200027"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sūryamalla Miśraṇa, 1815-1868."
+          ],
+          "titleDisplay": [
+            "Vaṃśabhāskara : eka adhyayana / lekhaka Ālamaśāha Khāna."
+          ],
+          "uri": "b10000028",
+          "lccClassification": [
+            "PK2708.9.S9 V334"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Udayapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000028"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-1945",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011094210"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-1945"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011094210"
+                    ],
+                    "idBarcode": [
+                      "33433011094210"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-001945"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000029",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Wilhelm Hansen edition no. 4372.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: 29589.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Organ music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "W. Hansen ; Distribution, Magnamusic-Baton"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cruor : for organ solo, 1977"
+          ],
+          "shelfMark": [
+            "JMF 83-93"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lorentzen, Bent."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82771131"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-93"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000029"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82771131"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Wilhelm Hansen edition no. 4372."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "29589."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100563"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200028"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Copenhagen ; New York : W. Hansen ; [s.l.] : Distribution, Magnamusic-Baton, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000029",
+            "urn:lccn:82771131",
+            "urn:oclc:NYPG001000013-C",
+            "urn:undefined:Wilhelm Hansen edition no. 4372.",
+            "urn:undefined:29589.",
+            "urn:undefined:NNSZ00100563",
+            "urn:undefined:(WaOLN)nyp0200028"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Organ music."
+          ],
+          "titleDisplay": [
+            "Cruor : for organ solo, 1977 / B. Lorentzen."
+          ],
+          "uri": "b10000029",
+          "lccClassification": [
+            "M11 .L"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Copenhagen ; New York : [s.l.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000029"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942034",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-93"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-93",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-93"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709556"
+                    ],
+                    "idBarcode": [
+                      "33433032709556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000093"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000030",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21, 264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Āryasamāja-śatābdī-saṃskaraṇam.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Authorship uncertain. Attributed variously to Āpiśali, Pānini and Śākaṭāyana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit: introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Suffixes and prefixes"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; prāptisthānam, Rāmalāla Kapūra Ṭrasṭa"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Uṇādi-koṣaḥ"
+          ],
+          "shelfMark": [
+            "*OKA 84-1931"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902275"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Āpiśali.",
+            "Pāṇini.",
+            "Śākatāyana.",
+            "Dayananda Sarasvati, Swami, 1824-1883.",
+            "Yudhiṣṭhira Mīmāṃsaka, 1909-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKA 84-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000030"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902275"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200029"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-B"
+          ],
+          "uniformTitle": [
+            "Uṇādisūtra."
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Karanāla : Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; Bahālagaḍha, Harayāṇa : prāptisthānam, Rāmalāla Kapūra Ṭrasṭa, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000030",
+            "urn:lccn:75902275",
+            "urn:oclc:NYPG001000014-B",
+            "urn:undefined:NNSZ00100014",
+            "urn:undefined:(WaOLN)nyp0200029"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Suffixes and prefixes."
+          ],
+          "titleDisplay": [
+            "Uṇādi-koṣaḥ / Dayānanda Sarasvatī Svāminā viracitayā Vaidika-laukika-koṣābhidhayā vyākhyayā sahitaḥ vividhābhi-ṣṭippaṇībhiḥ sūcībhiśca saṃyutaḥ ; sampādakaḥ Yudhiṣṭhiro Mīmāṃsakaḥ."
+          ],
+          "uri": "b10000030",
+          "lccClassification": [
+            "PK551 .U73"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Karanāla : Bahālagaḍha, Harayāṇa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000030"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000007",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKA 84-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012968222"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKA 84-1931"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012968222"
+                    ],
+                    "idBarcode": [
+                      "33433012968222"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKA 84-001931"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000031",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "W. Müller"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Neun Miniaturen : für Klavier : op. 52"
+          ],
+          "shelfMark": [
+            "JMG 83-17"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Petersen, Wilhelm, 1890-1957."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-17"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000031"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "W. Müller WM 1713 SM."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200030"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-C"
+          ],
+          "uniformTitle": [
+            "Miniaturen"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Heidelberg : W. Müller, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000031",
+            "urn:oclc:NYPG001000014-C",
+            "urn:undefined:W. Müller WM 1713 SM.",
+            "urn:undefined:NNSZ00100564",
+            "urn:undefined:(WaOLN)nyp0200030"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Neun Miniaturen : für Klavier : op. 52 / Wilhelm Petersen."
+          ],
+          "uri": "b10000031",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Heidelberg"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen",
+            "Miniaturen."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000031"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942035",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-17"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-17",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841631"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841631"
+                    ],
+                    "idBarcode": [
+                      "33433032841631"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000017"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000032",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14, 405, 7 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jahrom (Iran : Province)",
+            "Jahrom (Iran : Province) -- Biography",
+            "Khafr (Iran)",
+            "Khafr (Iran) -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kitābfurūshī-i Khayyām"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr"
+          ],
+          "shelfMark": [
+            "*OMP 84-2007"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ishrāq, Muḥammad Karīm."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2007"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200031"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tihrān : Kitābfurūshī-i Khayyām, 1351 [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000032",
+            "urn:oclc:NYPG001000015-B",
+            "urn:undefined:NNSZ00100015",
+            "urn:undefined:(WaOLN)nyp0200031"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jahrom (Iran : Province) -- Biography.",
+            "Khafr (Iran) -- Biography."
+          ],
+          "titleDisplay": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr / taʼlīf-i Muḥammad Karīm Ishrāq."
+          ],
+          "uri": "b10000032",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm"
+          ]
+        },
+        "sort": [
+          "b10000032"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2007",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173012"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2007"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173012"
+                    ],
+                    "idBarcode": [
+                      "33433013173012"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002007"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000033",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (20 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For voice and organ.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sacred songs (Medium voice) with organ",
+            "Psalms (Music)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Agápe"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Psalm settings"
+          ],
+          "shelfMark": [
+            "JMG 83-59"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Nelhybel, Vaclav."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-59"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000033"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100565"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200032"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Carol Stream, Ill. : Agápe, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000033",
+            "urn:oclc:NYPG001000015-C",
+            "urn:undefined:NNSZ00100565",
+            "urn:undefined:(WaOLN)nyp0200032"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sacred songs (Medium voice) with organ.",
+            "Psalms (Music)"
+          ],
+          "titleDisplay": [
+            "Psalm settings / Vaclav Nelhybel."
+          ],
+          "uri": "b10000033",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Carol Stream, Ill."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Hear me when I call -- Be not far from me -- Hear my voice -- The Lord is my rock."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000033"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942037",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-59",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-59"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942036",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-59",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842035"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-59"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842035"
+                    ],
+                    "idBarcode": [
+                      "33433032842035"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "366 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Brhatkathāślokasaṁgrahaḥ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Colophon: Iti Śrībhaṭṭabudhasvāminā krte ślokasaṁgrahe Brhatkathāyāṁ--",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Text in Sanskrit; apparatus in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Prithivi Prakashan"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brhatkathāślokasaṁgraha : a study"
+          ],
+          "shelfMark": [
+            "*OKR 84-2006"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Budhasvāmin."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903273"
+          ],
+          "seriesStatement": [
+            "Indian civilization series ; no. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Guṇāḍhya.",
+            "Agrawala, Vasudeva Sharana.",
+            "Agrawala, Prithvi Kumar."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKR 84-2006"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000034"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903273"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100016"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200033"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Varanasi : Prithivi Prakashan, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000034",
+            "urn:lccn:74903273",
+            "urn:oclc:NYPG001000016-B",
+            "urn:undefined:NNSZ00100016",
+            "urn:undefined:(WaOLN)nyp0200033"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Brhatkathāślokasaṁgraha : a study / by V.S. Agrawala ; with Sanskrit text, edited by P.K. Agrawala."
+          ],
+          "uri": "b10000034",
+          "lccClassification": [
+            "PK3794.B84 B7 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Varanasi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000034"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKR 84-2006",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011528696"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKR 84-2006"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011528696"
+                    ],
+                    "idBarcode": [
+                      "33433011528696"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKR 84-002006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000035",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "22 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Suite.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 12:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Serenade voor piano : 1980"
+          ],
+          "shelfMark": [
+            "JMG 83-6"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kasbergen, Marinus, 1936-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000035"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100566"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200034"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-C"
+          ],
+          "uniformTitle": [
+            "Serenade, piano"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000035",
+            "urn:oclc:NYPG001000016-C",
+            "urn:undefined:NNSZ00100566",
+            "urn:undefined:(WaOLN)nyp0200034"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Piano)"
+          ],
+          "titleDisplay": [
+            "Serenade voor piano : 1980 / Marinus Kasbergen."
+          ],
+          "uri": "b10000035",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Serenade"
+          ],
+          "tableOfContents": [
+            "Varianten -- Nocturne -- Toccata I -- Intermezzo -- Toccata II."
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000035"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942038",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841490"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-6"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841490"
+                    ],
+                    "idBarcode": [
+                      "33433032841490"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-6",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-6"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000036",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "viii, 38 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; prefatory matter in Sanskrit or Telegu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nārāyaṇatīrtha, 17th cent",
+            "Nārāyaṇatīrtha, 17th cent -- In literature"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic]"
+          ],
+          "shelfMark": [
+            "*OKB 84-1928"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75902755"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKB 84-1928"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000036"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902755"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200035"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[s.1. : s.n.], 1972"
+          ],
+          "identifier": [
+            "urn:bnum:10000036",
+            "urn:lccn:75902755",
+            "urn:oclc:NYPG001000017-B",
+            "urn:undefined:NNSZ00100017",
+            "urn:undefined:(WaOLN)nyp0200035"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nārāyaṇatīrtha, 17th cent -- In literature."
+          ],
+          "titleDisplay": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic] / praṇetā Garikapāṭi Lakṣmīkāntaḥ."
+          ],
+          "uri": "b10000036",
+          "lccClassification": [
+            "PK3799.L28 S68"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[s.1."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000036"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKB 84-1928"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKB 84-1928",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058548433"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKB 84-1928"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058548433"
+                    ],
+                    "idBarcode": [
+                      "33433058548433"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKB 84-001928"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000037",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13a p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 15:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Guitar)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Eight studies for guitar : in form of a suite : 1979"
+          ],
+          "shelfMark": [
+            "JMG 83-5"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hekster, Walter."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000037"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100567"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200036"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-C"
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000037",
+            "urn:oclc:NYPG001000017-C",
+            "urn:undefined:NNSZ00100567",
+            "urn:undefined:(WaOLN)nyp0200036"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Guitar)"
+          ],
+          "titleDisplay": [
+            "Eight studies for guitar : in form of a suite : 1979 / Walter Hekster."
+          ],
+          "uri": "b10000037",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies"
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000037"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841482"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-5"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841482"
+                    ],
+                    "idBarcode": [
+                      "33433032841482"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000005"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000038",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 160 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit, with verse and prose translations in Hindi; prefatory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit poetry",
+            "Sanskrit poetry -- Himachal Pradesh"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Himācala Kalā-Saṃskrti-Bhāṣā Akādamī"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana"
+          ],
+          "shelfMark": [
+            "*OKP 84-1932"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900772"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Prarthi, Lall Chand, 1916-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 84-1932"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000038"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900772"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200037"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Śimalā : Himācala Kalā-Saṃskrti-Bhāṣā Akādamī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000038",
+            "urn:lccn:76900772",
+            "urn:oclc:NYPG001000018-B",
+            "urn:undefined:NNSZ00100018",
+            "urn:undefined:(WaOLN)nyp0200037"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit poetry -- Himachal Pradesh."
+          ],
+          "titleDisplay": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana / mukhya sampādaka Lāla Canda Prārthī ; sampādaka maṇḍala, Manasā Rāma Śarmā 'Arūṇa'...[et al.]."
+          ],
+          "uri": "b10000038",
+          "lccClassification": [
+            "PK3800.H52 R7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Śimalā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000038"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783788",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 84-1932",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 84-1932"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153572"
+                    ],
+                    "idBarcode": [
+                      "33433058153572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKP 84-001932"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000039",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "49 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "C.F. Peters"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Five sonatas for pianoforte"
+          ],
+          "shelfMark": [
+            "JMG 83-66"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hässler, Johann Wilhelm, 1747-1822."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Oberdoerffer, Fritz."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000039"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters no. 66799. C.F. Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100568"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200038"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-C"
+          ],
+          "uniformTitle": [
+            "Sonatas, piano. Selections"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000039",
+            "urn:oclc:NYPG001000018-C",
+            "urn:undefined:Edition Peters no. 66799. C.F. Peters",
+            "urn:undefined:NNSZ00100568",
+            "urn:undefined:(WaOLN)nyp0200038"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Five sonatas for pianoforte / Johann Wilhelm Hässler ; edited by Fritz Oberdoerffer."
+          ],
+          "uri": "b10000039",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatas"
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000039"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842100"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-66"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842100"
+                    ],
+                    "idBarcode": [
+                      "33433032842100"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000066"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000040",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "146 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār."
+          ],
+          "shelfMark": [
+            "*OLB 84-1947"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Pulavar Arasu, 1900-"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "78913375"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 672"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1947"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000040"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78913375"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200039"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000040",
+            "urn:lccn:78913375",
+            "urn:oclc:NYPG001000019-B",
+            "urn:undefined:NNSZ00100019",
+            "urn:undefined:(WaOLN)nyp0200039"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953."
+          ],
+          "titleDisplay": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār. Āciriyar Pulavar Aracu."
+          ],
+          "uri": "b10000040",
+          "lccClassification": [
+            "PL4758.9.K223 Z83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000040"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783789",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1947",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301622"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1947"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301622"
+                    ],
+                    "idBarcode": [
+                      "33433061301622"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001947"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000041",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (23 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 5 clarinets.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Woodwind quintets (Clarinets (5))",
+            "Woodwind quintets (Clarinets (5)) -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Primavera"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Encounter"
+          ],
+          "shelfMark": [
+            "JMF 83-66"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Usher, Julia."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "81770739"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000041"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770739"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100569"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200040"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Primavera, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000041",
+            "urn:lccn:81770739",
+            "urn:oclc:NYPG001000019-C",
+            "urn:undefined:NNSZ00100569",
+            "urn:undefined:(WaOLN)nyp0200040"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Woodwind quintets (Clarinets (5)) -- Scores."
+          ],
+          "titleDisplay": [
+            "Encounter / Julia Usher."
+          ],
+          "uri": "b10000041",
+          "lccClassification": [
+            "M557.2.U8 E5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Greeting -- Circular argument -- Escape."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000041"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709291"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-66"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709291"
+                    ],
+                    "idBarcode": [
+                      "33433032709291"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000066"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000042",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 108 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit: pref. in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Advaita",
+            "Vedanta"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Devabhāṣā Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "dateEndString": [
+            "1972"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita."
+          ],
+          "shelfMark": [
+            "*OKN 84-1926"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902870"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Brahmashram, Śwami, 1915-"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 84-1926"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000042"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902870"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100020"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200041"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-B"
+          ],
+          "uniformTitle": [
+            "Mahābhārata. Sanatsugātīya."
+          ],
+          "dateEndYear": [
+            1972
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Prayāga, Devabhāṣā Prakāśana, Samvat 2028, i.e. 1971 or 2]"
+          ],
+          "identifier": [
+            "urn:bnum:10000042",
+            "urn:lccn:72902870",
+            "urn:oclc:NYPG001000020-B",
+            "urn:undefined:NNSZ00100020",
+            "urn:undefined:(WaOLN)nyp0200041"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Advaita.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita. Vyākhyātā Svāmī Brahmāśrama."
+          ],
+          "uri": "b10000042",
+          "lccClassification": [
+            "B132.V3 M264"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Prayāga"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000042"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783790",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 84-1926"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 84-1926",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618392"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKN 84-1926"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618392"
+                    ],
+                    "idBarcode": [
+                      "33433058618392"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 84-001926"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (28 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 2 flutes, 2 oboes, 2 clarinets, 2 horns, and 2 bassoons.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 5:00-6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: D.15 579.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Wind ensembles",
+            "Wind ensembles -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Verlag Doblinger"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Capriccio : für 10 Blasinstrumente"
+          ],
+          "shelfMark": [
+            "JMC 83-9"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Eröd, Iván."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Doblingers Studienpartituren ; Stp. 410"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMC 83-9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000043"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Stp. 410 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "D.15 579 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100570"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200042"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Wien : Verlag Doblinger, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000043",
+            "urn:oclc:NYPG001000020-C",
+            "urn:undefined:Stp. 410 Verlag Doblinger",
+            "urn:undefined:D.15 579 Verlag Doblinger",
+            "urn:undefined:NNSZ00100570",
+            "urn:undefined:(WaOLN)nyp0200042"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Wind ensembles -- Scores."
+          ],
+          "titleDisplay": [
+            "Capriccio : für 10 Blasinstrumente / Iván Eröd."
+          ],
+          "uri": "b10000043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wien"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000043"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMC 83-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMC 83-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004744128"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMC 83-9"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004744128"
+                    ],
+                    "idBarcode": [
+                      "33433004744128"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMC 83-000009"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000044",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[99] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Biographies of Khri-chen Byaṅ-chub-chos-ʼphel and Śel-dkar Bla-ma Saṅs-rgyas-bstan-ʼphel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from prints from blocks from Lhasa and Śel-dkar Dgaʼ-ldan-legs-bśad-gliṅ.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884",
+            "Lamas",
+            "Lamas -- Tibet",
+            "Lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ngawang Sopa"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2361"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rgal-dbaṅ Chos-rje Blo-bzaṅ-ʼphrin-las-rnam-rgyal, active 1840-1860."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77901316"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ngag-dbang-blo-bzang-rgya-mtsho, Dalai Lama V, 1617-1682."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2361"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000044"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77901316"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000021-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100021"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200043"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000021-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "New Delhi : Ngawang Sopa, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000044",
+            "urn:lccn:77901316",
+            "urn:oclc:NYPG001000021-B",
+            "urn:undefined:NNSZ00100021",
+            "urn:undefined:(WaOLN)nyp0200043"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838.",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884.",
+            "Lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel / by Dar-han Mkhan-sprul Blo-bzaṅ-ʼphrin-las-rnam-rgyal. Bkaʼ-gdams bstan-paʼi mdzod-ʼdzin Rje-btsun Bla-ma Saṅs-rgyas-bstan-ʼphel dpal-bzaṅ-poʼi rnam par thar pa dad ldan yid kyi dgaʼ ston : the biography of Saṅs-rgyas-bstan-ʼphel of Śel-dkar / by Śel-dkar Bkaʼ-ʼgyur Bla-ma Ṅag-dbaṅ-blo-bzaṅ-bstan-ʼdzin-tshul-khrims-rgyal-mtshan."
+          ],
+          "uri": "b10000044",
+          "lccClassification": [
+            "BQ942.Y367 R47 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000044"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000011",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2361",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080645"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080645"
+                    ],
+                    "idBarcode": [
+                      "33433015080645"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002361"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000045",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "12 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Violin music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sole selling agents, Or-Tav"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Thoughts & feelings : for violin solo"
+          ],
+          "shelfMark": [
+            "JMG 82-688"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stutschewsky, Joachim, 1891-1982."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "80770813"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 82-688"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000045"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80770813"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000021-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100571"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200044"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000021-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tel-Aviv : Sole selling agents, Or-Tav, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000045",
+            "urn:lccn:80770813",
+            "urn:oclc:NYPG001000021-C",
+            "urn:undefined:NNSZ00100571",
+            "urn:undefined:(WaOLN)nyp0200044"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Violin music."
+          ],
+          "titleDisplay": [
+            "Thoughts & feelings : for violin solo / Joachim Stutschewsky."
+          ],
+          "uri": "b10000045",
+          "lccClassification": [
+            "M42 .S"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tel-Aviv"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000045"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942043",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 82-688"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 82-688",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032707568"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 82-688"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032707568"
+                    ],
+                    "idBarcode": [
+                      "33433032707568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 82-000688"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000046",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[83] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Kye rdor rnam bśad.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from tracing and manuscripts from the library of Mkhan-po Rin-chen by Trayang and Jamyang Samten.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456",
+            "Tripiṭaka.",
+            "Tripiṭaka. -- Commentaries",
+            "Sa-skya-pa lamas",
+            "Sa-skya-pa lamas -- Tibet",
+            "Sa-skya-pa lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Trayang and Jamyang Samten"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2362"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Tshe-dbaṅ-rdo-rje-rig-ʼdzin, Prince of Sde-dge."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77900893"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sangs-rgyas-phun-tshogs, Ngor-chen, 1649-1705."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000046"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77900893"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000022-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100022"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200045"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000022-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "New Delhi : Trayang and Jamyang Samten, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000046",
+            "urn:lccn:77900893",
+            "urn:oclc:NYPG001000022-B",
+            "urn:undefined:NNSZ00100022",
+            "urn:undefined:(WaOLN)nyp0200045"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456.",
+            "Tripiṭaka. -- Commentaries.",
+            "Sa-skya-pa lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra / by Sde-dge Yab-chen Tshe-dbaṅ-rdo-rje-rig-ʼdzin alias Byams-pa-kun-dgaʼ-bstan-paʼi-rgyal-mtshan. Rgyal ba Rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas : the life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po / by Ṅor-chen Saṅs-rgyas-phun-tshogs."
+          ],
+          "uri": "b10000046",
+          "lccClassification": [
+            "BG974.0727 T75"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "titleAlt": [
+            "Rgyal ba rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas.",
+            "Detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra.",
+            "Life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000046"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080413"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080413"
+                    ],
+                    "idBarcode": [
+                      "33433015080413"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002362"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000047",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (30 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"This work was written between 14 March and 1 May, 1979\"--verso t.p.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 15 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vocalises (High voice) with instrumental ensemble",
+            "Vocalises (High voice) with instrumental ensemble -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello"
+          ],
+          "shelfMark": [
+            "JMG 83-79"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "81770634"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-79"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000047"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770634"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000022-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100572"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200046"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000022-C"
+          ],
+          "uniformTitle": [
+            "Vocalise, soprano, instrumental ensemble, op. 38"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London, England (Arlington Park House, London W4) : Redcliffe Edition, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000047",
+            "urn:lccn:81770634",
+            "urn:oclc:NYPG001000022-C",
+            "urn:undefined:NNSZ00100572",
+            "urn:undefined:(WaOLN)nyp0200046"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vocalises (High voice) with instrumental ensemble -- Scores."
+          ],
+          "titleDisplay": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello / Francis Routh."
+          ],
+          "uri": "b10000047",
+          "lccClassification": [
+            "M1613.3 .R8 op.38"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London, England (Arlington Park House, London W4)"
+          ],
+          "titleAlt": [
+            "Vocalise, op. 38"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "38 cm."
+          ]
+        },
+        "sort": [
+          "b10000047"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942044",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-79"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-79",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842233"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-79"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842233"
+                    ],
+                    "idBarcode": [
+                      "33433032842233"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000079"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000048",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[150] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a MS. preserved at Pha-lo-ldiṅ Monastery in Bhutan.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Buddhism",
+            "Buddhism -- Rituals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kunzang Topgey"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2382"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901012"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2382"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000048"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000023-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100023"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200047"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000023-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Thimphu : Kunzang Topgey, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000048",
+            "urn:lccn:76901012",
+            "urn:oclc:NYPG001000023-B",
+            "urn:undefined:NNSZ00100023",
+            "urn:undefined:(WaOLN)nyp0200047"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Buddhism -- Rituals."
+          ],
+          "titleDisplay": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "uri": "b10000048",
+          "lccClassification": [
+            "BQ7695 .B55"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Thimphu"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 38 cm."
+          ]
+        },
+        "sort": [
+          "b10000048"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2382",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080439"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080439"
+                    ],
+                    "idBarcode": [
+                      "33433015080439"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002382"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000049",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (105 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 25 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Symphony, op. 26 : full score"
+          ],
+          "shelfMark": [
+            "JMG 83-80"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "81770641"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-80"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000049"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770641"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000023-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100573"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200048"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000023-C"
+          ],
+          "uniformTitle": [
+            "Symphony, op. 26"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "London (Arlington Park House, London W4 4HD) : Redcliffe Edition, c1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000049",
+            "urn:lccn:81770641",
+            "urn:oclc:NYPG001000023-C",
+            "urn:undefined:NNSZ00100573",
+            "urn:undefined:(WaOLN)nyp0200048"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "Symphony, op. 26 : full score / Francis Routh."
+          ],
+          "uri": "b10000049",
+          "lccClassification": [
+            "M1001 .R8615 op.26"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London (Arlington Park House, London W4 4HD)"
+          ],
+          "titleAlt": [
+            "Symphony, op. 26"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000049"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942045",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-80"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-80",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842241"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-80"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842241"
+                    ],
+                    "idBarcode": [
+                      "33433032842241"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000080"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000050",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[188] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a print from the early 16th century western Tibetan blocks by Urgyan Dorje.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?",
+            "Bkaʼ-brgyud-pa lamas",
+            "Bkaʼ-brgyud-pa lamas -- Tibet",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography",
+            "Spiritual life",
+            "Spiritual life -- Buddhism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Urgyan Dorje"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2381"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901747"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2381"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000050"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901747"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000024-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100024"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200049"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000024-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "New Delhi : Urgyan Dorje, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000050",
+            "urn:lccn:76901747",
+            "urn:oclc:NYPG001000024-B",
+            "urn:undefined:NNSZ00100024",
+            "urn:undefined:(WaOLN)nyp0200049"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography.",
+            "Spiritual life -- Buddhism."
+          ],
+          "titleDisplay": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "uri": "b10000050",
+          "lccClassification": [
+            "BQ942.A187 A35 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000050"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2381",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080421"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080421"
+                    ],
+                    "idBarcode": [
+                      "33433015080421"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002381"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000051",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "score (64 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Samfundet til udgivelse af dansk musik"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972"
+          ],
+          "shelfMark": [
+            "JMG 83-75"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Christiansen, Henning."
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "idLccn": [
+            "78770955"
+          ],
+          "seriesStatement": [
+            "[Publikation] - Samfundet til udgivelse af dansk musik : 3. serie, nr. 264"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-75"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000051"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78770955"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000024-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100574"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200050"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000024-C"
+          ],
+          "uniformTitle": [
+            "Symphony, no. 2, op. 69c",
+            "Samfundet til udgivelse af dansk musik (Series) ; 3. ser., nr. 264."
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "København : Samfundet til udgivelse af dansk musik, 1977."
+          ],
+          "identifier": [
+            "urn:bnum:10000051",
+            "urn:lccn:78770955",
+            "urn:oclc:NYPG001000024-C",
+            "urn:undefined:NNSZ00100574",
+            "urn:undefined:(WaOLN)nyp0200050"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972 / Henning Christiansen."
+          ],
+          "uri": "b10000051",
+          "lccClassification": [
+            "M1001 .C533 op.69c"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "København"
+          ],
+          "titleAlt": [
+            "Symphony, no. 2, op. 69c",
+            "Den forsvundne."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "37 cm."
+          ]
+        },
+        "sort": [
+          "b10000051"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942046",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-75"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-75",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842191"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-75"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842191"
+                    ],
+                    "idBarcode": [
+                      "33433032842191"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000075"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-c9ae77b14dc7053c80e7ade9f7258695.json
+++ b/test/fixtures/query-c9ae77b14dc7053c80e7ade9f7258695.json
@@ -1,0 +1,27 @@
+{
+  "took": 15,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 0,
+    "hits": []
+  },
+  "aggregations": {
+    "statuses": {
+      "doc_count": 2,
+      "nonrecap_statuses": {
+        "doc_count": 1,
+        "nonrecap_status_buckets": {
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+          "buckets": []
+        }
+      }
+    }
+  }
+}

--- a/test/fixtures/query-cd08514c371a97a1d632d2cae77e614b.json
+++ b/test/fixtures/query-cd08514c371a97a1d632d2cae77e614b.json
@@ -1,0 +1,229 @@
+{
+  "took": 45,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 33.05313,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "pb1717",
+        "_score": 33.05313,
+        "_source": {
+          "extent": [
+            "x, 340 p. : ill. ;"
+          ],
+          "subjectLiteral_exploded": [
+            "Cats",
+            "Cats -- Fiction",
+            "Cats"
+          ],
+          "publisherLiteral": [
+            "Lothrop, Lee & Shepard Books,"
+          ],
+          "description": [
+            "More than 40 stories and essays about cats by famous writers."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cat encounters : a cat-lover's anthology /"
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "   79002437 "
+          ],
+          "contributorLiteral": [
+            "Lewis, Gogo.",
+            "Manley, Seon."
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "1717"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0688419143"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "   79002437 "
+            }
+          ],
+          "updatedAt": 1523549727960,
+          "publicationStatement": [
+            "New York : Lothrop, Lee & Shepard Books, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:1717",
+            "urn:isbn:0688419143",
+            "urn:lccn:   79002437 "
+          ],
+          "idIsbn": [
+            "0688419143"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cats -- Fiction.",
+            "Cats."
+          ],
+          "titleDisplay": [
+            "Cat encounters : a cat-lover's anthology / selected by Seon Manley & Gogo Lewis."
+          ],
+          "uri": "pb1717",
+          "lccClassification": [
+            "SF445.5 .C378"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "identifier": [
+                      "urn:barcode:32101087644330"
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available "
+                    ],
+                    "uri": "pi2775",
+                    "shelfMark": [
+                      "SF445.5 .C378"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "SF445.5 .C378"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101087644330"
+                      }
+                    ],
+                    "idBarcode": [
+                      "32101087644330"
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available "
+                      }
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-d054cfe113815a4ebac30b02ba46ea20.json
+++ b/test/fixtures/query-d054cfe113815a4ebac30b02ba46ea20.json
@@ -1,0 +1,918 @@
+{
+  "took": 354,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 51.423527,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 51.423527,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-d6915c707f4994db87b41a3b4e9fdfa2.json
+++ b/test/fixtures/query-d6915c707f4994db87b41a3b4e9fdfa2.json
@@ -1,0 +1,918 @@
+{
+  "took": 60,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.902664,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b22144813",
+        "_score": 14.902664,
+        "_source": {
+          "extent": [
+            "1234, [1] pages, x leaves : illustrations ;",
+            "1234, [1] p., x leaves : ill. ;",
+            "Third description instance : More 3rd instance ;"
+          ],
+          "partOf": [
+            "In: -- 773 0b"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Publication Date  (unformated) -- 362 1b"
+          ],
+          "publisherLiteral": [
+            "Specious Publ. [prev.pub.-- 260.2b]",
+            "CopyCat pub. co. -- 260 bb"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            201
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "parallelTitle": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "shelfMark": [
+            "Q-TAG (852 8b q tag.  Staff call in bib.)"
+          ],
+          "idLccn": [
+            "LCCN -- 010",
+            "9790001138673",
+            "ISMN",
+            "Danacode",
+            "UPC",
+            "EAN"
+          ],
+          "idIssn": [
+            "ISSN -- 022"
+          ],
+          "seriesStatement": [
+            "440 Series ; v. number -- 440 b0",
+            "490 Series ; v. number  -- 490 0b",
+            "Author, of series. CMA Test Records. -- 800 1b",
+            "CMA (Cat). CMA Test Records -- 810 2b "
+          ],
+          "dateStartYear": [
+            201
+          ],
+          "parallelCreatorLiteral": [
+            "‏גלוגר,מרים פ."
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Q-TAG (852 8b q tag.  Staff call in bib.)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "22144813"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0123456789"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780123456786 (qualifier)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "ISBN -- 020"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "ISSN -- 022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "LCCN -- 010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "9790001138673"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "ISMN"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "Danacode"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "UPC"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "EAN"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Report number. -- 027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Publisher no. -- 028 02  "
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Standard number (old RLIN, etc.) -- 035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Sudoc no.  -- 086"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "GPO Item number. -- 074"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "ISBN -- 020 $z"
+            }
+          ],
+          "formerTitle": [
+            "Former title -- 247 00"
+          ],
+          "updatedAt": 1659464869747,
+          "publicationStatement": [
+            "[s.l.] : Specious Publ. [prev.pub.-- 260.2b], 2001. ",
+            "Long Island CIty, N.Y. : CopyCat pub. co. -- 260 bb, 2011.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "identifier": [
+            "urn:bnum:22144813",
+            "urn:isbn:0123456789",
+            "urn:isbn:9780123456786 (qualifier)",
+            "urn:isbn:ISBN -- 020",
+            "urn:issn:ISSN -- 022",
+            "urn:lccn:LCCN -- 010",
+            "urn:lccn:9790001138673",
+            "urn:lccn:ISMN",
+            "urn:lccn:Danacode",
+            "urn:lccn:UPC",
+            "urn:lccn:EAN",
+            "urn:undefined:Report number. -- 027",
+            "urn:undefined:Publisher no. -- 028 02  ",
+            "urn:undefined:Standard number (old RLIN, etc.) -- 035",
+            "urn:undefined:Sudoc no.  -- 086",
+            "urn:undefined:GPO Item number. -- 074",
+            "b22144813#1.0051",
+            "urn:isbn:ISBN -- 020 $z"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Starving artist -- 600 00.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term -- 653"
+          ],
+          "numAvailable": [
+            1
+          ],
+          "titleAlt": [
+            "Abrev. title -- 210 ",
+            "Key title --  222 ",
+            "T tagged 240 Uniform title -- t240",
+            "Portion of title  \\\\DO NOT DISPLAY\\\\ --  246 10",
+            "Parallel title \\\\DO NOT DISPLAY\\\\ -- 246 11",
+            "Portion of title 246 30",
+            "Parallel title 246 31",
+            "Distinctive title 246 12",
+            "Other title 246 13",
+            "Cover title 246 14",
+            "Cover title 246 04",
+            "Added title page title 246 15",
+            "Running title 246 17",
+            "Caption title 246 16",
+            "Spine title 246 18",
+            "No type of title specified 246 3 blank",
+            "246 1 blank",
+            "Zaglavie Russiĭi",
+            "Added title -- 740 0b"
+          ],
+          "tableOfContents": [
+            "Complete table of contents.   -- 505 0b",
+            "1. Incomplete table of contents. -- First instance.-- 505 1b",
+            "2. Incomplete table of contents -- Second  instance. 505 1b",
+            "3. Incomplete table of contents -- Third instance entered out of order. 505 1b",
+            "Title subfield $t and author subfield $r and miscellaneous subfield $g in enahnced contents field 505 10."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Ordinary note. -- 500",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "²³¹",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "¯¯¯\\⠀⠀⠀⠀⠀⠀⠀⠀/¯¯¯",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "⠀⠀⠀\\___(  ツ   )___/",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "With",
+              "label": "Bound with note. -- 501",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Thesis",
+              "label": "Thesis -- (degree) note.  -- 502",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [1235]). -- 504",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Access -- 506 blank,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Access",
+              "label": "Restricted Access -- 506 1,any",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Scale",
+              "label": "Scale (graphic) -- 507",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Credits",
+              "label": "Credits (Creation/production credits note) -- 508",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Performer",
+              "label": "Cast --511 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Type of Report",
+              "label": "Type of Report. -- 513",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Data Quality",
+              "label": "Data quality -- 514",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Completely irregular. -- 515",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "File Type",
+              "label": "File type. -- 516",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Event",
+              "label": "Event. -- 518",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience: Rated for Catalogers and Metadata Junkies only -- 521",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Audience",
+              "label": "Audience (2): Test of 2nd 521 field.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Coverage",
+              "label": "Coverage -- 522",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Cite As",
+              "label": "Cite as: The Mega-MARC test record. -- 524",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Supplement",
+              "label": "Supplement -- 525",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Study Program",
+              "label": "Study program -- 526 8b ",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Additional Formats",
+              "label": "Other test records available. -- 530",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Original Location",
+              "label": "Original location in SASB -- 535",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Funding",
+              "label": "Funding -- 536",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "System Details",
+              "label": "System Details  -- 538",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Terms of Use",
+              "label": "Use as test record  -- 540",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source display-- 5411b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source",
+              "label": "Source \\\\DO NOT DISPLAY\\\\ -- 541 bb $a",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Location of Other Archival Materials",
+              "label": "Location of Other Archival Materials -- 544",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 545",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Biography",
+              "label": "Biography -- 5451 Administrative history",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In English and non-roman scripts. -- 546",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Former Title",
+              "label": "Former title (complexity note) -- 547",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by CCO -- 550",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Indexes -- 555 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Documentation",
+              "label": "Documentation (information about, note) -- 556",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance display --5611b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Provenance",
+              "label": "Provenance \\\\DO NOT DISPLAY\\\\ -- 561 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Copy/Version",
+              "label": "Copy/Version (identification note) -- 562",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Binding",
+              "label": "Binding  -- 563",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Complemented by Linking entry: Bogus title -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Linking Entry",
+              "label": "Linking Entry (complexity note) -- 580",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Publications",
+              "label": "Publications (about described material note) -- 581",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action display --583 1b",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Processing Action",
+              "label": "Processing Action \\\\DO NOT DISPLAY\\\\ -- 583 bb",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Exhibitions",
+              "label": "Exhibitions -- 585",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Awards",
+              "label": "Awards -- 586",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: 1900/1901. -- 588 1b",
+              "type": "bf:Note"
+            }
+          ],
+          "subjectLiteral_exploded": [
+            "Starving artist",
+            "Starving artist -- 600 00",
+            "Artist, Starving, 1900-1999",
+            "Artist, Starving, 1900-1999 -- Autobiography.",
+            "Artist, Starving, 1900-1999 -- Autobiography. -- 600 10 with $d $v",
+            "testing 4 testing a testing b testing c testing d testing e testing g",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Corporate body subject.",
+            "Corporate body subject. --  610 20",
+            "Secret Society of Catalogers",
+            "Secret Society of Catalogers -- Periodicals.",
+            "Secret Society of Catalogers -- Periodicals. -- 610 20 $v",
+            "testing x as first subfield",
+            "testing x as first subfield -- testing v as second subfield.",
+            "testing x as first subfield -- testing v as second subfield. -- 610 10 $x$v only",
+            "Conference subject entry.",
+            "Conference subject entry. --  611 20",
+            "Stonecutters' Annual Picnic 1995 : Springfield)",
+            "Stonecutters' Annual Picnic 1995 : Springfield) -- 611 20 $n, $d, $c",
+            "testing 4 testing a testing c testing d testing e testing g",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing c testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Uniform title",
+            "Life is a common square.",
+            "Life is a common square. -- Criticism.",
+            "Life is a common square. -- Criticism. -- 630 00 $l, $x",
+            "testing 4 testing a testing d testing e testing g",
+            "testing 4 testing a testing d testing e testing g -- testing v",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing d testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Textile industry testing datetesting",
+            "Textile industry testing datetesting -- 650 b0 $z, $x",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India",
+            "Textile industry testing datetesting -- 650 b0 $z, $x -- India -- History",
+            "testing 4 testing a testing b testing c testing d testing e",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing b testing c testing d testing e -- testing v -- testing x -- testing y -- testing z",
+            "New York (N.Y.)",
+            "New York (N.Y.) -- 21st century",
+            "New York (N.Y.) -- 21st century -- Diaries.",
+            "New York (N.Y.) -- 21st century -- Diaries. -- 651 b0 $y, $x",
+            "Undiscovered country.",
+            "Undiscovered country. -- 651 b0",
+            "testing 4 testing a testing e testing g",
+            "testing 4 testing a testing e testing g -- testing v",
+            "testing 4 testing a testing e testing g -- testing v -- testing x",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y",
+            "testing 4 testing a testing e testing g -- testing v -- testing x -- testing y -- testing z",
+            "Indexed term",
+            "Indexed term -- 653"
+          ],
+          "description": [
+            "This record was originally created as a test record in CATNYP.  It was greatly expanded in ILS-STAFF to test the public display of various MARC fields. -- 520 (first)",
+            "Use this record to test CATALOG, OPAC, ENCORE, and BIBLIOCOMMONS display of MARC fields -- 520 (second)"
+          ],
+          "dateEndString": [
+            "2011"
+          ],
+          "title": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Maintenance test record-- 245 $b"
+          ],
+          "creatorLiteral": [
+            "Gloger, Miriam.",
+            "BookOps. Cataloging. --110 2b ab.",
+            "Congress (13th : 2013 : LIC, Queens) -- 111 2b (ndc)"
+          ],
+          "createdString": [
+            "201"
+          ],
+          "numElectronicResources": [
+            4
+          ],
+          "contributorLiteral": [
+            "Cramer, Richard, 1948-.",
+            "Cramer, Richard, 1948-",
+            "Bayer, Jeffrey.",
+            "Bayer, Jeffrey",
+            "New York Public Library Database Management Group. -- 710 2b",
+            "Conference added author.  711 2b",
+            "Added entry (uncontrolled name) -- 7201",
+            "Cramer, Richard, 1948- fmo",
+            "Virtual collection -- 791 2b"
+          ],
+          "donor": [
+            "Donor / Sponsor --  799 bb"
+          ],
+          "uniformTitle": [
+            "T tagged 240 Uniform title -- t240",
+            "Added title -- 730 0b",
+            "CMA Test Records -- 830 b0"
+          ],
+          "dateEndYear": [
+            2011
+          ],
+          "parallelTitleAlt": [
+            "",
+            "‏зглавие руссий"
+          ],
+          "idIsbn": [
+            "0123456789",
+            "9780123456786 (qualifier)",
+            "ISBN -- 020"
+          ],
+          "genreForm": [
+            "Genre heading.",
+            "Blank pages and looks – Someplace – 1990.",
+            "testing a – testing b – testing c – testing v – testing x – testing y – testing z"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "201"
+          ],
+          "titleDisplay": [
+            "Life is a strange circle (updated 20180627) --245 10 $a, Test record --$k current April 19, 2013 --$f, Testing period --$g [Virtual-- 245 $h] (245-- $n) Titles, includes RDA specific fields -- 245 $p : Maintenance test record-- 245 $b,  Version--$s / CMA division -- 245 $c."
+          ],
+          "uri": "b22144813",
+          "numItems": [
+            2
+          ],
+          "parallelTitleDisplay": [
+            "‏כותר שאינו באותיות לטינית = зглавие руссий."
+          ],
+          "placeOfPublication": [
+            "[s.l.]",
+            "Long Island CIty, N.Y.",
+            "Production -- 264 b0 (RDA) ",
+            "Publisher -- 264 b1 (RDA)",
+            "Distributor -- 264 b2 (RDA)",
+            "Manufacturer -- 264 b3 (RDA)",
+            "Copyright Date -- 264 b4 (RDA)",
+            "Earlier Publisher -- 264 21 (RDA)",
+            "Earlier Distributor -- 264 22 (RDA)",
+            "Earlier Manufacturer -- 264 23 (RDA)",
+            "Earlier Copyright Date -- 264 24 (RDA)",
+            "Latest Publisher -- 264 31 (RDA)",
+            "Latest Distributor -- 264 32 (RDA)",
+            "Latest Manufacturer -- 264 33 (RDA)",
+            "Latest Copyright Date -- 264 34 (RDA)"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "supplementaryContent": [
+            {
+              "label": "Contents",
+              "url": "http://www.ilibri.casalini.it/toc/07260245.pdf"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-42-supplementary.com/"
+            },
+            {
+              "url": "http://www.ThereIsNoLabelSubfieldInThis856-4b-supplementary.com/"
+            }
+          ],
+          "idIsbn_clean": [
+            "0123456789",
+            "9780123456786",
+            "020"
+          ],
+          "dimensions": [
+            "26 cm +",
+            "26 cm. +",
+            "More 3rd instance -- 300 (3rd instance)"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 1,
+              "max_score": 1,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": 1,
+                  "_source": {
+                    "uri": "i22144813-e",
+                    "electronicLocator": [
+                      {
+                        "url": "http://blogs.nypl.org/rcramer/",
+                        "label": "856 40"
+                      },
+                      {
+                        "url": "http://yizkor.nypl.org/index.php?id=2936",
+                        "label": "Yizkor Book  (NYPL resource) 856 41"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-40-fulltext.com/"
+                      },
+                      {
+                        "url": "http://www.ThereIsNoLabelSubfieldInThis856-41-fulltext.com/"
+                      }
+                    ],
+                    "shelfMark_sort": "bi22144813-e"
+                  }
+                }
+              ]
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857771",
+                    "status": [
+                      {
+                        "id": "status:k",
+                        "label": "Check with staff"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:k||Check with staff"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mall1",
+                        "label": "Schwarzman Building - Main Reading Room 315 - Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mall1||Schwarzman Building - Main Reading Room 315 - Reference"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER v.1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "3333333333"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "v.1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:3333333333"
+                    ],
+                    "idBarcode": [
+                      "3333333333"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER v.000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37857772",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1103",
+                        "label": "Dorot Jewish Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1103||Dorot Jewish Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmf2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmf2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER nothing",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "44455533322211"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "J-LANG FORMAT Branch --  091 (C-Tag Branch call) Biographee CUTTER"
+                    ],
+                    "enumerationChronology": [
+                      "nothing"
+                    ],
+                    "identifier": [
+                      "urn:barcode:44455533322211"
+                    ],
+                    "idBarcode": [
+                      "44455533322211"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aJ-LANG FORMAT Branch -- 091 (C-Tag Branch call) Biographee CUTTER nothing"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-d9cd1cdcbf439915ea5376c0fd8a9cf8.json
+++ b/test/fixtures/query-d9cd1cdcbf439915ea5376c0fd8a9cf8.json
@@ -1,0 +1,14445 @@
+{
+  "took": 418,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 2405022,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000004",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "23, 216 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1956.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mutaṟkuṟaḷ uvamai."
+          ],
+          "shelfMark": [
+            "*OLB 84-1934"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kothandapani Pillai, K., 1896-"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "74915265"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1247"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1934"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000004"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74915265"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200003"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tirunelvēli, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1965."
+          ],
+          "identifier": [
+            "urn:bnum:10000004",
+            "urn:lccn:74915265",
+            "urn:oclc:NYPG001000001-B",
+            "urn:undefined:NNSZ00100001",
+            "urn:undefined:(WaOLN)nyp0200003"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Mutaṟkuṟaḷ uvamai. Āciriyar Ku. Kōtaṇṭapāṇi Piḷḷai."
+          ],
+          "uri": "b10000004",
+          "lccClassification": [
+            "PL4758.9.T5 K6 1965"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirunelvēli"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000004"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783781",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1934",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1934"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301556"
+                    ],
+                    "idBarcode": [
+                      "33433061301556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001934"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000006",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "227 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of The reconstruction of religious thought in Islam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām"
+          ],
+          "shelfMark": [
+            "*OGC 84-1984"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Iqbal, Muhammad, Sir, 1877-1938."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75962707"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Maḥmūd, ʻAbbās."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1984"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000006"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75962707"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100002"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200005"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "al-Qāhirah, Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000006",
+            "urn:lccn:75962707",
+            "urn:oclc:NYPG001000002-B",
+            "urn:undefined:NNSZ00100002",
+            "urn:undefined:(WaOLN)nyp0200005"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām, taʼlif Muhammad Iqbāl. Tarjamat ʻAbbās Maḥmūd. Rājaʻa muqaddimatahu wa-al-faṣl al-awwal minhu ʻAbd al-ʻAzīz al-Maraghī, wa-rājaʻa baqīyat al-Kitāb Mahdī ʻAllām."
+          ],
+          "uri": "b10000006",
+          "lccClassification": [
+            "BP161 .I712 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000006"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691665"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1984"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691665"
+                    ],
+                    "idBarcode": [
+                      "33433022691665"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001984"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000008",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "351 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Parimaḷam Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṇṇāviṉ ciṟukataikaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1986"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Annadurai, C. N., 1909-1969."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913998"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1986"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000008"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913998"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100003"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200007"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Parimaḷam Patippakam [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000008",
+            "urn:lccn:72913998",
+            "urn:oclc:NYPG001000003-B",
+            "urn:undefined:NNSZ00100003",
+            "urn:undefined:(WaOLN)nyp0200007"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Aṇṇāviṉ ciṟukataikaḷ. [Eḻutiyavar] Ci. Eṉ. Aṇṇāturai."
+          ],
+          "uri": "b10000008",
+          "lccClassification": [
+            "PL4758.9.A5 A84"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000008"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783782",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1986",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301689"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1986"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301689"
+                    ],
+                    "idBarcode": [
+                      "33433061301689"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001986"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000010",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "110 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cēkkiḻār, active 12th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaikkaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1938"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Irācamāṇikkaṉār, Mā., 1907-1967."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913466"
+          ],
+          "seriesStatement": [
+            "Corṇammāḷ corpoḻivu varicai, 6"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1938"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100004"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200009"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Aṇṇāmalainakar, Aṇṇāmalaip Palkalaikkaḻakam, 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000010",
+            "urn:lccn:72913466",
+            "urn:oclc:NYPG001000004-B",
+            "urn:undefined:NNSZ00100004",
+            "urn:undefined:(WaOLN)nyp0200009"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cēkkiḻār, active 12th century."
+          ],
+          "titleDisplay": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ. [Āṟṟiyavar] Mā. Irācamāṇikkaṉār."
+          ],
+          "uri": "b10000010",
+          "lccClassification": [
+            "PL4758.9.C385 Z8"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Aṇṇāmalainakar"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000010"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783783",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1938",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301598"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1938"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301598"
+                    ],
+                    "idBarcode": [
+                      "33433061301598"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001938"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "223 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p.221.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Thaqāfah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi"
+          ],
+          "shelfMark": [
+            "*OFS 84-1997"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ḥāwī, Īlīyā Salīm."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 84-1997"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200011"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Thaqāfah, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000012",
+            "urn:oclc:NYPG001000005-B",
+            "urn:undefined:NNSZ00100005",
+            "urn:undefined:(WaOLN)nyp0200011"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "titleDisplay": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi / bi-qalam Īlīyā Ḥāwī."
+          ],
+          "uri": "b10000012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000012"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000003",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 84-1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514719"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 84-1997"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514719"
+                    ],
+                    "idBarcode": [
+                      "33433014514719"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFS 84-001997"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000014",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "520 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on cover: Islamic unity or the Mutual approach among Muslim sects.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Panislamism",
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muʼassasat al-Aʻlamī lil-Maṭbūʻāt"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah"
+          ],
+          "shelfMark": [
+            "*OGC 84-1996"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Shīrāzī, ʻAbd al-Karīm Bī Āzār."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1996"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000014"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100006"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200013"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Muʼassasat al-Aʻlamī lil-Maṭbūʻāt, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000014",
+            "urn:oclc:NYPG001000006-B",
+            "urn:undefined:NNSZ00100006",
+            "urn:undefined:(WaOLN)nyp0200013"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Panislamism.",
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah / Jamʻ wa-tartīb ʻAbd al-Karīm Bī Āzār al-Shīrāzī."
+          ],
+          "uri": "b10000014",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Islamic unity."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000014"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691780"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1996"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691780"
+                    ],
+                    "idBarcode": [
+                      "33433022691780"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001996"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000016",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "111 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuṟuntokai"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Manṅkaḷa Nūlakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nalla Kuṟuntokaiyil nāṉilam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1937"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Cellappaṉ, Cilampoli, 1929-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "74913402"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1937"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000016"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74913402"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200015"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Ceṉṉai, Manṅkaḷa Nūlakam, 1959 [i.e. 1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000016",
+            "urn:lccn:74913402",
+            "urn:oclc:NYPG001000007-B",
+            "urn:undefined:NNSZ00100007",
+            "urn:undefined:(WaOLN)nyp0200015"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuṟuntokai."
+          ],
+          "titleDisplay": [
+            "Nalla Kuṟuntokaiyil nāṉilam. [Eḻutiyavar] Cu. Cellappaṉ."
+          ],
+          "uri": "b10000016",
+          "lccClassification": [
+            "PL4758.9.K794 Z6 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000016"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783785",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1937",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301580"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1937"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301580"
+                    ],
+                    "idBarcode": [
+                      "33433061301580"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001937"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "68 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Lebanon"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Ṭalīʻah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā"
+          ],
+          "shelfMark": [
+            "*OFX 84-1995"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Bashshūr, Najlāʼ Naṣīr."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "78970449"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1995"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000018"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78970449"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100008"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200017"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Ṭalīʻah, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000018",
+            "urn:lccn:78970449",
+            "urn:oclc:NYPG001000008-B",
+            "urn:undefined:NNSZ00100008",
+            "urn:undefined:(WaOLN)nyp0200017"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Lebanon."
+          ],
+          "titleDisplay": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā / Najlāʼ Naṣīr Bashshūr."
+          ],
+          "uri": "b10000018",
+          "lccClassification": [
+            "HQ1728 .B37"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000018"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000004",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1995"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031718"
+                    ],
+                    "idBarcode": [
+                      "33433002031718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001995"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000020",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 172, 320 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tolkāppiyar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaik Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tolkāppiyam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1936"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "creatorLiteral": [
+            "Veḷḷaivāraṇaṉ, Ka."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "74914844"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1936"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000020"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74914844"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200019"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "[Aṇṇāmalainakar] Aṇṇāmalaip Palkalaik Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000020",
+            "urn:lccn:74914844",
+            "urn:oclc:NYPG001000009-B",
+            "urn:undefined:NNSZ00100009",
+            "urn:undefined:(WaOLN)nyp0200019"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tolkāppiyar."
+          ],
+          "titleDisplay": [
+            "Tolkāppiyam. [Eḻutiyavar] Ka. Veḷḷaivāraṇaṉ."
+          ],
+          "uri": "b10000020",
+          "lccClassification": [
+            "PL4754.T583 V4 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Aṇṇāmalainakar]"
+          ],
+          "titleAlt": [
+            "Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Tolkāppiyam.--Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000020"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783786",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1936 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1936 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301572"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1936"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301572"
+                    ],
+                    "idBarcode": [
+                      "33433061301572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-1936 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000022",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "19, 493 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1942.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Grammar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1935"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Puttamittiraṉār, active 11th century."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "73913714"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1388"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Peruntēvaṉār, active 11th century.",
+            "Kōvintarāja Mutaliyār, Kā. Ra., 1874-1952."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1935"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73913714"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100010"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200021"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000022",
+            "urn:lccn:73913714",
+            "urn:oclc:NYPG001000010-B",
+            "urn:undefined:NNSZ00100010",
+            "urn:undefined:(WaOLN)nyp0200021"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ. Patippāciriyar Kā. Ra. Kōvintarāca Mutaliyār."
+          ],
+          "uri": "b10000022",
+          "lccClassification": [
+            "PL4754 .P8 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "titleAlt": [
+            "Viracōḻiyam."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000022"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783787",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1935",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301564"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1935"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301564"
+                    ],
+                    "idBarcode": [
+                      "33433061301564"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001935"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000024",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bahrain",
+            "Bahrain -- History",
+            "Bahrain -- History -- 20th century",
+            "Bahrain -- Economic conditions",
+            "Bahrain -- Social conditions"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār Ibn Khaldūn"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī"
+          ],
+          "shelfMark": [
+            "*OFK 84-1944"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rumayḥī, Muḥammad Ghānim."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "79971032"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFK 84-1944"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000024"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79971032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200023"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[Bayrūt] : Dār Ibn Khaldūn, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000024",
+            "urn:lccn:79971032",
+            "urn:oclc:NYPG001000011-B",
+            "urn:undefined:NNSZ00100011",
+            "urn:undefined:(WaOLN)nyp0200023"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bahrain -- History -- 20th century.",
+            "Bahrain -- Economic conditions.",
+            "Bahrain -- Social conditions."
+          ],
+          "titleDisplay": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī / Muḥammad al-Rumayḥī."
+          ],
+          "uri": "b10000024",
+          "lccClassification": [
+            "DS247.B28 R85"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000024"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000005",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK 84-1944",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005548676"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK 84-1944"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005548676"
+                    ],
+                    "idBarcode": [
+                      "33433005548676"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFK 84-001944"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000026",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "222 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 217-220.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Syria"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975"
+          ],
+          "shelfMark": [
+            "*OFX 84-1953"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Razzāz, Nabīlah."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76960987"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1953"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000026"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960987"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200025"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Dimashq : Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000026",
+            "urn:lccn:76960987",
+            "urn:oclc:NYPG001000012-B",
+            "urn:undefined:NNSZ00100012",
+            "urn:undefined:(WaOLN)nyp0200025"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Syria."
+          ],
+          "titleDisplay": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975 / Nabīlah al-Razzāz."
+          ],
+          "uri": "b10000026",
+          "lccClassification": [
+            "HQ402 .R39"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10000026"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000006",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1953",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031700"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1953"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031700"
+                    ],
+                    "idBarcode": [
+                      "33433002031700"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001953"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000028",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "9, 3, 3, 324 p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Prastuta śodha-prabandha Rājasthāna Viśvavidyālaya, Jayapura kī Pī-eca.Ḍī-upāthi ke nimitta viśvavidyālaya anudāna āyoga kī risarca phailośipa ke antargata likhā gayā thā.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [321]-324.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sūryamalla Miśraṇa, 1815-1868"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Rājasthāna Sāhitya Akādamī (Saṅgama)"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vaṃśabhāskara : eka adhyayana"
+          ],
+          "shelfMark": [
+            "*OKTM 84-1945"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Khāna, Ālama Śāha, 1936-2003."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75903689"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000028"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75903689"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200027"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Udayapura : Rājasthāna Sāhitya Akādamī (Saṅgama), 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000028",
+            "urn:lccn:75903689",
+            "urn:oclc:NYPG001000013-B",
+            "urn:undefined:NNSZ00100013",
+            "urn:undefined:(WaOLN)nyp0200027"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sūryamalla Miśraṇa, 1815-1868."
+          ],
+          "titleDisplay": [
+            "Vaṃśabhāskara : eka adhyayana / lekhaka Ālamaśāha Khāna."
+          ],
+          "uri": "b10000028",
+          "lccClassification": [
+            "PK2708.9.S9 V334"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Udayapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000028"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-1945",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011094210"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-1945"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011094210"
+                    ],
+                    "idBarcode": [
+                      "33433011094210"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-001945"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000030",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21, 264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Āryasamāja-śatābdī-saṃskaraṇam.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Authorship uncertain. Attributed variously to Āpiśali, Pānini and Śākaṭāyana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit: introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Suffixes and prefixes"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; prāptisthānam, Rāmalāla Kapūra Ṭrasṭa"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Uṇādi-koṣaḥ"
+          ],
+          "shelfMark": [
+            "*OKA 84-1931"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902275"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Āpiśali.",
+            "Pāṇini.",
+            "Śākatāyana.",
+            "Dayananda Sarasvati, Swami, 1824-1883.",
+            "Yudhiṣṭhira Mīmāṃsaka, 1909-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKA 84-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000030"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902275"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200029"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-B"
+          ],
+          "uniformTitle": [
+            "Uṇādisūtra."
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Karanāla : Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; Bahālagaḍha, Harayāṇa : prāptisthānam, Rāmalāla Kapūra Ṭrasṭa, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000030",
+            "urn:lccn:75902275",
+            "urn:oclc:NYPG001000014-B",
+            "urn:undefined:NNSZ00100014",
+            "urn:undefined:(WaOLN)nyp0200029"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Suffixes and prefixes."
+          ],
+          "titleDisplay": [
+            "Uṇādi-koṣaḥ / Dayānanda Sarasvatī Svāminā viracitayā Vaidika-laukika-koṣābhidhayā vyākhyayā sahitaḥ vividhābhi-ṣṭippaṇībhiḥ sūcībhiśca saṃyutaḥ ; sampādakaḥ Yudhiṣṭhiro Mīmāṃsakaḥ."
+          ],
+          "uri": "b10000030",
+          "lccClassification": [
+            "PK551 .U73"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Karanāla : Bahālagaḍha, Harayāṇa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000030"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000007",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKA 84-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012968222"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKA 84-1931"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012968222"
+                    ],
+                    "idBarcode": [
+                      "33433012968222"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKA 84-001931"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000032",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14, 405, 7 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jahrom (Iran : Province)",
+            "Jahrom (Iran : Province) -- Biography",
+            "Khafr (Iran)",
+            "Khafr (Iran) -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kitābfurūshī-i Khayyām"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr"
+          ],
+          "shelfMark": [
+            "*OMP 84-2007"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ishrāq, Muḥammad Karīm."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2007"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200031"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tihrān : Kitābfurūshī-i Khayyām, 1351 [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000032",
+            "urn:oclc:NYPG001000015-B",
+            "urn:undefined:NNSZ00100015",
+            "urn:undefined:(WaOLN)nyp0200031"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jahrom (Iran : Province) -- Biography.",
+            "Khafr (Iran) -- Biography."
+          ],
+          "titleDisplay": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr / taʼlīf-i Muḥammad Karīm Ishrāq."
+          ],
+          "uri": "b10000032",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm"
+          ]
+        },
+        "sort": [
+          "b10000032"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2007",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173012"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2007"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173012"
+                    ],
+                    "idBarcode": [
+                      "33433013173012"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002007"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "366 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Brhatkathāślokasaṁgrahaḥ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Colophon: Iti Śrībhaṭṭabudhasvāminā krte ślokasaṁgrahe Brhatkathāyāṁ--",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Text in Sanskrit; apparatus in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Prithivi Prakashan"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brhatkathāślokasaṁgraha : a study"
+          ],
+          "shelfMark": [
+            "*OKR 84-2006"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Budhasvāmin."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903273"
+          ],
+          "seriesStatement": [
+            "Indian civilization series ; no. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Guṇāḍhya.",
+            "Agrawala, Vasudeva Sharana.",
+            "Agrawala, Prithvi Kumar."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKR 84-2006"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000034"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903273"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100016"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200033"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Varanasi : Prithivi Prakashan, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000034",
+            "urn:lccn:74903273",
+            "urn:oclc:NYPG001000016-B",
+            "urn:undefined:NNSZ00100016",
+            "urn:undefined:(WaOLN)nyp0200033"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Brhatkathāślokasaṁgraha : a study / by V.S. Agrawala ; with Sanskrit text, edited by P.K. Agrawala."
+          ],
+          "uri": "b10000034",
+          "lccClassification": [
+            "PK3794.B84 B7 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Varanasi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000034"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKR 84-2006",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011528696"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKR 84-2006"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011528696"
+                    ],
+                    "idBarcode": [
+                      "33433011528696"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKR 84-002006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000036",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "viii, 38 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; prefatory matter in Sanskrit or Telegu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nārāyaṇatīrtha, 17th cent",
+            "Nārāyaṇatīrtha, 17th cent -- In literature"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic]"
+          ],
+          "shelfMark": [
+            "*OKB 84-1928"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75902755"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKB 84-1928"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000036"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902755"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200035"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[s.1. : s.n.], 1972"
+          ],
+          "identifier": [
+            "urn:bnum:10000036",
+            "urn:lccn:75902755",
+            "urn:oclc:NYPG001000017-B",
+            "urn:undefined:NNSZ00100017",
+            "urn:undefined:(WaOLN)nyp0200035"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nārāyaṇatīrtha, 17th cent -- In literature."
+          ],
+          "titleDisplay": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic] / praṇetā Garikapāṭi Lakṣmīkāntaḥ."
+          ],
+          "uri": "b10000036",
+          "lccClassification": [
+            "PK3799.L28 S68"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[s.1."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000036"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKB 84-1928"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKB 84-1928",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058548433"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKB 84-1928"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058548433"
+                    ],
+                    "idBarcode": [
+                      "33433058548433"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKB 84-001928"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000038",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 160 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit, with verse and prose translations in Hindi; prefatory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit poetry",
+            "Sanskrit poetry -- Himachal Pradesh"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Himācala Kalā-Saṃskrti-Bhāṣā Akādamī"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana"
+          ],
+          "shelfMark": [
+            "*OKP 84-1932"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900772"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Prarthi, Lall Chand, 1916-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 84-1932"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000038"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900772"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200037"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Śimalā : Himācala Kalā-Saṃskrti-Bhāṣā Akādamī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000038",
+            "urn:lccn:76900772",
+            "urn:oclc:NYPG001000018-B",
+            "urn:undefined:NNSZ00100018",
+            "urn:undefined:(WaOLN)nyp0200037"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit poetry -- Himachal Pradesh."
+          ],
+          "titleDisplay": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana / mukhya sampādaka Lāla Canda Prārthī ; sampādaka maṇḍala, Manasā Rāma Śarmā 'Arūṇa'...[et al.]."
+          ],
+          "uri": "b10000038",
+          "lccClassification": [
+            "PK3800.H52 R7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Śimalā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000038"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783788",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 84-1932",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 84-1932"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153572"
+                    ],
+                    "idBarcode": [
+                      "33433058153572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKP 84-001932"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000040",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "146 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār."
+          ],
+          "shelfMark": [
+            "*OLB 84-1947"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Pulavar Arasu, 1900-"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "78913375"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 672"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1947"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000040"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78913375"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200039"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000040",
+            "urn:lccn:78913375",
+            "urn:oclc:NYPG001000019-B",
+            "urn:undefined:NNSZ00100019",
+            "urn:undefined:(WaOLN)nyp0200039"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953."
+          ],
+          "titleDisplay": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār. Āciriyar Pulavar Aracu."
+          ],
+          "uri": "b10000040",
+          "lccClassification": [
+            "PL4758.9.K223 Z83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000040"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783789",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1947",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301622"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1947"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301622"
+                    ],
+                    "idBarcode": [
+                      "33433061301622"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001947"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000042",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 108 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit: pref. in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Advaita",
+            "Vedanta"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Devabhāṣā Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "dateEndString": [
+            "1972"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita."
+          ],
+          "shelfMark": [
+            "*OKN 84-1926"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902870"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Brahmashram, Śwami, 1915-"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 84-1926"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000042"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902870"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100020"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200041"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-B"
+          ],
+          "uniformTitle": [
+            "Mahābhārata. Sanatsugātīya."
+          ],
+          "dateEndYear": [
+            1972
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Prayāga, Devabhāṣā Prakāśana, Samvat 2028, i.e. 1971 or 2]"
+          ],
+          "identifier": [
+            "urn:bnum:10000042",
+            "urn:lccn:72902870",
+            "urn:oclc:NYPG001000020-B",
+            "urn:undefined:NNSZ00100020",
+            "urn:undefined:(WaOLN)nyp0200041"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Advaita.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita. Vyākhyātā Svāmī Brahmāśrama."
+          ],
+          "uri": "b10000042",
+          "lccClassification": [
+            "B132.V3 M264"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Prayāga"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000042"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783790",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 84-1926"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 84-1926",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618392"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKN 84-1926"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618392"
+                    ],
+                    "idBarcode": [
+                      "33433058618392"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 84-001926"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000044",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[99] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Biographies of Khri-chen Byaṅ-chub-chos-ʼphel and Śel-dkar Bla-ma Saṅs-rgyas-bstan-ʼphel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from prints from blocks from Lhasa and Śel-dkar Dgaʼ-ldan-legs-bśad-gliṅ.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884",
+            "Lamas",
+            "Lamas -- Tibet",
+            "Lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ngawang Sopa"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2361"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rgal-dbaṅ Chos-rje Blo-bzaṅ-ʼphrin-las-rnam-rgyal, active 1840-1860."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77901316"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ngag-dbang-blo-bzang-rgya-mtsho, Dalai Lama V, 1617-1682."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2361"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000044"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77901316"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000021-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100021"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200043"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000021-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "New Delhi : Ngawang Sopa, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000044",
+            "urn:lccn:77901316",
+            "urn:oclc:NYPG001000021-B",
+            "urn:undefined:NNSZ00100021",
+            "urn:undefined:(WaOLN)nyp0200043"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838.",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884.",
+            "Lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel / by Dar-han Mkhan-sprul Blo-bzaṅ-ʼphrin-las-rnam-rgyal. Bkaʼ-gdams bstan-paʼi mdzod-ʼdzin Rje-btsun Bla-ma Saṅs-rgyas-bstan-ʼphel dpal-bzaṅ-poʼi rnam par thar pa dad ldan yid kyi dgaʼ ston : the biography of Saṅs-rgyas-bstan-ʼphel of Śel-dkar / by Śel-dkar Bkaʼ-ʼgyur Bla-ma Ṅag-dbaṅ-blo-bzaṅ-bstan-ʼdzin-tshul-khrims-rgyal-mtshan."
+          ],
+          "uri": "b10000044",
+          "lccClassification": [
+            "BQ942.Y367 R47 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000044"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000011",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2361",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080645"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080645"
+                    ],
+                    "idBarcode": [
+                      "33433015080645"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002361"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000046",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[83] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Kye rdor rnam bśad.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from tracing and manuscripts from the library of Mkhan-po Rin-chen by Trayang and Jamyang Samten.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456",
+            "Tripiṭaka.",
+            "Tripiṭaka. -- Commentaries",
+            "Sa-skya-pa lamas",
+            "Sa-skya-pa lamas -- Tibet",
+            "Sa-skya-pa lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Trayang and Jamyang Samten"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2362"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Tshe-dbaṅ-rdo-rje-rig-ʼdzin, Prince of Sde-dge."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77900893"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sangs-rgyas-phun-tshogs, Ngor-chen, 1649-1705."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000046"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77900893"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000022-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100022"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200045"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000022-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "New Delhi : Trayang and Jamyang Samten, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000046",
+            "urn:lccn:77900893",
+            "urn:oclc:NYPG001000022-B",
+            "urn:undefined:NNSZ00100022",
+            "urn:undefined:(WaOLN)nyp0200045"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456.",
+            "Tripiṭaka. -- Commentaries.",
+            "Sa-skya-pa lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra / by Sde-dge Yab-chen Tshe-dbaṅ-rdo-rje-rig-ʼdzin alias Byams-pa-kun-dgaʼ-bstan-paʼi-rgyal-mtshan. Rgyal ba Rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas : the life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po / by Ṅor-chen Saṅs-rgyas-phun-tshogs."
+          ],
+          "uri": "b10000046",
+          "lccClassification": [
+            "BG974.0727 T75"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "titleAlt": [
+            "Rgyal ba rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas.",
+            "Detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra.",
+            "Life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000046"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080413"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080413"
+                    ],
+                    "idBarcode": [
+                      "33433015080413"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002362"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000048",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[150] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a MS. preserved at Pha-lo-ldiṅ Monastery in Bhutan.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Buddhism",
+            "Buddhism -- Rituals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kunzang Topgey"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2382"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901012"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2382"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000048"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000023-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100023"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200047"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000023-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Thimphu : Kunzang Topgey, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000048",
+            "urn:lccn:76901012",
+            "urn:oclc:NYPG001000023-B",
+            "urn:undefined:NNSZ00100023",
+            "urn:undefined:(WaOLN)nyp0200047"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Buddhism -- Rituals."
+          ],
+          "titleDisplay": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "uri": "b10000048",
+          "lccClassification": [
+            "BQ7695 .B55"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Thimphu"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 38 cm."
+          ]
+        },
+        "sort": [
+          "b10000048"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2382",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080439"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080439"
+                    ],
+                    "idBarcode": [
+                      "33433015080439"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002382"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000050",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[188] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a print from the early 16th century western Tibetan blocks by Urgyan Dorje.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?",
+            "Bkaʼ-brgyud-pa lamas",
+            "Bkaʼ-brgyud-pa lamas -- Tibet",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography",
+            "Spiritual life",
+            "Spiritual life -- Buddhism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Urgyan Dorje"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2381"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901747"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2381"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000050"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901747"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000024-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100024"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200049"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000024-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "New Delhi : Urgyan Dorje, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000050",
+            "urn:lccn:76901747",
+            "urn:oclc:NYPG001000024-B",
+            "urn:undefined:NNSZ00100024",
+            "urn:undefined:(WaOLN)nyp0200049"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography.",
+            "Spiritual life -- Buddhism."
+          ],
+          "titleDisplay": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "uri": "b10000050",
+          "lccClassification": [
+            "BQ942.A187 A35 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000050"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2381",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080421"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080421"
+                    ],
+                    "idBarcode": [
+                      "33433015080421"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002381"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000052",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[247] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Gu ruʼi rnam thar ṅo tshar phun tshogs rgya mtsho.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Padma Sambhava, approximately 717-approximately 762",
+            "Lamas",
+            "Lamas -- Tibet",
+            "Lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sherab Gyaltshen Lama"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rig ʼdzin grub paʼi dbaṅ phyug chen po Padma-ʼbyuṅ-gnas kyi rnam par thar pa ṅo mtshar phun sum tshogs paʼi rgya mtsho : a detailed account of the life of Guru Rimpoche Padmasambhava Miraculously Born"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2383"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Bkra-śis-stobs-rgyal, Byaṅ-bdag."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76900205"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2383"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000052"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900205"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000025-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100025"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200051"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000025-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Gangtog : Sherab Gyaltshen Lama, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000052",
+            "urn:lccn:76900205",
+            "urn:oclc:NYPG001000025-B",
+            "urn:undefined:NNSZ00100025",
+            "urn:undefined:(WaOLN)nyp0200051"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Padma Sambhava, approximately 717-approximately 762.",
+            "Lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "Rig ʼdzin grub paʼi dbaṅ phyug chen po Padma-ʼbyuṅ-gnas kyi rnam par thar pa ṅo mtshar phun sum tshogs paʼi rgya mtsho : a detailed account of the life of Guru Rimpoche Padmasambhava Miraculously Born / by Byaṅ-bdag Bkra-śis-stobs-rgyal."
+          ],
+          "uri": "b10000052",
+          "lccClassification": [
+            "BQ7950.P327 B55 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Gangtog"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000052"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000015",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2383"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2383",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080447"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2383"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080447"
+                    ],
+                    "idBarcode": [
+                      "33433015080447"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002383"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000054",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[161] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a one volume collection of the writings from the library of Rtogs-ldan Rin-po-che of Sgaṅ-sṅon.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "ʼBri-gung-pa (Sect)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tsondu Senghe"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Collected works (gsun ʼbum) of ʼBri-guṅ Skyob-pa ʼJig-rten-mgon-po Pin-chen-dpal."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2384"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "ʼBri-gung Chos-rje ʼJig-rten-mgon-po, 1143-1217."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77900734"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2384"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000054"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77900734"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000026-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100026"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200053"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000026-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bir, H.P. : Tsondu Senghe, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000054",
+            "urn:lccn:77900734",
+            "urn:oclc:NYPG001000026-B",
+            "urn:undefined:NNSZ00100026",
+            "urn:undefined:(WaOLN)nyp0200053"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "ʼBri-gung-pa (Sect)"
+          ],
+          "titleDisplay": [
+            "Collected works (gsun ʼbum) of ʼBri-guṅ Skyob-pa ʼJig-rten-mgon-po Pin-chen-dpal."
+          ],
+          "uri": "b10000054",
+          "lccClassification": [
+            "BQ7684 .B74 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bir, H.P."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000054"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000016",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2384"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2384",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080454"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2384"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080454"
+                    ],
+                    "idBarcode": [
+                      "33433015080454"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002384"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000056",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[155] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Half title: Pha rin po che Ratna-badzra gyi mgyur ʼbum zab don rdo rje ʼphreṅ ba bźugs so.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a rare manuscript from Dzong-khul Monastery in Zangskar.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "ʼBrug-pa (Sect)",
+            "ʼBrug-pa (Sect) -- Prayer books and devotions",
+            "ʼBrug-pa (Sect) -- Prayer books and devotions -- Tibetan"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kargyud Sungrab Nyamso Khang"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Collected songs (mgur) of esoteric realisation of Ratna-badzra (Rin-chen-rdo-rje)."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2385"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rad-na-badzra."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901741"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2385"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000056"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901741"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000027-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100027"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200055"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000027-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Darjeeling : Kargyud Sungrab Nyamso Khang, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000056",
+            "urn:lccn:76901741",
+            "urn:oclc:NYPG001000027-B",
+            "urn:undefined:NNSZ00100027",
+            "urn:undefined:(WaOLN)nyp0200055"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "ʼBrug-pa (Sect) -- Prayer books and devotions -- Tibetan."
+          ],
+          "titleDisplay": [
+            "Collected songs (mgur) of esoteric realisation of Ratna-badzra (Rin-chen-rdo-rje)."
+          ],
+          "uri": "b10000056",
+          "lccClassification": [
+            "BQ7683.6 .R37 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Darjeeling"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000056"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000017",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2385"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2385",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080462"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2385"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080462"
+                    ],
+                    "idBarcode": [
+                      "33433015080462"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002385"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000058",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[132] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on spine: Rdzogs chen yaṅ ti nag po gser ʼbru chos skor.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced photographically from a rare manuscript from the collection of Brag-thog Monastery in Ladakh by Pema Choden.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Rnying-ma-pa (Sect)",
+            "Rnying-ma-pa (Sect) -- Rituals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "S.W. Tashigangpa"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Yaṅ ti nag po gser gyi ʼbru gcig paʼi chos skor : a collection of Nyingmapa Dzogchen teachings"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-5174"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Duṅ-mtsho-ras-pa, active 14th century."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "72908332"
+          ],
+          "seriesStatement": [
+            "Smanrtsis shesrig spendzod; v. 41"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-5174"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000058"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72908332"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000028-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100028"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200057"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000028-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Leh : S.W. Tashigangpa, 1972."
+          ],
+          "identifier": [
+            "urn:bnum:10000058",
+            "urn:lccn:72908332",
+            "urn:oclc:NYPG001000028-B",
+            "urn:undefined:NNSZ00100028",
+            "urn:undefined:(WaOLN)nyp0200057"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rnying-ma-pa (Sect) -- Rituals."
+          ],
+          "titleDisplay": [
+            "Yaṅ ti nag po gser gyi ʼbru gcig paʼi chos skor : a collection of Nyingmapa Dzogchen teachings / rediscovered by Duṅ-mtsho-ras-pa (Phyi-ma)."
+          ],
+          "uri": "b10000058",
+          "lccClassification": [
+            "BQ7662.4 .D86 1972"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leh"
+          ],
+          "titleAlt": [
+            "Rdzogs chen yaṅ ti nag po gser ʼbru chos skor."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000058"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000018",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-5174"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-5174",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012357756"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-5174"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012357756"
+                    ],
+                    "idBarcode": [
+                      "33433012357756"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-005174"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000060",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 v. (unpaged)"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Photographic reproduction of a Tashilhunpo xylograph.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tibetan; introd. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Blo-bzang-chos-kyi-rgyal-mtshan, Panchen Lama IV, 1570-1662"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The autobiography of the First Panchen Lama Blo-bzang-chos-kyi-rgyal-mtsho."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-5074"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Blo-bzang-chos-kyi-rgyal-mtshan, Panchen Lama IV, 1570-1662."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "70908872"
+          ],
+          "seriesStatement": [
+            "Gedan sungrab minyam gyunphel series, v. 12"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Demo, Ngawang Gelek, 1939-"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-5074"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000060"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "70908872"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000029-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100029"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200059"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000029-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[New Delhi, 1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000060",
+            "urn:lccn:70908872",
+            "urn:oclc:NYPG001000029-B",
+            "urn:undefined:NNSZ00100029",
+            "urn:undefined:(WaOLN)nyp0200059"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Blo-bzang-chos-kyi-rgyal-mtshan, Panchen Lama IV, 1570-1662."
+          ],
+          "titleDisplay": [
+            "The autobiography of the First Panchen Lama Blo-bzang-chos-kyi-rgyal-mtsho. Edited and reproduced by Ngawang Gelek Demo, with an English introd. by E. Gene Smith."
+          ],
+          "uri": "b10000060",
+          "lccClassification": [
+            "BQ7945.B547 A33"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "29 x 43 cm."
+          ]
+        },
+        "sort": [
+          "b10000060"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000019",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-5074"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-5074",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080363"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-5074"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080363"
+                    ],
+                    "idBarcode": [
+                      "33433015080363"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-005074"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000062",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 v. (unpaged)"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Gnas-chung chos spyod.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Buddhism",
+            "Buddhism -- Rituals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "[Can be obtained from Tibet House, New Delhi]"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sa gsum na mngon par mtho ba Rdo rje sgra dbyangs gling gi zhal ʼdon bskang gsoʼi rim pa phyogs gcig tu bsgrigs paʼi ngo mtshar nor buʼi ʼphreng ba skal bzang gzhon nuʼi mgul rgyan. The collected liturgical texts of Gnas-chung Rdo-rje-sgra-dbyangs-gling, the residence of the State Oracle of Tibet."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-5073"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "74906111"
+          ],
+          "seriesStatement": [
+            "Ngagyur Ngingmay Sungrab, v. 3"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sonam Topgay Kazi."
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-5073"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000062"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74906111"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000030-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100030"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200061"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000030-B"
+          ],
+          "uniformTitle": [
+            "Gnas-chuṅ chos spyod."
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Gangtok [Can be obtained from Tibet House, New Delhi] 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000062",
+            "urn:lccn:74906111",
+            "urn:oclc:NYPG001000030-B",
+            "urn:undefined:NNSZ00100030",
+            "urn:undefined:(WaOLN)nyp0200061"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Buddhism -- Rituals."
+          ],
+          "titleDisplay": [
+            "Sa gsum na mngon par mtho ba Rdo rje sgra dbyangs gling gi zhal ʼdon bskang gsoʼi rim pa phyogs gcig tu bsgrigs paʼi ngo mtshar nor buʼi ʼphreng ba skal bzang gzhon nuʼi mgul rgyan. The collected liturgical texts of Gnas-chung Rdo-rje-sgra-dbyangs-gling, the residence of the State Oracle of Tibet. Reproduced photographically from Bskal-bzang-rin-chenʼs xylographic edition of 1845 by Sonam Topgay Kazi, with an English pref. by E. Gene Smith."
+          ],
+          "uri": "b10000062",
+          "lccClassification": [
+            "BQ7695 .G58 1969"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Gangtok"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "29 x 44 cm."
+          ]
+        },
+        "sort": [
+          "b10000062"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000020",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-5073"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-5073",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030669448"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-5073"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030669448"
+                    ],
+                    "idBarcode": [
+                      "33433030669448"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-005073"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000064",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "168 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Shiʻr an-Nmir ibn Tawlab.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 159-168.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Maṭbaʻat al-Maʻārif"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Shiʻr"
+          ],
+          "shelfMark": [
+            "*OFA 82-2370"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Namir ibn Tawlab."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "76240902"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Qaysī, Nūrī Ḥammūdī."
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFA 82-2370"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000064"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76240902"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000031-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100031"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200063"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000031-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Baghdād, Maṭbaʻat al-Maʻārif [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000064",
+            "urn:lccn:76240902",
+            "urn:oclc:NYPG001000031-B",
+            "urn:undefined:NNSZ00100031",
+            "urn:undefined:(WaOLN)nyp0200063"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Shiʻr, al-Namir ibn Tawlab. Ṣanʻat Nūrī ʻHammūdī al-Qaysī."
+          ],
+          "uri": "b10000064",
+          "lccClassification": [
+            "PJ7696.N3 S5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Baghdād"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000064"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000021",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFA 82-2370"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFA 82-2370",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002000481"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFA 82-2370"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002000481"
+                    ],
+                    "idBarcode": [
+                      "33433002000481"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFA 82-002370"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000066",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "70, 272 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sāhitya Bhaṇḍāra"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1962
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Meghadūta. Hindī anuvāda, sakalāṅgapūrṇa samīkshātmaka bhūmikā, vyākhyātmaka ṭippāṇī, mallināthīya saṃskṛta ṭīkā tathā anya[sic] upayogī pariśishṭoṃ sahita."
+          ],
+          "shelfMark": [
+            "*OKP 82-2129"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kālidāsa."
+          ],
+          "createdString": [
+            "1962"
+          ],
+          "idLccn": [
+            "sa 65007611"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Mallinātha.",
+            "Shastri, S. R."
+          ],
+          "dateStartYear": [
+            1962
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 82-2129"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000066"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 65007611"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000032-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100032"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200065"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000032-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Meraṭha, Sāhitya Bhaṇḍāra, 1962."
+          ],
+          "identifier": [
+            "urn:bnum:10000066",
+            "urn:lccn:sa 65007611",
+            "urn:oclc:NYPG001000032-B",
+            "urn:undefined:NNSZ00100032",
+            "urn:undefined:(WaOLN)nyp0200065"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1962"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Meghadūta. Hindī anuvāda, sakalāṅgapūrṇa samīkshātmaka bhūmikā, vyākhyātmaka ṭippāṇī, mallināthīya saṃskṛta ṭīkā tathā anya[sic] upayogī pariśishṭoṃ sahita. Mahākavikālidāsapraṇita. Śivarāja Śāstrī dvārā sampādita evaṃ saṃśodhita."
+          ],
+          "uri": "b10000066",
+          "lccClassification": [
+            "PK3796 .M5 1962"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Meraṭha"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000066"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783793",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 82-2129"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 82-2129",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058152988"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 82-2129"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058152988"
+                    ],
+                    "idBarcode": [
+                      "33433058152988"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKP 82-002129"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000068",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "228 p. port."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Urdu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Urdu language",
+            "Urdu language -- Rhyme"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:urd",
+              "label": "Urdu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Qavāfī-yi Kāmil ; ʻilm-i qāfīyah bi-qānūn-i qadīm va jadīd."
+          ],
+          "shelfMark": [
+            "*OKTX 82-2129"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kāmil Jūnāgaṛhī."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "72932110"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTX 82-2129"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000068"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72932110"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000033-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100033"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200067"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000033-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[Karācī, 1970]"
+          ],
+          "identifier": [
+            "urn:bnum:10000068",
+            "urn:lccn:72932110",
+            "urn:oclc:NYPG001000033-B",
+            "urn:undefined:NNSZ00100033",
+            "urn:undefined:(WaOLN)nyp0200067"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Urdu language -- Rhyme."
+          ],
+          "titleDisplay": [
+            "Qavāfī-yi Kāmil ; ʻilm-i qāfīyah bi-qānūn-i qadīm va jadīd. Muʼallifah-yi Kāmil Jūnāgaṛhī."
+          ],
+          "uri": "b10000068",
+          "lccClassification": [
+            "PK1979 .K3"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Karācī"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000068"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000022",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTX 82-2129"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTX 82-2129",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004672303"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTX 82-2129"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004672303"
+                    ],
+                    "idBarcode": [
+                      "33433004672303"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTX 82-002129"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000070",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2 v. in 1."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "In Malayalam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 published by Ke. Bṟadērsȧ, Kōḻikkōṭȧ.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Malayalam literature",
+            "Malayalam literature -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Vidyārtthimitṟaṃ Bukkuḍippō"
+          ],
+          "language": [
+            {
+              "id": "lang:mal",
+              "label": "Malayalam"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Gadyamañjari."
+          ],
+          "shelfMark": [
+            "*OLD 82-2140"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kumāran, Mūrkkōttȧ, 1874-1941."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "sa 68007302"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLD 82-2140"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000070"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68007302"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000034-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100034"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200069"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000034-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Kōṭṭayaṃ, Vidyārtthimitṟaṃ Bukkuḍippō [1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000070",
+            "urn:lccn:sa 68007302",
+            "urn:oclc:NYPG001000034-B",
+            "urn:undefined:NNSZ00100034",
+            "urn:undefined:(WaOLN)nyp0200069"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Malayalam literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Gadyamañjari. Granthakarttā Mūrkkōttu Kumāran."
+          ],
+          "uri": "b10000070",
+          "lccClassification": [
+            "PL4718.O5 .K77"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kōṭṭayaṃ"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000070"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000023",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLD 82-2140"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLD 82-2140",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004314914"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLD 82-2140"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004314914"
+                    ],
+                    "idBarcode": [
+                      "33433004314914"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLD 82-002140"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000072",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "54 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Primers, Persian"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Āgāh"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Fārsī nivīsī barā-yi kūdakān"
+          ],
+          "shelfMark": [
+            "*OMP 82-2194"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ibrāhīmī, Nādir."
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 82-2194"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000072"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000035-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200071"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000035-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Āgāh, 2536 [1977]"
+          ],
+          "identifier": [
+            "urn:bnum:10000072",
+            "urn:oclc:NYPG001000035-B",
+            "urn:undefined:NNSZ00100035",
+            "urn:undefined:(WaOLN)nyp0200071"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Primers, Persian."
+          ],
+          "titleDisplay": [
+            "Fārsī nivīsī barā-yi kūdakān / Nādir Ibrāhīmī."
+          ],
+          "uri": "b10000072",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000072"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000024",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 82-2194"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 82-2194",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013172402"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 82-2194"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013172402"
+                    ],
+                    "idBarcode": [
+                      "33433013172402"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMP 82-002194"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000074",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4 v. facsims."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 3-4 edited by M. S. Maʻrūf only.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Text of the diwan is vocalized.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Maʻārif"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            4
+          ],
+          "createdYear": [
+            1971
+          ],
+          "dateEndString": [
+            "1975"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dīwān al-Bārūdī"
+          ],
+          "shelfMark": [
+            "*OFA 82-2183"
+          ],
+          "numItemVolumesParsed": [
+            4
+          ],
+          "creatorLiteral": [
+            "Bārūdī, Maḥmūd Sāmī, 1839-1904."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "74963263"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Jārim, ʻAlī.",
+            "Maʻrūf, Muḥammad Shafīq."
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFA 82-2183"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000074"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74963263"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000036-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100036"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200073"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000036-B"
+          ],
+          "dateEndYear": [
+            1975
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Miṣr, Dār al-Maʻārif, 1971-1974 i.e. 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000074",
+            "urn:lccn:74963263",
+            "urn:oclc:NYPG001000036-B",
+            "urn:undefined:NNSZ00100036",
+            "urn:undefined:(WaOLN)nyp0200073"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Dīwān al-Bārūdī [taʼlīf] Maḥmūd Sāmī al-Bārūdī. Ḥaqqaqahu wa-ṣaḥḥaạhu wa-ḍabaṭahu wa-sharaḥahu ʻAlī al-Jārim [wa]-Muḥammad Shafīq Maʻrūf"
+          ],
+          "uri": "b10000074",
+          "lccClassification": [
+            "PJ7816 .A694 1971"
+          ],
+          "numItems": [
+            4
+          ],
+          "numAvailable": [
+            4
+          ],
+          "placeOfPublication": [
+            "Miṣr"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Juzʼ 1. Qāfiyat al-Hamzah-qāfiyat al-Dhāl. -- Juzʼ 2. Qāfiyat al-Rāʼ - qāfiyat al-Kāf. -- Juzʼ 3. Qāfiyat al-Lām - qāfiyat al-Mīm. -- Juzʼ 4. Qāfiyat al-Nūn-qā fiyat al-yāʼ."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000074"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 4,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000028",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFA 82-2183 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFA 82-2183 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002000465"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "physicalLocation": [
+                      "*OFA 82-2183"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002000465"
+                    ],
+                    "idBarcode": [
+                      "33433002000465"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 4,
+                        "lte": 4
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         4-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFA 82-2183 v. 000004"
+                  },
+                  "sort": [
+                    "         4-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFA 82-2183 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFA 82-2183 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002000457"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "physicalLocation": [
+                      "*OFA 82-2183"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002000457"
+                    ],
+                    "idBarcode": [
+                      "33433002000457"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 3,
+                        "lte": 3
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         3-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFA 82-2183 v. 000003"
+                  },
+                  "sort": [
+                    "         3-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000026",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFA 82-2183 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFA 82-2183 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002000440"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "physicalLocation": [
+                      "*OFA 82-2183"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002000440"
+                    ],
+                    "idBarcode": [
+                      "33433002000440"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFA 82-2183 v. 000002"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000025",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFA 82-2183 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFA 82-2183 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002000432"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OFA 82-2183"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002000432"
+                    ],
+                    "idBarcode": [
+                      "33433002000432"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFA 82-2183 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000076",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "132 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Urdu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Mujibur Rahman, Sheikh, 1922-1975",
+            "Finance, Public",
+            "Finance, Public -- Pakistan",
+            "Pakistan",
+            "Pakistan -- Politics and government"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Maktab-i Urdū Ḍaʼjist"
+          ],
+          "language": [
+            {
+              "id": "lang:urd",
+              "label": "Urdu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Chah nikāt kī saccī taṣvīr."
+          ],
+          "shelfMark": [
+            "*OKTX 82-2408"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Quraishī, Al̤tāf Ḥasan."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "78932499"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTX 82-2408"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000076"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78932499"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000037-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100037"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200075"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000037-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Lāhaur, Maktab-i Urdū Ḍaʼjist [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000076",
+            "urn:lccn:78932499",
+            "urn:oclc:NYPG001000037-B",
+            "urn:undefined:NNSZ00100037",
+            "urn:undefined:(WaOLN)nyp0200075"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Mujibur Rahman, Sheikh, 1922-1975.",
+            "Finance, Public -- Pakistan.",
+            "Pakistan -- Politics and government."
+          ],
+          "titleDisplay": [
+            "Chah nikāt kī saccī taṣvīr. [Muṣannif] Al̤tāf Ḥasan Quraishī."
+          ],
+          "uri": "b10000076",
+          "lccClassification": [
+            "JQ543 1969 .Q87"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Lāhaur"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000076"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000029",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTX 82-2408"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTX 82-2408",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004672238"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTX 82-2408"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004672238"
+                    ],
+                    "idBarcode": [
+                      "33433004672238"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTX 82-002408"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000078",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "144 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Rājakamala Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1966
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Raśmibandha."
+          ],
+          "shelfMark": [
+            "*OKTN 82-2402"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Pant, Sumitra Nandan, 1900-"
+          ],
+          "createdString": [
+            "1966"
+          ],
+          "idLccn": [
+            "sa 67003708"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1966
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTN 82-2402"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000078"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 67003708"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000038-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100038"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200077"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000038-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Dillī] Rājakamala Prakāśana [1966]"
+          ],
+          "identifier": [
+            "urn:bnum:10000078",
+            "urn:lccn:sa 67003708",
+            "urn:oclc:NYPG001000038-B",
+            "urn:undefined:NNSZ00100038",
+            "urn:undefined:(WaOLN)nyp0200077"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1966"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Raśmibandha. [Lekhaka] Sumitrānandana Panta."
+          ],
+          "uri": "b10000078",
+          "lccClassification": [
+            "PK2098.P32 R3 1966"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dillī]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000078"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000030",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTN 82-2402"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTN 82-2402",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011745118"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTN 82-2402"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011745118"
+                    ],
+                    "idBarcode": [
+                      "33433011745118"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTN 82-002402"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000081",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "80 p. illus."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added title: Urdu kī pahili seerrhi",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Urdu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Primers, Urdu"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Maktab-i Mīrī Laʼibrīrī"
+          ],
+          "language": [
+            {
+              "id": "lang:urd",
+              "label": "Urdu"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Urdū kī pahlī sīṛhī; jadīd uslūb ʻāhil mabādī."
+          ],
+          "shelfMark": [
+            "*OKTX 82-2414"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Alifulmiḥrā̲s, 1919-"
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "76932355"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTX 82-2414"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000081"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76932355"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000040-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100040"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200080"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000040-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Lāhaur, Maktab-i Mīrī Laʼibrīrī [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000081",
+            "urn:lccn:76932355",
+            "urn:oclc:NYPG001000040-B",
+            "urn:undefined:NNSZ00100040",
+            "urn:undefined:(WaOLN)nyp0200080"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Primers, Urdu."
+          ],
+          "titleDisplay": [
+            "Urdū kī pahlī sīṛhī; jadīd uslūb ʻāhil mabādī. Az Alifulmiḥrā̲s."
+          ],
+          "uri": "b10000081",
+          "lccClassification": [
+            "PK1972 .A53"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Lāhaur"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000081"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTX 82-2414"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTX 82-2414",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004672246"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTX 82-2414"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004672246"
+                    ],
+                    "idBarcode": [
+                      "33433004672246"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTX 82-002414"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000083",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 41, 4, 456 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes commentary of Namisādhu.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Although some scholars (Aufrecht, Weber) have identified the author with Rudrabhaṭṭa, the bulk of evidence produced by others (Peterson, Jacobi) seems to prove that they are not the same. The editor also concludes that they are different persons.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 456.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit; introd. in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit poetry",
+            "Sanskrit poetry -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Hindī-Anusandhāna-Parishad, Dillī Viśvavidyālaya ke nimitta Vāsudeva Prakāśana dvārā prakāśita"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kāvyālaṅkāra. Aṅśuprabhāʼʼkhya-Hindīvyākhyā-sahita."
+          ],
+          "shelfMark": [
+            "*OKP 82-2410"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rudraṭa, active 9th century."
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "sa 66001274"
+          ],
+          "seriesStatement": [
+            "Hindī Anusandhāna Parishad granthamālā, 33"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Namisādhu, active 1068.",
+            "Chaudhary, S. D."
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 82-2410"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000083"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 66001274"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000041-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100041"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200082"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000041-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Dillī, Hindī-Anusandhāna-Parishad, Dillī Viśvavidyālaya ke nimitta Vāsudeva Prakāśana dvārā prakāśita [1965]"
+          ],
+          "identifier": [
+            "urn:bnum:10000083",
+            "urn:lccn:sa 66001274",
+            "urn:oclc:NYPG001000041-B",
+            "urn:undefined:NNSZ00100041",
+            "urn:undefined:(WaOLN)nyp0200082"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit poetry -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Kāvyālaṅkāra. Aṅśuprabhāʼʼkhya-Hindīvyākhyā-sahita. Rudraṭa praṇīta. Hindīvyākhyākāra Satyadeva Chaudharī."
+          ],
+          "uri": "b10000083",
+          "lccClassification": [
+            "PK2916 .R8 1965"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dillī"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000083"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783794",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 82-2410"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 82-2410",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153028"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 82-2410"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153028"
+                    ],
+                    "idBarcode": [
+                      "33433058153028"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKP 82-002410"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000085",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "11, 321, 87 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Abridged version of Jayasi's Padamāvata-Sāra: p. [1]-87 (3d group)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Hindī Bhavana"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Padamāvata-sāra. Jāyasi-kṛta Padamāvata kā anuśīlana aura sankshepa."
+          ],
+          "shelfMark": [
+            "*OKTM 82-2424"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Narang, Indra Chandra, 1907-"
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 68005298"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Malika Mohammada Jāyasī, active 1540."
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 82-2424"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000085"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 68005298"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000042-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100042"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200084"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000042-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Jālandhara, Hindī Bhavana, 1964."
+          ],
+          "identifier": [
+            "urn:bnum:10000085",
+            "urn:lccn:sa 68005298",
+            "urn:oclc:NYPG001000042-B",
+            "urn:undefined:NNSZ00100042",
+            "urn:undefined:(WaOLN)nyp0200084"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Padamāvata-sāra. Jāyasi-kṛta Padamāvata kā anuśīlana aura sankshepa. Sampādaka Indracandra Nāranga."
+          ],
+          "uri": "b10000085",
+          "lccClassification": [
+            "PK2095.M3 P36"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Jālandhara"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000085"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 82-2424"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 82-2424",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011108135"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 82-2424"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011108135"
+                    ],
+                    "idBarcode": [
+                      "33433011108135"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTM 82-002424"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000087",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "12, 195 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindi drama"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Iṇḍiyāna Presa (Pablikeśansa)"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Āṭha ekāṅkī."
+          ],
+          "shelfMark": [
+            "*OKTN 82-2423"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Śarma, Nityānanda"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "sa 67003777"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTN 82-2423"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000087"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 67003777"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000043-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100043"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200086"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000043-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Ilāhābāda, Iṇḍiyāna Presa (Pablikeśansa) [1965]"
+          ],
+          "identifier": [
+            "urn:bnum:10000087",
+            "urn:lccn:sa 67003777",
+            "urn:oclc:NYPG001000043-B",
+            "urn:undefined:NNSZ00100043",
+            "urn:undefined:(WaOLN)nyp0200086"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindi drama."
+          ],
+          "titleDisplay": [
+            "Āṭha ekāṅkī. Sampādaka Nityānanda Śarmā."
+          ],
+          "uri": "b10000087",
+          "lccClassification": [
+            "PK2071 .S2"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ilāhābāda"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000087"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTN 82-2423"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTN 82-2423",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011745134"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTN 82-2423"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011745134"
+                    ],
+                    "idBarcode": [
+                      "33433011745134"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTN 82-002423"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000089",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "351 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "A novel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Bengali.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Beṅgala Pābaliśārsa"
+          ],
+          "language": [
+            {
+              "id": "lang:ben",
+              "label": "Bengali"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bāghinī."
+          ],
+          "shelfMark": [
+            "*OKV 82-2420"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Basu, Samaresh, 1921-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "79903322"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKV 82-2420"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000089"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79903322"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000044-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100044"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200088"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000044-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Kalikātā, Beṅgala Pābaliśārsa [1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000089",
+            "urn:lccn:79903322",
+            "urn:oclc:NYPG001000044-B",
+            "urn:undefined:NNSZ00100044",
+            "urn:undefined:(WaOLN)nyp0200088"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Bāghinī. [Lekhaka] Samareśa Basu."
+          ],
+          "uri": "b10000089",
+          "lccClassification": [
+            "Pk1718.B39 B3 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Kalikātā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000089"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000034",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKV 82-2420"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKV 82-2420",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011167040"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKV 82-2420"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011167040"
+                    ],
+                    "idBarcode": [
+                      "33433011167040"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKV 82-002420"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000091",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "920, 144 p. : ill., map ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Translation of Contributions to the anthropology of Iran.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [817]-838.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Anthropometry",
+            "Anthropometry -- Iran"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Intishārāt-i Ibn Sīnā"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mardumʹshināsī-i Īrān"
+          ],
+          "shelfMark": [
+            "*OMK 82-2419"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Field, Henry, 1902-"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMK 82-2419"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000091"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000045-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100045"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200090"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000045-B"
+          ],
+          "uniformTitle": [
+            "Contributions to the anthropology of Iran. Persian"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tihrān : Intishārāt-i Ibn Sīnā, 1343 [1965]"
+          ],
+          "identifier": [
+            "urn:bnum:10000091",
+            "urn:oclc:NYPG001000045-B",
+            "urn:undefined:NNSZ00100045",
+            "urn:undefined:(WaOLN)nyp0200090"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Anthropometry -- Iran."
+          ],
+          "titleDisplay": [
+            "Mardumʹshināsī-i Īrān / Hinrī Fīld. Tarjumah-ʼi ʻAbd Allāh Faryār."
+          ],
+          "uri": "b10000091",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Contributions to the anthropology of Iran."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000091"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000036",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMK 82-2419"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMK 82-2419",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013106327"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMK 82-2419"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013106327"
+                    ],
+                    "idBarcode": [
+                      "33433013106327"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMK 82-002419"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000093",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "90 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Kuṟaḷ neṟi cittaneṟi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar",
+            "Tamil Siddhas"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Civāṉantā Cittaneṟip Payiṟcik Kaḻkamm; inn̄ūl kiṭaikkum iṭam: S. Caṅkaraṉār, Ceṉṉai"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kuṟaḷ neṟiyum Citta neṟiyum; ārāyccik kaṭṭurai."
+          ],
+          "shelfMark": [
+            "*OLB 82-5144"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Pasumporkizhar, N., 1936-"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74902781"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 82-5144"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000093"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74902781"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000046-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100046"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200092"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000046-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Pacumpoṉ, Irāmanātapuram Māvaṭṭam, Civāṉantā Cittaneṟip Payiṟcik Kaḻkamm; inn̄ūl kiṭaikkum iṭam: S. Caṅkaraṉār, Ceṉṉai, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000093",
+            "urn:lccn:74902781",
+            "urn:oclc:NYPG001000046-B",
+            "urn:undefined:NNSZ00100046",
+            "urn:undefined:(WaOLN)nyp0200092"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar.",
+            "Tamil Siddhas."
+          ],
+          "titleDisplay": [
+            "Kuṟaḷ neṟiyum Citta neṟiyum; ārāyccik kaṭṭurai. Ākkiyōṉ Nā. Pacumpoṟkiḻār."
+          ],
+          "uri": "b10000093",
+          "lccClassification": [
+            "PL4758.9.T5 P3"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Pacumpoṉ, Irāmanātapuram Māvaṭṭam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Kuṟaḷ neṟi cittaneṟi."
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000093"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000037",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 82-5144"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 82-5144",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001838980"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 82-5144"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001838980"
+                    ],
+                    "idBarcode": [
+                      "33433001838980"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 82-005144"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000095",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "17, 504, xi p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Sources de l'histoire du Yemen à l'époque musulmane",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Introduction in Arabic and French.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [437]-467.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Yemen (Republic)",
+            "Yemen (Republic) -- History",
+            "Yemen (Republic) -- History -- Bibliography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Maʻhad al-ʻIlmī al-Faransī lil-Āthār al-Sharqīyah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Maṣādir tārīkh al-Yaman fī al-ʻaṣr al-Islāmī"
+          ],
+          "shelfMark": [
+            "*OFK 82-5143"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Sayyid, Ayman Fuʼād."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75960138"
+          ],
+          "seriesStatement": [
+            "Nuṣūṣ wa-tarjamāt -- al-Maʻhad al-ʻIlmī al-Faransī lil-Āthar al-Sharqīyah; al-mujallad 7"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFK 82-5143"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000095"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960138"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000047-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100047"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200094"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000047-B"
+          ],
+          "uniformTitle": [
+            "Textes et traductions d'auteurs orientaux ; t. 7."
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "al-Qāhirah : al-Maʻhad al-ʻIlmī al-Faransī lil-Āthār al-Sharqīyah, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000095",
+            "urn:lccn:75960138",
+            "urn:oclc:NYPG001000047-B",
+            "urn:undefined:NNSZ00100047",
+            "urn:undefined:(WaOLN)nyp0200094"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Yemen (Republic) -- History -- Bibliography."
+          ],
+          "titleDisplay": [
+            "Maṣādir tārīkh al-Yaman fī al-ʻaṣr al-Islāmī / waḍaʻahā Ayman Fuʼād Sayyid."
+          ],
+          "uri": "b10000095",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah"
+          ],
+          "titleAlt": [
+            "Sources de l'histoire de Yemen à l'époque musulmane."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000095"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000038",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFK 82-5143"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK 82-5143",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005548338"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK 82-5143"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005548338"
+                    ],
+                    "idBarcode": [
+                      "33433005548338"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFK 82-005143"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000097",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "218 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Poems.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Sharikah al-Waṭanīyah lil-Nashr wa-al-Tawzīʻ"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Anti Laylāy"
+          ],
+          "shelfMark": [
+            "*OFA 82-5142"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kharfī, Ṣāliḥ."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75960362"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFA 82-5142"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000097"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960362"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000048-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100048"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200096"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000048-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "al-Jazāʼir : al-Sharikah al-Waṭanīyah lil-Nashr wa-al-Tawzīʻ, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000097",
+            "urn:lccn:75960362",
+            "urn:oclc:NYPG001000048-B",
+            "urn:undefined:NNSZ00100048",
+            "urn:undefined:(WaOLN)nyp0200096"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Anti Laylāy / Ṣāliḥ Kharfī."
+          ],
+          "uri": "b10000097",
+          "lccClassification": [
+            "PJ7842.H3245 A83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Jazāʼir"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000097"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFA 82-5142"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFA 82-5142",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002000689"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFA 82-5142"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002000689"
+                    ],
+                    "idBarcode": [
+                      "33433002000689"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFA 82-005142"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000099",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "520 p. : facsims. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Originally presented as the author's thesis (M. A.) Kullīyat Dār al-ʻUlūm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 507-515.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ibn Rashīq al-Qayrawānī, al-Ḥasan, -1064?",
+            "Arabic poetry",
+            "Arabic poetry -- 750-1258",
+            "Arabic poetry -- 750-1258 -- History and criticism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wakālat al-Maṭbūʻāt"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ibn Rashīq wa-naqd al-shiʻr : dirāsah naqdīyah taḥlīlīyah muqāranah"
+          ],
+          "shelfMark": [
+            "*OFS 82-5141"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Makhlūf, ʻAbd al-Raʼūf."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75960190"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 82-5141"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000099"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960190"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000049-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100049"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200098"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000049-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "al-Kuwayt : Wakālat al-Maṭbūʻāt, 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000099",
+            "urn:lccn:75960190",
+            "urn:oclc:NYPG001000049-B",
+            "urn:undefined:NNSZ00100049",
+            "urn:undefined:(WaOLN)nyp0200098"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ibn Rashīq al-Qayrawānī, al-Ḥasan, -1064?",
+            "Arabic poetry -- 750-1258 -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Ibn Rashīq wa-naqd al-shiʻr : dirāsah naqdīyah taḥlīlīyah muqāranah / bi-qalam ʻAbd al-Raʼūf ʻAbd al-ʻAzīz Makhlūf."
+          ],
+          "uri": "b10000099",
+          "lccClassification": [
+            "PJ7750.I27 Z82 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Kuwayt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000099"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 82-5141"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 82-5141",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514545"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 82-5141"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514545"
+                    ],
+                    "idBarcode": [
+                      "33433014514545"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFS 82-005141"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000101",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "7, 237 p. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "An abridgment of the thesis originally submitted to Jāmiʻat al-Qāhirah, 1963.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 225-229",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Arameans",
+            "Arameans -- Egypt"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "s.n."
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Arāmīyūn fī Miṣr, mundhu bidāyat ẓuhūrihim fī al-qarn al-sābiʻ Q.M. ḥattá ikhtifāʼihim fī al-qarn al-thānī Q.M."
+          ],
+          "shelfMark": [
+            "*OFP 82-5140"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ayad, Boulos Ayad."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "75960565"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFP 82-5140"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000101"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960565"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000050-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100050"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200100"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000050-B"
+          ],
+          "updatedAt": 1674870759272,
+          "publicationStatement": [
+            "[al-Qāhirah : s.n., al-muqaddimah 1975]"
+          ],
+          "identifier": [
+            "urn:bnum:10000101",
+            "urn:lccn:75960565",
+            "urn:oclc:NYPG001000050-B",
+            "urn:undefined:NNSZ00100050",
+            "urn:undefined:(WaOLN)nyp0200100"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Arameans -- Egypt."
+          ],
+          "titleDisplay": [
+            "al-Arāmīyūn fī Miṣr, mundhu bidāyat ẓuhūrihim fī al-qarn al-sābiʻ Q.M. ḥattá ikhtifāʼihim fī al-qarn al-thānī Q.M. / Taʼlīf Būlus ʻAyyād ʻAyyād."
+          ],
+          "uri": "b10000101",
+          "lccClassification": [
+            "DT72.A73 A92"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000101"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 82-5140"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 82-5140",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001937568"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFP 82-5140"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001937568"
+                    ],
+                    "idBarcode": [
+                      "33433001937568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFP 82-005140"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000103",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "11, 602 p.: port.;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Sharikah al-Waṭanīyah lil-Nashr wa-al-Tawzīʻ"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dīwān Muḥammad al-ʻĪd Muḥammad ʻAlī Khalīfah."
+          ],
+          "shelfMark": [
+            "*OFA 82-5137"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Khalīfah, Muḥammad al-ʻĪd, 1904-1979."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "75960366"
+          ],
+          "seriesStatement": [
+            "Manshūrāt Wizārat al-Tarbiyah al-Waṭanīyah bi-al-Jazāʼir; 1"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFA 82-5137"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000103"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960366"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000051-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100051"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200102"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000051-B"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "[al-Jazāʼir]: al-Sharikah al-Waṭanīyah lil-Nashr wa-al-Tawzīʻ, 1967."
+          ],
+          "identifier": [
+            "urn:bnum:10000103",
+            "urn:lccn:75960366",
+            "urn:oclc:NYPG001000051-B",
+            "urn:undefined:NNSZ00100051",
+            "urn:undefined:(WaOLN)nyp0200102"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Dīwān Muḥammad al-ʻĪd Muḥammad ʻAlī Khalīfah."
+          ],
+          "uri": "b10000103",
+          "lccClassification": [
+            "PJ7842.H2937 A17 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[al-Jazāʼir]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000103"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFA 82-5137"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFA 82-5137",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002000671"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFA 82-5137"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002000671"
+                    ],
+                    "idBarcode": [
+                      "33433002000671"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFA 82-005137"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-dbc59d08840a5c4eea7829861c292806.json
+++ b/test/fixtures/query-dbc59d08840a5c4eea7829861c292806.json
@@ -1,0 +1,222 @@
+{
+  "took": 134,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 122.90753,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b12423567",
+        "_score": 122.90753,
+        "_source": {
+          "extent": [
+            "202 p."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Campanella, Tommaso, 1568-1639"
+          ],
+          "publisherLiteral": [
+            "S. Neaulme"
+          ],
+          "language": [
+            {
+              "id": "lang:lat",
+              "label": "Latin"
+            }
+          ],
+          "createdYear": [
+            1741
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vita Th. Campanellae."
+          ],
+          "shelfMark": [
+            "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+          ],
+          "creatorLiteral": [
+            "Cyprian, Ernst Salomon, 1673-1745."
+          ],
+          "createdString": [
+            "1741"
+          ],
+          "dateStartYear": [
+            1741
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12423567"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp2408048"
+            }
+          ],
+          "updatedAt": 1657655482511,
+          "publicationStatement": [
+            "Trajecti ad Rhenum, S. Neaulme, 1741."
+          ],
+          "identifier": [
+            "urn:bnum:12423567",
+            "urn:undefined:(WaOLN)nyp2408048"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1741"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Campanella, Tommaso, 1568-1639."
+          ],
+          "titleDisplay": [
+            "Vita Th. Campanellae. Autore Ern. Sal. Cypriano. Accedunt hac secunda editione appendices IV. doctorum virorum de Campanellae vita, philosophia & libris schediasmata complectentes."
+          ],
+          "uri": "b12423567",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Trajecti ad Rhenum"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "16 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16020288",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433104031624"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "AN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433104031624"
+                    ],
+                    "idBarcode": [
+                      "33433104031624"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "shelfMark_sort": "aAN (Campanella) (Cyprian, E. S. Vita Th. Campanellae)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-dc9ebd16c795435aa3641dc3bf45d6e5.json
+++ b/test/fixtures/query-dc9ebd16c795435aa3641dc3bf45d6e5.json
@@ -1,0 +1,14078 @@
+{
+  "took": 1554,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 13314427,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Stauffenburg"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Gmelin, Hermann, 1900-1958.",
+            "Baum, Richard.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGNYPG-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "idOclc": [
+            "NYPGNYPG-B"
+          ],
+          "updatedAt": 1678937667178,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:oclc:NYPGNYPG-B",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen"
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "3923721544"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000003",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. : col. ill. maps ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrides (Scotland)",
+            "Hebrides (Scotland) -- Pictorial works"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Constable"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1989
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Scottish islands"
+          ],
+          "shelfMark": [
+            "JFF 89-526"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Waite, Charlie."
+          ],
+          "createdString": [
+            "1989"
+          ],
+          "idLccn": [
+            "gb 89012970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1989
+          ],
+          "donor": [
+            "Gift of the Drue Heinz Book Fund for English Literature"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 89-526"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000003"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0094675708 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "gb 89012970"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGUKBPGP8917-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200002"
+            }
+          ],
+          "idOclc": [
+            "NYPGUKBPGP8917-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Constable, 1989."
+          ],
+          "identifier": [
+            "urn:bnum:10000003",
+            "urn:isbn:0094675708 :",
+            "urn:lccn:gb 89012970",
+            "urn:oclc:NYPGUKBPGP8917-B",
+            "urn:undefined:(WaOLN)nyp0200002"
+          ],
+          "idIsbn": [
+            "0094675708 "
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1989"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrides (Scotland) -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Scottish islands / Charlie Waite."
+          ],
+          "uri": "b10000003",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0094675708"
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000003"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 89-526"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 89-526",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050409147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 89-526"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050409147"
+                    ],
+                    "idBarcode": [
+                      "33433050409147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFF 89-000526"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000004",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "23, 216 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1956.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mutaṟkuṟaḷ uvamai."
+          ],
+          "shelfMark": [
+            "*OLB 84-1934"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kothandapani Pillai, K., 1896-"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "74915265"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1247"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1934"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000004"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74915265"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200003"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tirunelvēli, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1965."
+          ],
+          "identifier": [
+            "urn:bnum:10000004",
+            "urn:lccn:74915265",
+            "urn:oclc:NYPG001000001-B",
+            "urn:undefined:NNSZ00100001",
+            "urn:undefined:(WaOLN)nyp0200003"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Mutaṟkuṟaḷ uvamai. Āciriyar Ku. Kōtaṇṭapāṇi Piḷḷai."
+          ],
+          "uri": "b10000004",
+          "lccClassification": [
+            "PL4758.9.T5 K6 1965"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirunelvēli"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000004"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783781",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1934",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1934"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301556"
+                    ],
+                    "idBarcode": [
+                      "33433061301556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001934"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000005",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (43 p.) + 1 part (12 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Acc. arr. for piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Soch. 22\"--Caption.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: 11049.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Concertos (Violin)",
+            "Concertos (Violin) -- Solo with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muzyka"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom"
+          ],
+          "shelfMark": [
+            "JMF 83-336"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Wieniawski, Henri, 1835-1880."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-336"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000005"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "11049. Muzyka"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100551"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200004"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-C"
+          ],
+          "uniformTitle": [
+            "Concertos, violin, orchestra, no. 2, op. 22, D minor; arranged"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Moskva : Muzyka, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000005",
+            "urn:oclc:NYPG001000001-C",
+            "urn:undefined:11049. Muzyka",
+            "urn:undefined:NNSZ00100551",
+            "urn:undefined:(WaOLN)nyp0200004"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Concertos (Violin) -- Solo with piano."
+          ],
+          "titleDisplay": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom / G. Ven︠i︡avskiĭ ; klavir."
+          ],
+          "uri": "b10000005",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Moskva"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Concertos, no. 2, op. 22"
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10000005"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942022",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-336"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-336",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032711909"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-336"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032711909"
+                    ],
+                    "idBarcode": [
+                      "33433032711909"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000336"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000006",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "227 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of The reconstruction of religious thought in Islam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām"
+          ],
+          "shelfMark": [
+            "*OGC 84-1984"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Iqbal, Muhammad, Sir, 1877-1938."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75962707"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Maḥmūd, ʻAbbās."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1984"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000006"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75962707"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100002"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200005"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "al-Qāhirah, Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000006",
+            "urn:lccn:75962707",
+            "urn:oclc:NYPG001000002-B",
+            "urn:undefined:NNSZ00100002",
+            "urn:undefined:(WaOLN)nyp0200005"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām, taʼlif Muhammad Iqbāl. Tarjamat ʻAbbās Maḥmūd. Rājaʻa muqaddimatahu wa-al-faṣl al-awwal minhu ʻAbd al-ʻAzīz al-Maraghī, wa-rājaʻa baqīyat al-Kitāb Mahdī ʻAllām."
+          ],
+          "uri": "b10000006",
+          "lccClassification": [
+            "BP161 .I712 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000006"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691665"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1984"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691665"
+                    ],
+                    "idBarcode": [
+                      "33433022691665"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001984"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 7:35.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: Z.8917.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Guitar music",
+            "Guitar",
+            "Guitar -- Studies and exercises"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Editio Musica"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Due studi per chitarra"
+          ],
+          "shelfMark": [
+            "JMG 83-276"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Patachich, Iván."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000007"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Z.8917. Editio Musica"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100552"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200006"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-C"
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Budapest : Editio Musica, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000007",
+            "urn:oclc:NYPG001000002-C",
+            "urn:undefined:Z.8917. Editio Musica",
+            "urn:undefined:NNSZ00100552",
+            "urn:undefined:(WaOLN)nyp0200006"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Guitar music.",
+            "Guitar -- Studies and exercises."
+          ],
+          "titleDisplay": [
+            "Due studi per chitarra / Patachich Iván."
+          ],
+          "uri": "b10000007",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Budapest"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies"
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000007"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942023",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-276"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-276",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883591"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-276"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883591"
+                    ],
+                    "idBarcode": [
+                      "33433032883591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000276"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000008",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "351 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Parimaḷam Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṇṇāviṉ ciṟukataikaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1986"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Annadurai, C. N., 1909-1969."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913998"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1986"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000008"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913998"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100003"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200007"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Parimaḷam Patippakam [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000008",
+            "urn:lccn:72913998",
+            "urn:oclc:NYPG001000003-B",
+            "urn:undefined:NNSZ00100003",
+            "urn:undefined:(WaOLN)nyp0200007"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Aṇṇāviṉ ciṟukataikaḷ. [Eḻutiyavar] Ci. Eṉ. Aṇṇāturai."
+          ],
+          "uri": "b10000008",
+          "lccClassification": [
+            "PL4758.9.A5 A84"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000008"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783782",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1986",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301689"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1986"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301689"
+                    ],
+                    "idBarcode": [
+                      "33433061301689"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001986"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000009",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "30 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Edition Peters Nr. 5489.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: E.P. 13028.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Edition Peters ; C.F. Peters"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Miniaturen II : 13 kleine Klavierstücke"
+          ],
+          "shelfMark": [
+            "JMG 83-278"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Golle, Jürgen, 1942-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-278"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000009"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters Nr. 5489 Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "E.P. 13028. Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200008"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-C"
+          ],
+          "uniformTitle": [
+            "Miniaturen, no. 2"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Leipzig : Edition Peters ; New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000009",
+            "urn:oclc:NYPG001000003-C",
+            "urn:undefined:Edition Peters Nr. 5489 Edition Peters",
+            "urn:undefined:E.P. 13028. Edition Peters",
+            "urn:undefined:NNSZ00100553",
+            "urn:undefined:(WaOLN)nyp0200008"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Miniaturen II : 13 kleine Klavierstücke / Jürgen Golle."
+          ],
+          "uri": "b10000009",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig : New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen, no. 2"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000009"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942024",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-278"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-278",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883617"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-278"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883617"
+                    ],
+                    "idBarcode": [
+                      "33433032883617"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000278"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000010",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "110 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cēkkiḻār, active 12th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaikkaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1938"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Irācamāṇikkaṉār, Mā., 1907-1967."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913466"
+          ],
+          "seriesStatement": [
+            "Corṇammāḷ corpoḻivu varicai, 6"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1938"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100004"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200009"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Aṇṇāmalainakar, Aṇṇāmalaip Palkalaikkaḻakam, 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000010",
+            "urn:lccn:72913466",
+            "urn:oclc:NYPG001000004-B",
+            "urn:undefined:NNSZ00100004",
+            "urn:undefined:(WaOLN)nyp0200009"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cēkkiḻār, active 12th century."
+          ],
+          "titleDisplay": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ. [Āṟṟiyavar] Mā. Irācamāṇikkaṉār."
+          ],
+          "uri": "b10000010",
+          "lccClassification": [
+            "PL4758.9.C385 Z8"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Aṇṇāmalainakar"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000010"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783783",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1938",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301598"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1938"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301598"
+                    ],
+                    "idBarcode": [
+                      "33433061301598"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001938"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "46 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)",
+            "Easter music (Organ)",
+            "Passion music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Boeijenga"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1982"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Passie en pasen : suite voor orgel, opus 50"
+          ],
+          "shelfMark": [
+            "JMG 83-279"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Berg, Jan J. van den."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-279"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000011"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200010"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-C"
+          ],
+          "dateEndYear": [
+            1982
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Sneek [Netherlands] : Boeijenga, [between 1976 and 1982]."
+          ],
+          "identifier": [
+            "urn:bnum:10000011",
+            "urn:oclc:NYPG001000004-C",
+            "urn:undefined:(WaOLN)nyp0200010"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)",
+            "Easter music (Organ)",
+            "Passion music."
+          ],
+          "titleDisplay": [
+            "Passie en pasen : suite voor orgel, opus 50 / door Jan J. van den Berg."
+          ],
+          "uri": "b10000011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Sneek [Netherlands]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Passie. I. Psalm 22. II. Leer mij O Heer. III. \"Mijn Verlosser hangt aan 't kruis.\" IV. \"O hoofd vol bloed en wonden.\" V. \"O kostbaar kruis.\" VI. \"Jezus, leven van mijn leven\" -- Pasen. VII. Toccata over \"Christus is opgestanden.\" VIII. Canon: \"Jesus unser Trost und Leben.\" IX. Trio: Ik zeg het allen dat Hij leeft.\" X. Trio: \"Staakt Uw rouwen Magdalene.\" XI. Postludium over \"Jesus leeft en wij met Hem\" (met \"Christus onze Heer verrees\" als tegenstem)."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000011"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942025",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-279"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-279",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883625"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-279"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883625"
+                    ],
+                    "idBarcode": [
+                      "33433032883625"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000279"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "223 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p.221.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Thaqāfah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi"
+          ],
+          "shelfMark": [
+            "*OFS 84-1997"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ḥāwī, Īlīyā Salīm."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 84-1997"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200011"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Thaqāfah, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000012",
+            "urn:oclc:NYPG001000005-B",
+            "urn:undefined:NNSZ00100005",
+            "urn:undefined:(WaOLN)nyp0200011"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "titleDisplay": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi / bi-qalam Īlīyā Ḥāwī."
+          ],
+          "uri": "b10000012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000012"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000003",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 84-1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514719"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 84-1997"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514719"
+                    ],
+                    "idBarcode": [
+                      "33433014514719"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFS 84-001997"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000013",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "32 p. of music : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Popular music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Arr. for piano with chord symbols; superlinear German words.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Popular music -- Germany (East)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Harth Musik Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "shelfMark": [
+            "JMF 83-366"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-366"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000013"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100555"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200012"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Leipzig : Harth Musik Verlag, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000013",
+            "urn:oclc:NYPG001000005-C",
+            "urn:undefined:NNSZ00100555",
+            "urn:undefined:(WaOLN)nyp0200012"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Popular music -- Germany (East)"
+          ],
+          "titleDisplay": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "uri": "b10000013",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Disko Treff eins."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000013"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942026",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-366"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-366",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032712204"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-366"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032712204"
+                    ],
+                    "idBarcode": [
+                      "33433032712204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000366"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000014",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "520 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on cover: Islamic unity or the Mutual approach among Muslim sects.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Panislamism",
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muʼassasat al-Aʻlamī lil-Maṭbūʻāt"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah"
+          ],
+          "shelfMark": [
+            "*OGC 84-1996"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Shīrāzī, ʻAbd al-Karīm Bī Āzār."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1996"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000014"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100006"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200013"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Muʼassasat al-Aʻlamī lil-Maṭbūʻāt, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000014",
+            "urn:oclc:NYPG001000006-B",
+            "urn:undefined:NNSZ00100006",
+            "urn:undefined:(WaOLN)nyp0200013"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Panislamism.",
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah / Jamʻ wa-tartīb ʻAbd al-Karīm Bī Āzār al-Shīrāzī."
+          ],
+          "uri": "b10000014",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Islamic unity."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000014"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691780"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1996"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691780"
+                    ],
+                    "idBarcode": [
+                      "33433022691780"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001996"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000015",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "25 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For organ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"A McAfee Music Publication.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: DM 220.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Belwin-Mills"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Suite no. 1 : 1977"
+          ],
+          "shelfMark": [
+            "JNG 83-102"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hampton, Calvin."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNG 83-102"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000015"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "DM 220. Belwin-Mills"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100556"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200014"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-C"
+          ],
+          "uniformTitle": [
+            "Suite, organ, no. 1"
+          ],
+          "updatedAt": 1678726416948,
+          "publicationStatement": [
+            "Melville, NY : Belwin-Mills, [1980?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000015",
+            "urn:oclc:NYPG001000006-C",
+            "urn:undefined:DM 220. Belwin-Mills",
+            "urn:undefined:NNSZ00100556",
+            "urn:undefined:(WaOLN)nyp0200014"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)"
+          ],
+          "titleDisplay": [
+            "Suite no. 1 : 1977 / Calvin Hampton."
+          ],
+          "uri": "b10000015",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Melville, NY"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Suite, no. 1"
+          ],
+          "tableOfContents": [
+            "Fanfares -- Antiphon -- Toccata."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000015"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000016",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "111 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuṟuntokai"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Manṅkaḷa Nūlakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nalla Kuṟuntokaiyil nāṉilam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1937"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Cellappaṉ, Cilampoli, 1929-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "74913402"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1937"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000016"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74913402"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200015"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Ceṉṉai, Manṅkaḷa Nūlakam, 1959 [i.e. 1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000016",
+            "urn:lccn:74913402",
+            "urn:oclc:NYPG001000007-B",
+            "urn:undefined:NNSZ00100007",
+            "urn:undefined:(WaOLN)nyp0200015"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuṟuntokai."
+          ],
+          "titleDisplay": [
+            "Nalla Kuṟuntokaiyil nāṉilam. [Eḻutiyavar] Cu. Cellappaṉ."
+          ],
+          "uri": "b10000016",
+          "lccClassification": [
+            "PL4758.9.K794 Z6 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000016"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783785",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1937",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301580"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1937"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301580"
+                    ],
+                    "idBarcode": [
+                      "33433061301580"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001937"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000017",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (17 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For baritone and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Words printed also as text.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 3:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Corbière, Tristan, 1845-1875",
+            "Corbière, Tristan, 1845-1875 -- Musical settings",
+            "Songs (Medium voice) with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lettre du Mexique : pour baryton et piano, 1942"
+          ],
+          "shelfMark": [
+            "JMG 83-395"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Escher, Rudolf."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Corbière, Tristan, 1845-1875."
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000017"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100557"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200016"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000017",
+            "urn:oclc:NYPG001000007-C",
+            "urn:undefined:NNSZ00100557",
+            "urn:undefined:(WaOLN)nyp0200016"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Corbière, Tristan, 1845-1875 -- Musical settings.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "Lettre du Mexique : pour baryton et piano, 1942 / Rudolf Escher ; poème de Tristan Corbière."
+          ],
+          "uri": "b10000017",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000017"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-395"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-395",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032735007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-395"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032735007"
+                    ],
+                    "idBarcode": [
+                      "33433032735007"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000395"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "68 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Lebanon"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Ṭalīʻah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā"
+          ],
+          "shelfMark": [
+            "*OFX 84-1995"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Bashshūr, Najlāʼ Naṣīr."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "78970449"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1995"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000018"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78970449"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100008"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200017"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Ṭalīʻah, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000018",
+            "urn:lccn:78970449",
+            "urn:oclc:NYPG001000008-B",
+            "urn:undefined:NNSZ00100008",
+            "urn:undefined:(WaOLN)nyp0200017"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Lebanon."
+          ],
+          "titleDisplay": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā / Najlāʼ Naṣīr Bashshūr."
+          ],
+          "uri": "b10000018",
+          "lccClassification": [
+            "HQ1728 .B37"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000018"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000004",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1995"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031718"
+                    ],
+                    "idBarcode": [
+                      "33433002031718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001995"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000019",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: M 18.487.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Waltzes (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zwölf Walzer und ein Epilog : für Klavier"
+          ],
+          "shelfMark": [
+            "JMG 83-111"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Benary, Peter."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-111"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000019"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Möseler M 18.487."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200018"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-C"
+          ],
+          "uniformTitle": [
+            "Walzer und ein Epilog"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000019",
+            "urn:oclc:NYPG001000008-C",
+            "urn:undefined:Möseler M 18.487.",
+            "urn:undefined:NNSZ00100558",
+            "urn:undefined:(WaOLN)nyp0200018"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Waltzes (Piano)"
+          ],
+          "titleDisplay": [
+            "Zwölf Walzer und ein Epilog : für Klavier / Peter Benary."
+          ],
+          "uri": "b10000019",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Walzer und ein Epilog",
+            "Walzer und ein Epilog."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000019"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942028",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-111"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-111",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-111"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845053"
+                    ],
+                    "idBarcode": [
+                      "33433032845053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000111"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000020",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 172, 320 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tolkāppiyar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaik Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tolkāppiyam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1936"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "creatorLiteral": [
+            "Veḷḷaivāraṇaṉ, Ka."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "74914844"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1936"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000020"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74914844"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200019"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "[Aṇṇāmalainakar] Aṇṇāmalaip Palkalaik Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000020",
+            "urn:lccn:74914844",
+            "urn:oclc:NYPG001000009-B",
+            "urn:undefined:NNSZ00100009",
+            "urn:undefined:(WaOLN)nyp0200019"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tolkāppiyar."
+          ],
+          "titleDisplay": [
+            "Tolkāppiyam. [Eḻutiyavar] Ka. Veḷḷaivāraṇaṉ."
+          ],
+          "uri": "b10000020",
+          "lccClassification": [
+            "PL4754.T583 V4 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Aṇṇāmalainakar]"
+          ],
+          "titleAlt": [
+            "Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Tolkāppiyam.--Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000020"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783786",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1936 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1936 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301572"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1936"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301572"
+                    ],
+                    "idBarcode": [
+                      "33433061301572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-1936 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000021",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (51 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: NM 384.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Verlag Neue Musik"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aurora : sinfonischer Prolog : Partitur"
+          ],
+          "shelfMark": [
+            "JMG 83-113"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Weitzendorf, Heinz."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-113"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000021"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NM 384. Verlag Neue Musik"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100559"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200020"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-C"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Berlin : Verlag Neue Musik, c1978."
+          ],
+          "identifier": [
+            "urn:bnum:10000021",
+            "urn:oclc:NYPG001000009-C",
+            "urn:undefined:NM 384. Verlag Neue Musik",
+            "urn:undefined:NNSZ00100559",
+            "urn:undefined:(WaOLN)nyp0200020"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "Aurora : sinfonischer Prolog : Partitur / Heinz Weitzendorf."
+          ],
+          "uri": "b10000021",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Berlin"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000021"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942029",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-113"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-113",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845079"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-113"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845079"
+                    ],
+                    "idBarcode": [
+                      "33433032845079"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000113"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000022",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "19, 493 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1942.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Grammar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1935"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Puttamittiraṉār, active 11th century."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "73913714"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1388"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Peruntēvaṉār, active 11th century.",
+            "Kōvintarāja Mutaliyār, Kā. Ra., 1874-1952."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1935"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73913714"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100010"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200021"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000022",
+            "urn:lccn:73913714",
+            "urn:oclc:NYPG001000010-B",
+            "urn:undefined:NNSZ00100010",
+            "urn:undefined:(WaOLN)nyp0200021"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ. Patippāciriyar Kā. Ra. Kōvintarāca Mutaliyār."
+          ],
+          "uri": "b10000022",
+          "lccClassification": [
+            "PL4754 .P8 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "titleAlt": [
+            "Viracōḻiyam."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000022"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783787",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1935",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301564"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1935"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301564"
+                    ],
+                    "idBarcode": [
+                      "33433061301564"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001935"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000023",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (18 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For band or wind ensemble.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Based on the composer's Veni creator spiritus.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: KC913.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Band music",
+            "Band music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Shawnee Press"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Musica sacra"
+          ],
+          "shelfMark": [
+            "JMF 83-38"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Zaninelli, Luigi."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-38"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000023"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "KC913 Shawnee Press"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100560"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200022"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-C"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Delaware Water Gap, Pa. : Shawnee Press, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000023",
+            "urn:oclc:NYPG001000010-C",
+            "urn:undefined:KC913 Shawnee Press",
+            "urn:undefined:NNSZ00100560",
+            "urn:undefined:(WaOLN)nyp0200022"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Band music -- Scores."
+          ],
+          "titleDisplay": [
+            "Musica sacra / Luigi Zaninelli."
+          ],
+          "uri": "b10000023",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Delaware Water Gap, Pa."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10000023"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942030",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-38"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-38",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709028"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-38"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709028"
+                    ],
+                    "idBarcode": [
+                      "33433032709028"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000038"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000024",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bahrain",
+            "Bahrain -- History",
+            "Bahrain -- History -- 20th century",
+            "Bahrain -- Economic conditions",
+            "Bahrain -- Social conditions"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār Ibn Khaldūn"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī"
+          ],
+          "shelfMark": [
+            "*OFK 84-1944"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rumayḥī, Muḥammad Ghānim."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "79971032"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFK 84-1944"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000024"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79971032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200023"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[Bayrūt] : Dār Ibn Khaldūn, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000024",
+            "urn:lccn:79971032",
+            "urn:oclc:NYPG001000011-B",
+            "urn:undefined:NNSZ00100011",
+            "urn:undefined:(WaOLN)nyp0200023"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bahrain -- History -- 20th century.",
+            "Bahrain -- Economic conditions.",
+            "Bahrain -- Social conditions."
+          ],
+          "titleDisplay": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī / Muḥammad al-Rumayḥī."
+          ],
+          "uri": "b10000024",
+          "lccClassification": [
+            "DS247.B28 R85"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000024"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000005",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK 84-1944",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005548676"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK 84-1944"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005548676"
+                    ],
+                    "idBarcode": [
+                      "33433005548676"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFK 84-001944"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000025",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei Sonatinen für Klavier"
+          ],
+          "shelfMark": [
+            "JMF 83-107"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stockmeier, Wolfgang."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 179"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-107"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000025"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100561"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200024"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-C"
+          ],
+          "uniformTitle": [
+            "Sonatinas, piano"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000025",
+            "urn:oclc:NYPG001000011-C",
+            "urn:undefined:NNSZ00100561",
+            "urn:undefined:(WaOLN)nyp0200024"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Drei Sonatinen für Klavier / Wolfgang Stockmeier."
+          ],
+          "uri": "b10000025",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatinas"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000025"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-107"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-107",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709697"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-107"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709697"
+                    ],
+                    "idBarcode": [
+                      "33433032709697"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000107"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000026",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "222 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 217-220.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Syria"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975"
+          ],
+          "shelfMark": [
+            "*OFX 84-1953"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Razzāz, Nabīlah."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76960987"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1953"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000026"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960987"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200025"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Dimashq : Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000026",
+            "urn:lccn:76960987",
+            "urn:oclc:NYPG001000012-B",
+            "urn:undefined:NNSZ00100012",
+            "urn:undefined:(WaOLN)nyp0200025"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Syria."
+          ],
+          "titleDisplay": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975 / Nabīlah al-Razzāz."
+          ],
+          "uri": "b10000026",
+          "lccClassification": [
+            "HQ402 .R39"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10000026"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000006",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1953",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031700"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1953"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031700"
+                    ],
+                    "idBarcode": [
+                      "33433002031700"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001953"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000027",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Violin)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei kleine Sonaten : für Violine solo"
+          ],
+          "shelfMark": [
+            "JMF 83-95"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Köhler, Friedemann."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 172"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-95"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000027"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100562"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200026"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-C"
+          ],
+          "uniformTitle": [
+            "Kleine Sonaten, violin"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler Verlag, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000027",
+            "urn:oclc:NYPG001000012-C",
+            "urn:undefined:NNSZ00100562",
+            "urn:undefined:(WaOLN)nyp0200026"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Violin)"
+          ],
+          "titleDisplay": [
+            "Drei kleine Sonaten : für Violine solo / Friedemann Köhler."
+          ],
+          "uri": "b10000027",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Kleine Sonaten"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000027"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-95"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-95",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-95"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709572"
+                    ],
+                    "idBarcode": [
+                      "33433032709572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000095"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000028",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "9, 3, 3, 324 p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Prastuta śodha-prabandha Rājasthāna Viśvavidyālaya, Jayapura kī Pī-eca.Ḍī-upāthi ke nimitta viśvavidyālaya anudāna āyoga kī risarca phailośipa ke antargata likhā gayā thā.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [321]-324.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sūryamalla Miśraṇa, 1815-1868"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Rājasthāna Sāhitya Akādamī (Saṅgama)"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vaṃśabhāskara : eka adhyayana"
+          ],
+          "shelfMark": [
+            "*OKTM 84-1945"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Khāna, Ālama Śāha, 1936-2003."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75903689"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000028"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75903689"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200027"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Udayapura : Rājasthāna Sāhitya Akādamī (Saṅgama), 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000028",
+            "urn:lccn:75903689",
+            "urn:oclc:NYPG001000013-B",
+            "urn:undefined:NNSZ00100013",
+            "urn:undefined:(WaOLN)nyp0200027"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sūryamalla Miśraṇa, 1815-1868."
+          ],
+          "titleDisplay": [
+            "Vaṃśabhāskara : eka adhyayana / lekhaka Ālamaśāha Khāna."
+          ],
+          "uri": "b10000028",
+          "lccClassification": [
+            "PK2708.9.S9 V334"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Udayapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000028"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-1945",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011094210"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-1945"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011094210"
+                    ],
+                    "idBarcode": [
+                      "33433011094210"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-001945"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000029",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Wilhelm Hansen edition no. 4372.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: 29589.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Organ music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "W. Hansen ; Distribution, Magnamusic-Baton"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cruor : for organ solo, 1977"
+          ],
+          "shelfMark": [
+            "JMF 83-93"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lorentzen, Bent."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82771131"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-93"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000029"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82771131"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Wilhelm Hansen edition no. 4372."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "29589."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100563"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200028"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Copenhagen ; New York : W. Hansen ; [s.l.] : Distribution, Magnamusic-Baton, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000029",
+            "urn:lccn:82771131",
+            "urn:oclc:NYPG001000013-C",
+            "urn:undefined:Wilhelm Hansen edition no. 4372.",
+            "urn:undefined:29589.",
+            "urn:undefined:NNSZ00100563",
+            "urn:undefined:(WaOLN)nyp0200028"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Organ music."
+          ],
+          "titleDisplay": [
+            "Cruor : for organ solo, 1977 / B. Lorentzen."
+          ],
+          "uri": "b10000029",
+          "lccClassification": [
+            "M11 .L"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Copenhagen ; New York : [s.l.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000029"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942034",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-93"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-93",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-93"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709556"
+                    ],
+                    "idBarcode": [
+                      "33433032709556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000093"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000030",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21, 264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Āryasamāja-śatābdī-saṃskaraṇam.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Authorship uncertain. Attributed variously to Āpiśali, Pānini and Śākaṭāyana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit: introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Suffixes and prefixes"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; prāptisthānam, Rāmalāla Kapūra Ṭrasṭa"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Uṇādi-koṣaḥ"
+          ],
+          "shelfMark": [
+            "*OKA 84-1931"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902275"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Āpiśali.",
+            "Pāṇini.",
+            "Śākatāyana.",
+            "Dayananda Sarasvati, Swami, 1824-1883.",
+            "Yudhiṣṭhira Mīmāṃsaka, 1909-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKA 84-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000030"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902275"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200029"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-B"
+          ],
+          "uniformTitle": [
+            "Uṇādisūtra."
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Karanāla : Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; Bahālagaḍha, Harayāṇa : prāptisthānam, Rāmalāla Kapūra Ṭrasṭa, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000030",
+            "urn:lccn:75902275",
+            "urn:oclc:NYPG001000014-B",
+            "urn:undefined:NNSZ00100014",
+            "urn:undefined:(WaOLN)nyp0200029"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Suffixes and prefixes."
+          ],
+          "titleDisplay": [
+            "Uṇādi-koṣaḥ / Dayānanda Sarasvatī Svāminā viracitayā Vaidika-laukika-koṣābhidhayā vyākhyayā sahitaḥ vividhābhi-ṣṭippaṇībhiḥ sūcībhiśca saṃyutaḥ ; sampādakaḥ Yudhiṣṭhiro Mīmāṃsakaḥ."
+          ],
+          "uri": "b10000030",
+          "lccClassification": [
+            "PK551 .U73"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Karanāla : Bahālagaḍha, Harayāṇa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000030"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000007",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKA 84-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012968222"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKA 84-1931"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012968222"
+                    ],
+                    "idBarcode": [
+                      "33433012968222"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKA 84-001931"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000031",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "W. Müller"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Neun Miniaturen : für Klavier : op. 52"
+          ],
+          "shelfMark": [
+            "JMG 83-17"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Petersen, Wilhelm, 1890-1957."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-17"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000031"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "W. Müller WM 1713 SM."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200030"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-C"
+          ],
+          "uniformTitle": [
+            "Miniaturen"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Heidelberg : W. Müller, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000031",
+            "urn:oclc:NYPG001000014-C",
+            "urn:undefined:W. Müller WM 1713 SM.",
+            "urn:undefined:NNSZ00100564",
+            "urn:undefined:(WaOLN)nyp0200030"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Neun Miniaturen : für Klavier : op. 52 / Wilhelm Petersen."
+          ],
+          "uri": "b10000031",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Heidelberg"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen",
+            "Miniaturen."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000031"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942035",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-17"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-17",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841631"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841631"
+                    ],
+                    "idBarcode": [
+                      "33433032841631"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000017"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000032",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14, 405, 7 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jahrom (Iran : Province)",
+            "Jahrom (Iran : Province) -- Biography",
+            "Khafr (Iran)",
+            "Khafr (Iran) -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kitābfurūshī-i Khayyām"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr"
+          ],
+          "shelfMark": [
+            "*OMP 84-2007"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ishrāq, Muḥammad Karīm."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2007"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200031"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tihrān : Kitābfurūshī-i Khayyām, 1351 [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000032",
+            "urn:oclc:NYPG001000015-B",
+            "urn:undefined:NNSZ00100015",
+            "urn:undefined:(WaOLN)nyp0200031"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jahrom (Iran : Province) -- Biography.",
+            "Khafr (Iran) -- Biography."
+          ],
+          "titleDisplay": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr / taʼlīf-i Muḥammad Karīm Ishrāq."
+          ],
+          "uri": "b10000032",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm"
+          ]
+        },
+        "sort": [
+          "b10000032"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2007",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173012"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2007"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173012"
+                    ],
+                    "idBarcode": [
+                      "33433013173012"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002007"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000033",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (20 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For voice and organ.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sacred songs (Medium voice) with organ",
+            "Psalms (Music)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Agápe"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Psalm settings"
+          ],
+          "shelfMark": [
+            "JMG 83-59"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Nelhybel, Vaclav."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-59"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000033"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100565"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200032"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Carol Stream, Ill. : Agápe, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000033",
+            "urn:oclc:NYPG001000015-C",
+            "urn:undefined:NNSZ00100565",
+            "urn:undefined:(WaOLN)nyp0200032"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sacred songs (Medium voice) with organ.",
+            "Psalms (Music)"
+          ],
+          "titleDisplay": [
+            "Psalm settings / Vaclav Nelhybel."
+          ],
+          "uri": "b10000033",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Carol Stream, Ill."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Hear me when I call -- Be not far from me -- Hear my voice -- The Lord is my rock."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000033"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942037",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-59",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-59"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942036",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-59",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842035"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-59"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842035"
+                    ],
+                    "idBarcode": [
+                      "33433032842035"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "366 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Brhatkathāślokasaṁgrahaḥ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Colophon: Iti Śrībhaṭṭabudhasvāminā krte ślokasaṁgrahe Brhatkathāyāṁ--",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Text in Sanskrit; apparatus in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Prithivi Prakashan"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brhatkathāślokasaṁgraha : a study"
+          ],
+          "shelfMark": [
+            "*OKR 84-2006"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Budhasvāmin."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903273"
+          ],
+          "seriesStatement": [
+            "Indian civilization series ; no. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Guṇāḍhya.",
+            "Agrawala, Vasudeva Sharana.",
+            "Agrawala, Prithvi Kumar."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKR 84-2006"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000034"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903273"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100016"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200033"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Varanasi : Prithivi Prakashan, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000034",
+            "urn:lccn:74903273",
+            "urn:oclc:NYPG001000016-B",
+            "urn:undefined:NNSZ00100016",
+            "urn:undefined:(WaOLN)nyp0200033"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Brhatkathāślokasaṁgraha : a study / by V.S. Agrawala ; with Sanskrit text, edited by P.K. Agrawala."
+          ],
+          "uri": "b10000034",
+          "lccClassification": [
+            "PK3794.B84 B7 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Varanasi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000034"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKR 84-2006",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011528696"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKR 84-2006"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011528696"
+                    ],
+                    "idBarcode": [
+                      "33433011528696"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKR 84-002006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000035",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "22 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Suite.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 12:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Serenade voor piano : 1980"
+          ],
+          "shelfMark": [
+            "JMG 83-6"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kasbergen, Marinus, 1936-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000035"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100566"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200034"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-C"
+          ],
+          "uniformTitle": [
+            "Serenade, piano"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000035",
+            "urn:oclc:NYPG001000016-C",
+            "urn:undefined:NNSZ00100566",
+            "urn:undefined:(WaOLN)nyp0200034"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Piano)"
+          ],
+          "titleDisplay": [
+            "Serenade voor piano : 1980 / Marinus Kasbergen."
+          ],
+          "uri": "b10000035",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Serenade"
+          ],
+          "tableOfContents": [
+            "Varianten -- Nocturne -- Toccata I -- Intermezzo -- Toccata II."
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000035"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942038",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841490"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-6"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841490"
+                    ],
+                    "idBarcode": [
+                      "33433032841490"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-6",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-6"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000036",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "viii, 38 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; prefatory matter in Sanskrit or Telegu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nārāyaṇatīrtha, 17th cent",
+            "Nārāyaṇatīrtha, 17th cent -- In literature"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic]"
+          ],
+          "shelfMark": [
+            "*OKB 84-1928"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75902755"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKB 84-1928"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000036"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902755"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200035"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[s.1. : s.n.], 1972"
+          ],
+          "identifier": [
+            "urn:bnum:10000036",
+            "urn:lccn:75902755",
+            "urn:oclc:NYPG001000017-B",
+            "urn:undefined:NNSZ00100017",
+            "urn:undefined:(WaOLN)nyp0200035"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nārāyaṇatīrtha, 17th cent -- In literature."
+          ],
+          "titleDisplay": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic] / praṇetā Garikapāṭi Lakṣmīkāntaḥ."
+          ],
+          "uri": "b10000036",
+          "lccClassification": [
+            "PK3799.L28 S68"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[s.1."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000036"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKB 84-1928"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKB 84-1928",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058548433"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKB 84-1928"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058548433"
+                    ],
+                    "idBarcode": [
+                      "33433058548433"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKB 84-001928"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000037",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13a p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 15:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Guitar)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Eight studies for guitar : in form of a suite : 1979"
+          ],
+          "shelfMark": [
+            "JMG 83-5"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hekster, Walter."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000037"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100567"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200036"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-C"
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000037",
+            "urn:oclc:NYPG001000017-C",
+            "urn:undefined:NNSZ00100567",
+            "urn:undefined:(WaOLN)nyp0200036"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Guitar)"
+          ],
+          "titleDisplay": [
+            "Eight studies for guitar : in form of a suite : 1979 / Walter Hekster."
+          ],
+          "uri": "b10000037",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies"
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000037"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841482"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-5"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841482"
+                    ],
+                    "idBarcode": [
+                      "33433032841482"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000005"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000038",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 160 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit, with verse and prose translations in Hindi; prefatory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit poetry",
+            "Sanskrit poetry -- Himachal Pradesh"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Himācala Kalā-Saṃskrti-Bhāṣā Akādamī"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana"
+          ],
+          "shelfMark": [
+            "*OKP 84-1932"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900772"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Prarthi, Lall Chand, 1916-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 84-1932"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000038"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900772"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200037"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Śimalā : Himācala Kalā-Saṃskrti-Bhāṣā Akādamī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000038",
+            "urn:lccn:76900772",
+            "urn:oclc:NYPG001000018-B",
+            "urn:undefined:NNSZ00100018",
+            "urn:undefined:(WaOLN)nyp0200037"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit poetry -- Himachal Pradesh."
+          ],
+          "titleDisplay": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana / mukhya sampādaka Lāla Canda Prārthī ; sampādaka maṇḍala, Manasā Rāma Śarmā 'Arūṇa'...[et al.]."
+          ],
+          "uri": "b10000038",
+          "lccClassification": [
+            "PK3800.H52 R7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Śimalā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000038"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783788",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 84-1932",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 84-1932"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153572"
+                    ],
+                    "idBarcode": [
+                      "33433058153572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKP 84-001932"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000039",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "49 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "C.F. Peters"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Five sonatas for pianoforte"
+          ],
+          "shelfMark": [
+            "JMG 83-66"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hässler, Johann Wilhelm, 1747-1822."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Oberdoerffer, Fritz."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000039"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters no. 66799. C.F. Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100568"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200038"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-C"
+          ],
+          "uniformTitle": [
+            "Sonatas, piano. Selections"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000039",
+            "urn:oclc:NYPG001000018-C",
+            "urn:undefined:Edition Peters no. 66799. C.F. Peters",
+            "urn:undefined:NNSZ00100568",
+            "urn:undefined:(WaOLN)nyp0200038"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Five sonatas for pianoforte / Johann Wilhelm Hässler ; edited by Fritz Oberdoerffer."
+          ],
+          "uri": "b10000039",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatas"
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000039"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842100"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-66"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842100"
+                    ],
+                    "idBarcode": [
+                      "33433032842100"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000066"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000040",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "146 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār."
+          ],
+          "shelfMark": [
+            "*OLB 84-1947"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Pulavar Arasu, 1900-"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "78913375"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 672"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1947"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000040"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78913375"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200039"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000040",
+            "urn:lccn:78913375",
+            "urn:oclc:NYPG001000019-B",
+            "urn:undefined:NNSZ00100019",
+            "urn:undefined:(WaOLN)nyp0200039"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953."
+          ],
+          "titleDisplay": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār. Āciriyar Pulavar Aracu."
+          ],
+          "uri": "b10000040",
+          "lccClassification": [
+            "PL4758.9.K223 Z83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000040"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783789",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1947",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301622"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1947"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301622"
+                    ],
+                    "idBarcode": [
+                      "33433061301622"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001947"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000041",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (23 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 5 clarinets.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Woodwind quintets (Clarinets (5))",
+            "Woodwind quintets (Clarinets (5)) -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Primavera"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Encounter"
+          ],
+          "shelfMark": [
+            "JMF 83-66"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Usher, Julia."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "81770739"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000041"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770739"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100569"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200040"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Primavera, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000041",
+            "urn:lccn:81770739",
+            "urn:oclc:NYPG001000019-C",
+            "urn:undefined:NNSZ00100569",
+            "urn:undefined:(WaOLN)nyp0200040"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Woodwind quintets (Clarinets (5)) -- Scores."
+          ],
+          "titleDisplay": [
+            "Encounter / Julia Usher."
+          ],
+          "uri": "b10000041",
+          "lccClassification": [
+            "M557.2.U8 E5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Greeting -- Circular argument -- Escape."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000041"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709291"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-66"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709291"
+                    ],
+                    "idBarcode": [
+                      "33433032709291"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000066"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000042",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 108 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit: pref. in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Advaita",
+            "Vedanta"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Devabhāṣā Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "dateEndString": [
+            "1972"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita."
+          ],
+          "shelfMark": [
+            "*OKN 84-1926"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902870"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Brahmashram, Śwami, 1915-"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 84-1926"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000042"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902870"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100020"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200041"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-B"
+          ],
+          "uniformTitle": [
+            "Mahābhārata. Sanatsugātīya."
+          ],
+          "dateEndYear": [
+            1972
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Prayāga, Devabhāṣā Prakāśana, Samvat 2028, i.e. 1971 or 2]"
+          ],
+          "identifier": [
+            "urn:bnum:10000042",
+            "urn:lccn:72902870",
+            "urn:oclc:NYPG001000020-B",
+            "urn:undefined:NNSZ00100020",
+            "urn:undefined:(WaOLN)nyp0200041"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Advaita.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita. Vyākhyātā Svāmī Brahmāśrama."
+          ],
+          "uri": "b10000042",
+          "lccClassification": [
+            "B132.V3 M264"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Prayāga"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000042"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783790",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 84-1926"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 84-1926",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618392"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKN 84-1926"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618392"
+                    ],
+                    "idBarcode": [
+                      "33433058618392"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 84-001926"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (28 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 2 flutes, 2 oboes, 2 clarinets, 2 horns, and 2 bassoons.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 5:00-6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: D.15 579.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Wind ensembles",
+            "Wind ensembles -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Verlag Doblinger"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Capriccio : für 10 Blasinstrumente"
+          ],
+          "shelfMark": [
+            "JMC 83-9"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Eröd, Iván."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Doblingers Studienpartituren ; Stp. 410"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMC 83-9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000043"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Stp. 410 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "D.15 579 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100570"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200042"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Wien : Verlag Doblinger, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000043",
+            "urn:oclc:NYPG001000020-C",
+            "urn:undefined:Stp. 410 Verlag Doblinger",
+            "urn:undefined:D.15 579 Verlag Doblinger",
+            "urn:undefined:NNSZ00100570",
+            "urn:undefined:(WaOLN)nyp0200042"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Wind ensembles -- Scores."
+          ],
+          "titleDisplay": [
+            "Capriccio : für 10 Blasinstrumente / Iván Eröd."
+          ],
+          "uri": "b10000043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wien"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000043"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMC 83-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMC 83-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004744128"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMC 83-9"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004744128"
+                    ],
+                    "idBarcode": [
+                      "33433004744128"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMC 83-000009"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000044",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[99] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Biographies of Khri-chen Byaṅ-chub-chos-ʼphel and Śel-dkar Bla-ma Saṅs-rgyas-bstan-ʼphel.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from prints from blocks from Lhasa and Śel-dkar Dgaʼ-ldan-legs-bśad-gliṅ.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884",
+            "Lamas",
+            "Lamas -- Tibet",
+            "Lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ngawang Sopa"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2361"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rgal-dbaṅ Chos-rje Blo-bzaṅ-ʼphrin-las-rnam-rgyal, active 1840-1860."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77901316"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Ngag-dbang-blo-bzang-rgya-mtsho, Dalai Lama V, 1617-1682."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2361"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000044"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77901316"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000021-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100021"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200043"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000021-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "New Delhi : Ngawang Sopa, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000044",
+            "urn:lccn:77901316",
+            "urn:oclc:NYPG001000021-B",
+            "urn:undefined:NNSZ00100021",
+            "urn:undefined:(WaOLN)nyp0200043"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Byaṅ-chub-chos-ʼphel, Khri-chen LXIX, 1756-1838.",
+            "Saṅs-rgyas-bstan-ʼphel, Śel-dkar Bla-ma, 1817-1884.",
+            "Lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "ʼJam-mgon Rgyal-ba gñis-paʼi Rgyal-tshab Dpal-ldan Bla-ma Dam-pa Khyab-bdag Khri-chen Byaṅ-chub-chos-ʼphel dpal-bzaṅ-poʼi rnam par thar pa Dgaʼ ldan bstan paʼi mdzes rgyab [sic] : the biography of the 69th Khri-chen of Dgaʼ-ʼldan Byaṅ-chub-chos-ʼphel / by Dar-han Mkhan-sprul Blo-bzaṅ-ʼphrin-las-rnam-rgyal. Bkaʼ-gdams bstan-paʼi mdzod-ʼdzin Rje-btsun Bla-ma Saṅs-rgyas-bstan-ʼphel dpal-bzaṅ-poʼi rnam par thar pa dad ldan yid kyi dgaʼ ston : the biography of Saṅs-rgyas-bstan-ʼphel of Śel-dkar / by Śel-dkar Bkaʼ-ʼgyur Bla-ma Ṅag-dbaṅ-blo-bzaṅ-bstan-ʼdzin-tshul-khrims-rgyal-mtshan."
+          ],
+          "uri": "b10000044",
+          "lccClassification": [
+            "BQ942.Y367 R47 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000044"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000011",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2361",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080645"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2361"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080645"
+                    ],
+                    "idBarcode": [
+                      "33433015080645"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002361"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000045",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "12 p. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Violin music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Sole selling agents, Or-Tav"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Thoughts & feelings : for violin solo"
+          ],
+          "shelfMark": [
+            "JMG 82-688"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stutschewsky, Joachim, 1891-1982."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "80770813"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 82-688"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000045"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "80770813"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000021-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100571"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200044"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000021-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tel-Aviv : Sole selling agents, Or-Tav, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000045",
+            "urn:lccn:80770813",
+            "urn:oclc:NYPG001000021-C",
+            "urn:undefined:NNSZ00100571",
+            "urn:undefined:(WaOLN)nyp0200044"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Violin music."
+          ],
+          "titleDisplay": [
+            "Thoughts & feelings : for violin solo / Joachim Stutschewsky."
+          ],
+          "uri": "b10000045",
+          "lccClassification": [
+            "M42 .S"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tel-Aviv"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000045"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942043",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 82-688"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 82-688",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032707568"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 82-688"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032707568"
+                    ],
+                    "idBarcode": [
+                      "33433032707568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 82-000688"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000046",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[83] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Kye rdor rnam bśad.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from tracing and manuscripts from the library of Mkhan-po Rin-chen by Trayang and Jamyang Samten.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456",
+            "Tripiṭaka.",
+            "Tripiṭaka. -- Commentaries",
+            "Sa-skya-pa lamas",
+            "Sa-skya-pa lamas -- Tibet",
+            "Sa-skya-pa lamas -- Tibet -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Trayang and Jamyang Samten"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra"
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2362"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Tshe-dbaṅ-rdo-rje-rig-ʼdzin, Prince of Sde-dge."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "77900893"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Sangs-rgyas-phun-tshogs, Ngor-chen, 1649-1705."
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000046"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77900893"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000022-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100022"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200045"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000022-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "New Delhi : Trayang and Jamyang Samten, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000046",
+            "urn:lccn:77900893",
+            "urn:oclc:NYPG001000022-B",
+            "urn:undefined:NNSZ00100022",
+            "urn:undefined:(WaOLN)nyp0200045"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ngor-chen Kun-dgaʼ-bzang-po, 1382-1456.",
+            "Tripiṭaka. -- Commentaries.",
+            "Sa-skya-pa lamas -- Tibet -- Biography."
+          ],
+          "titleDisplay": [
+            "Dpal Kye rdo rjeʼi phyi naṅ bskyed rim ñams len gnad kyi gsal byed sñan brgyud bstan pa rgyas paʼi ñin byed : a detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra / by Sde-dge Yab-chen Tshe-dbaṅ-rdo-rje-rig-ʼdzin alias Byams-pa-kun-dgaʼ-bstan-paʼi-rgyal-mtshan. Rgyal ba Rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas : the life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po / by Ṅor-chen Saṅs-rgyas-phun-tshogs."
+          ],
+          "uri": "b10000046",
+          "lccClassification": [
+            "BG974.0727 T75"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "titleAlt": [
+            "Rgyal ba rdo rje ʼchan Kun dgaʼ bzaṅ poʼi rnam par thar pa legs bśad chu bo ʼdus paʼi rgya mtsho yon tan yid bźin nor buʼi byuṅ gnas.",
+            "Detailed exegesis of external and internal aspects of the visualization practice of the Hevajra tantra.",
+            "Life of the founder of the Ṅor-pa tradition, Ṅor-chen Kun-dgaʼ-bzaṅ-po."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000046"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080413"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2362"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080413"
+                    ],
+                    "idBarcode": [
+                      "33433015080413"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002362"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000047",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (30 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"This work was written between 14 March and 1 May, 1979\"--verso t.p.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 15 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vocalises (High voice) with instrumental ensemble",
+            "Vocalises (High voice) with instrumental ensemble -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello"
+          ],
+          "shelfMark": [
+            "JMG 83-79"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "idLccn": [
+            "81770634"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-79"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000047"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770634"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000022-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100572"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200046"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000022-C"
+          ],
+          "uniformTitle": [
+            "Vocalise, soprano, instrumental ensemble, op. 38"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London, England (Arlington Park House, London W4) : Redcliffe Edition, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000047",
+            "urn:lccn:81770634",
+            "urn:oclc:NYPG001000022-C",
+            "urn:undefined:NNSZ00100572",
+            "urn:undefined:(WaOLN)nyp0200046"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vocalises (High voice) with instrumental ensemble -- Scores."
+          ],
+          "titleDisplay": [
+            "Vocalise, op. 38, for soprano, clarinet, piano, violin, violoncello / Francis Routh."
+          ],
+          "uri": "b10000047",
+          "lccClassification": [
+            "M1613.3 .R8 op.38"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London, England (Arlington Park House, London W4)"
+          ],
+          "titleAlt": [
+            "Vocalise, op. 38"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "38 cm."
+          ]
+        },
+        "sort": [
+          "b10000047"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942044",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-79"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-79",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842233"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-79"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842233"
+                    ],
+                    "idBarcode": [
+                      "33433032842233"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000079"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000048",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[150] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a MS. preserved at Pha-lo-ldiṅ Monastery in Bhutan.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Buddhism",
+            "Buddhism -- Rituals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kunzang Topgey"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2382"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901012"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2382"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000048"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000023-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100023"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200047"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000023-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Thimphu : Kunzang Topgey, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000048",
+            "urn:lccn:76901012",
+            "urn:oclc:NYPG001000023-B",
+            "urn:undefined:NNSZ00100023",
+            "urn:undefined:(WaOLN)nyp0200047"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Buddhism -- Rituals."
+          ],
+          "titleDisplay": [
+            "Bkra śis Tshe riṅ mai sgrub skor sogs : a collection of texts outlining the rites of the Five Long Lived Sisters and other highly esoteric rituals."
+          ],
+          "uri": "b10000048",
+          "lccClassification": [
+            "BQ7695 .B55"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Thimphu"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 x 38 cm."
+          ]
+        },
+        "sort": [
+          "b10000048"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2382",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080439"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2382"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080439"
+                    ],
+                    "idBarcode": [
+                      "33433015080439"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002382"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000049",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (105 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 25 min.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Redcliffe Edition"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Symphony, op. 26 : full score"
+          ],
+          "shelfMark": [
+            "JMG 83-80"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Routh, Francis."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "81770641"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-80"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000049"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770641"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000023-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100573"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200048"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000023-C"
+          ],
+          "uniformTitle": [
+            "Symphony, op. 26"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "London (Arlington Park House, London W4 4HD) : Redcliffe Edition, c1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000049",
+            "urn:lccn:81770641",
+            "urn:oclc:NYPG001000023-C",
+            "urn:undefined:NNSZ00100573",
+            "urn:undefined:(WaOLN)nyp0200048"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "Symphony, op. 26 : full score / Francis Routh."
+          ],
+          "uri": "b10000049",
+          "lccClassification": [
+            "M1001 .R8615 op.26"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London (Arlington Park House, London W4 4HD)"
+          ],
+          "titleAlt": [
+            "Symphony, op. 26"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10000049"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942045",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-80"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-80",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842241"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-80"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842241"
+                    ],
+                    "idBarcode": [
+                      "33433032842241"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000080"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000050",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "[188] p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Reproduced from a print from the early 16th century western Tibetan blocks by Urgyan Dorje.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Tibetan; pref. in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?",
+            "Bkaʼ-brgyud-pa lamas",
+            "Bkaʼ-brgyud-pa lamas -- Tibet",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography",
+            "Spiritual life",
+            "Spiritual life -- Buddhism"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Urgyan Dorje"
+          ],
+          "language": [
+            {
+              "id": "lang:tib",
+              "label": "Tibetan"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "shelfMark": [
+            "*OZ+ 82-2381"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?"
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "76901747"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OZ+ 82-2381"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000050"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76901747"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000024-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100024"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200049"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000024-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "New Delhi : Urgyan Dorje, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000050",
+            "urn:lccn:76901747",
+            "urn:oclc:NYPG001000024-B",
+            "urn:undefined:NNSZ00100024",
+            "urn:undefined:(WaOLN)nyp0200049"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "ʼBaʼ-ra-ba Rgyal-mtshan-dpal-bzaṅ, 1310?-1391?",
+            "Bkaʼ-brgyud-pa lamas -- Tibet -- Biography.",
+            "Spiritual life -- Buddhism."
+          ],
+          "titleDisplay": [
+            "The rnam thar and mgur ʼbum of ʼBaʼ-ra-ba, with his Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "uri": "b10000050",
+          "lccClassification": [
+            "BQ942.A187 A35 1976"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New Delhi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sgrub pa ñams su blaṅ baʼi lag len dgos ʼdod ʼbyuṅ baʼi gter mdzod."
+          ],
+          "dimensions": [
+            "28 x 37 cm."
+          ]
+        },
+        "sort": [
+          "b10000050"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OZ+ 82-2381",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433015080421"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OZ+ 82-2381"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433015080421"
+                    ],
+                    "idBarcode": [
+                      "33433015080421"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OZ+ 82-002381"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000051",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "score (64 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Symphonies",
+            "Symphonies -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Samfundet til udgivelse af dansk musik"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972"
+          ],
+          "shelfMark": [
+            "JMG 83-75"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Christiansen, Henning."
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "idLccn": [
+            "78770955"
+          ],
+          "seriesStatement": [
+            "[Publikation] - Samfundet til udgivelse af dansk musik : 3. serie, nr. 264"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-75"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000051"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78770955"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000024-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100574"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200050"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000024-C"
+          ],
+          "uniformTitle": [
+            "Symphony, no. 2, op. 69c",
+            "Samfundet til udgivelse af dansk musik (Series) ; 3. ser., nr. 264."
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "København : Samfundet til udgivelse af dansk musik, 1977."
+          ],
+          "identifier": [
+            "urn:bnum:10000051",
+            "urn:lccn:78770955",
+            "urn:oclc:NYPG001000024-C",
+            "urn:undefined:NNSZ00100574",
+            "urn:undefined:(WaOLN)nyp0200050"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Symphonies -- Scores."
+          ],
+          "titleDisplay": [
+            "2 symfoni : Den forsvundne : baseret på musikken til filmen \"Den forsvundne fuldmægtig\" op. 69c, 1972 / Henning Christiansen."
+          ],
+          "uri": "b10000051",
+          "lccClassification": [
+            "M1001 .C533 op.69c"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "København"
+          ],
+          "titleAlt": [
+            "Symphony, no. 2, op. 69c",
+            "Den forsvundne."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "37 cm."
+          ]
+        },
+        "sort": [
+          "b10000051"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942046",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-75"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-75",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842191"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-75"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842191"
+                    ],
+                    "idBarcode": [
+                      "33433032842191"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000075"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-dff13c02a63bb0348fb151608bfddc83.json
+++ b/test/fixtures/query-dff13c02a63bb0348fb151608bfddc83.json
@@ -1,0 +1,11800 @@
+{
+  "took": 959,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 18415692,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000002",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "ix, 368 p., [1] leaf of plates : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Contributions in German and Italian.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Dante Alighieri, 1265-1321",
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation",
+            "Gmelin, Hermann, 1900-1958"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Stauffenburg"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin"
+          ],
+          "shelfMark": [
+            "JFE 86-3252"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "idLccn": [
+            "86124252"
+          ],
+          "seriesStatement": [
+            "Romanica et comparatistica ; Bd. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Gmelin, Hermann, 1900-1958.",
+            "Baum, Richard.",
+            "Hirdt, Willi."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 86-3252"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000002"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3923721544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "86124252"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGNYPG-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200001"
+            }
+          ],
+          "idOclc": [
+            "NYPGNYPG-B"
+          ],
+          "updatedAt": 1678937667178,
+          "publicationStatement": [
+            "Tübingen : Stauffenburg, c1985."
+          ],
+          "identifier": [
+            "urn:bnum:10000002",
+            "urn:isbn:3923721544",
+            "urn:lccn:86124252",
+            "urn:oclc:NYPGNYPG-B",
+            "urn:undefined:(WaOLN)nyp0200001"
+          ],
+          "idIsbn": [
+            "3923721544"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Dante Alighieri, 1265-1321 -- Criticism and interpretation.",
+            "Gmelin, Hermann, 1900-1958."
+          ],
+          "titleDisplay": [
+            "Dante Alighieri 1985 : in memoriam Hermann Gmelin / herausgegeben von Richard Baum und Willi Hirdt."
+          ],
+          "uri": "b10000002",
+          "lccClassification": [
+            "PQ4390 .D274 1985"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tübingen"
+          ],
+          "titleAlt": [
+            "Dante Alighieri neunzehnhundertfünfundachtzig."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "3923721544"
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000002"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 86-3252"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 86-3252",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433046113795"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 86-3252"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433046113795"
+                    ],
+                    "idBarcode": [
+                      "33433046113795"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFE 86-003252"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000003",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "199 p. : col. ill. maps ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hebrides (Scotland)",
+            "Hebrides (Scotland) -- Pictorial works"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Constable"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1989
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Scottish islands"
+          ],
+          "shelfMark": [
+            "JFF 89-526"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Waite, Charlie."
+          ],
+          "createdString": [
+            "1989"
+          ],
+          "idLccn": [
+            "gb 89012970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1989
+          ],
+          "donor": [
+            "Gift of the Drue Heinz Book Fund for English Literature"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFF 89-526"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000003"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0094675708 :"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "gb 89012970"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPGUKBPGP8917-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200002"
+            }
+          ],
+          "idOclc": [
+            "NYPGUKBPGP8917-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Constable, 1989."
+          ],
+          "identifier": [
+            "urn:bnum:10000003",
+            "urn:isbn:0094675708 :",
+            "urn:lccn:gb 89012970",
+            "urn:oclc:NYPGUKBPGP8917-B",
+            "urn:undefined:(WaOLN)nyp0200002"
+          ],
+          "idIsbn": [
+            "0094675708 "
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1989"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hebrides (Scotland) -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Scottish islands / Charlie Waite."
+          ],
+          "uri": "b10000003",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "0094675708"
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10000003"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783780",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFF 89-526"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFF 89-526",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433050409147"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFF 89-526"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433050409147"
+                    ],
+                    "idBarcode": [
+                      "33433050409147"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFF 89-000526"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000004",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "23, 216 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1956.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tiruvaḷḷuvar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1965
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mutaṟkuṟaḷ uvamai."
+          ],
+          "shelfMark": [
+            "*OLB 84-1934"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kothandapani Pillai, K., 1896-"
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "74915265"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1247"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1934"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000004"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74915265"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100001"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200003"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tirunelvēli, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1965."
+          ],
+          "identifier": [
+            "urn:bnum:10000004",
+            "urn:lccn:74915265",
+            "urn:oclc:NYPG001000001-B",
+            "urn:undefined:NNSZ00100001",
+            "urn:undefined:(WaOLN)nyp0200003"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tiruvaḷḷuvar."
+          ],
+          "titleDisplay": [
+            "Mutaṟkuṟaḷ uvamai. Āciriyar Ku. Kōtaṇṭapāṇi Piḷḷai."
+          ],
+          "uri": "b10000004",
+          "lccClassification": [
+            "PL4758.9.T5 K6 1965"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tirunelvēli"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000004"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783781",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1934"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1934",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1934"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301556"
+                    ],
+                    "idBarcode": [
+                      "33433061301556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001934"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000005",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (43 p.) + 1 part (12 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Acc. arr. for piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"Soch. 22\"--Caption.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: 11049.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Concertos (Violin)",
+            "Concertos (Violin) -- Solo with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muzyka"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom"
+          ],
+          "shelfMark": [
+            "JMF 83-336"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Wieniawski, Henri, 1835-1880."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-336"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000005"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000001-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "11049. Muzyka"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100551"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200004"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000001-C"
+          ],
+          "uniformTitle": [
+            "Concertos, violin, orchestra, no. 2, op. 22, D minor; arranged"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Moskva : Muzyka, 1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000005",
+            "urn:oclc:NYPG001000001-C",
+            "urn:undefined:11049. Muzyka",
+            "urn:undefined:NNSZ00100551",
+            "urn:undefined:(WaOLN)nyp0200004"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Concertos (Violin) -- Solo with piano."
+          ],
+          "titleDisplay": [
+            "Kon︠t︡sert No 2 dl︠i︡a skripki s orkestrom / G. Ven︠i︡avskiĭ ; klavir."
+          ],
+          "uri": "b10000005",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Moskva"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Concertos, no. 2, op. 22"
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10000005"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942022",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-336"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-336",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032711909"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-336"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032711909"
+                    ],
+                    "idBarcode": [
+                      "33433032711909"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000336"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000006",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "227 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of The reconstruction of religious thought in Islam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1968
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām"
+          ],
+          "shelfMark": [
+            "*OGC 84-1984"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Iqbal, Muhammad, Sir, 1877-1938."
+          ],
+          "createdString": [
+            "1968"
+          ],
+          "idLccn": [
+            "75962707"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Maḥmūd, ʻAbbās."
+          ],
+          "dateStartYear": [
+            1968
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1984"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000006"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75962707"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100002"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200005"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "al-Qāhirah, Lajnat al-Taʼlīf wa-al-Tarjamah wa-al-Nashr [1968]"
+          ],
+          "identifier": [
+            "urn:bnum:10000006",
+            "urn:lccn:75962707",
+            "urn:oclc:NYPG001000002-B",
+            "urn:undefined:NNSZ00100002",
+            "urn:undefined:(WaOLN)nyp0200005"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1968"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "Tajdīd al-tafkīr al-dīnī fī al-Islām, taʼlif Muhammad Iqbāl. Tarjamat ʻAbbās Maḥmūd. Rājaʻa muqaddimatahu wa-al-faṣl al-awwal minhu ʻAbd al-ʻAzīz al-Maraghī, wa-rājaʻa baqīyat al-Kitāb Mahdī ʻAllām."
+          ],
+          "uri": "b10000006",
+          "lccClassification": [
+            "BP161 .I712 1968"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000006"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691665"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1984"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691665"
+                    ],
+                    "idBarcode": [
+                      "33433022691665"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001984"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000007",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 7:35.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: Z.8917.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Guitar music",
+            "Guitar",
+            "Guitar -- Studies and exercises"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Editio Musica"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Due studi per chitarra"
+          ],
+          "shelfMark": [
+            "JMG 83-276"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Patachich, Iván."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000007"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000002-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Z.8917. Editio Musica"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100552"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200006"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000002-C"
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Budapest : Editio Musica, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000007",
+            "urn:oclc:NYPG001000002-C",
+            "urn:undefined:Z.8917. Editio Musica",
+            "urn:undefined:NNSZ00100552",
+            "urn:undefined:(WaOLN)nyp0200006"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Guitar music.",
+            "Guitar -- Studies and exercises."
+          ],
+          "titleDisplay": [
+            "Due studi per chitarra / Patachich Iván."
+          ],
+          "uri": "b10000007",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Budapest"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies"
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000007"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942023",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-276"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-276",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883591"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-276"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883591"
+                    ],
+                    "idBarcode": [
+                      "33433032883591"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000276"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000008",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "351 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Parimaḷam Patippakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aṇṇāviṉ ciṟukataikaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1986"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Annadurai, C. N., 1909-1969."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913998"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1986"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000008"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913998"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100003"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200007"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Parimaḷam Patippakam [1969]"
+          ],
+          "identifier": [
+            "urn:bnum:10000008",
+            "urn:lccn:72913998",
+            "urn:oclc:NYPG001000003-B",
+            "urn:undefined:NNSZ00100003",
+            "urn:undefined:(WaOLN)nyp0200007"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Aṇṇāviṉ ciṟukataikaḷ. [Eḻutiyavar] Ci. Eṉ. Aṇṇāturai."
+          ],
+          "uri": "b10000008",
+          "lccClassification": [
+            "PL4758.9.A5 A84"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000008"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783782",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1986"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1986",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301689"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1986"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301689"
+                    ],
+                    "idBarcode": [
+                      "33433061301689"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001986"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000009",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "30 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Edition Peters Nr. 5489.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: E.P. 13028.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Edition Peters ; C.F. Peters"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Miniaturen II : 13 kleine Klavierstücke"
+          ],
+          "shelfMark": [
+            "JMG 83-278"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Golle, Jürgen, 1942-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-278"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000009"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000003-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters Nr. 5489 Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "E.P. 13028. Edition Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200008"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000003-C"
+          ],
+          "uniformTitle": [
+            "Miniaturen, no. 2"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Leipzig : Edition Peters ; New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000009",
+            "urn:oclc:NYPG001000003-C",
+            "urn:undefined:Edition Peters Nr. 5489 Edition Peters",
+            "urn:undefined:E.P. 13028. Edition Peters",
+            "urn:undefined:NNSZ00100553",
+            "urn:undefined:(WaOLN)nyp0200008"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Miniaturen II : 13 kleine Klavierstücke / Jürgen Golle."
+          ],
+          "uri": "b10000009",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig : New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen, no. 2"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000009"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942024",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-278"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-278",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883617"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-278"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883617"
+                    ],
+                    "idBarcode": [
+                      "33433032883617"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000278"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000010",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "110 p."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cēkkiḻār, active 12th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaikkaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1938"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Irācamāṇikkaṉār, Mā., 1907-1967."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "72913466"
+          ],
+          "seriesStatement": [
+            "Corṇammāḷ corpoḻivu varicai, 6"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1938"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000010"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72913466"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100004"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200009"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Aṇṇāmalainakar, Aṇṇāmalaip Palkalaikkaḻakam, 1969."
+          ],
+          "identifier": [
+            "urn:bnum:10000010",
+            "urn:lccn:72913466",
+            "urn:oclc:NYPG001000004-B",
+            "urn:undefined:NNSZ00100004",
+            "urn:undefined:(WaOLN)nyp0200009"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cēkkiḻār, active 12th century."
+          ],
+          "titleDisplay": [
+            "Cēkkiḻār; Corṇammāḷ niṉaivuc coṟpoḻivukaḷ. [Āṟṟiyavar] Mā. Irācamāṇikkaṉār."
+          ],
+          "uri": "b10000010",
+          "lccClassification": [
+            "PL4758.9.C385 Z8"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Aṇṇāmalainakar"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000010"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783783",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1938"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1938",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301598"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1938"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301598"
+                    ],
+                    "idBarcode": [
+                      "33433061301598"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001938"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "46 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)",
+            "Easter music (Organ)",
+            "Passion music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Boeijenga"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "1982"
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Passie en pasen : suite voor orgel, opus 50"
+          ],
+          "shelfMark": [
+            "JMG 83-279"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Berg, Jan J. van den."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-279"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000011"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000004-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200010"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000004-C"
+          ],
+          "dateEndYear": [
+            1982
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Sneek [Netherlands] : Boeijenga, [between 1976 and 1982]."
+          ],
+          "identifier": [
+            "urn:bnum:10000011",
+            "urn:oclc:NYPG001000004-C",
+            "urn:undefined:(WaOLN)nyp0200010"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)",
+            "Easter music (Organ)",
+            "Passion music."
+          ],
+          "titleDisplay": [
+            "Passie en pasen : suite voor orgel, opus 50 / door Jan J. van den Berg."
+          ],
+          "uri": "b10000011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Sneek [Netherlands]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Passie. I. Psalm 22. II. Leer mij O Heer. III. \"Mijn Verlosser hangt aan 't kruis.\" IV. \"O hoofd vol bloed en wonden.\" V. \"O kostbaar kruis.\" VI. \"Jezus, leven van mijn leven\" -- Pasen. VII. Toccata over \"Christus is opgestanden.\" VIII. Canon: \"Jesus unser Trost und Leben.\" IX. Trio: Ik zeg het allen dat Hij leeft.\" X. Trio: \"Staakt Uw rouwen Magdalene.\" XI. Postludium over \"Jesus leeft en wij met Hem\" (met \"Christus onze Heer verrees\" als tegenstem)."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000011"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942025",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-279"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-279",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032883625"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-279"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032883625"
+                    ],
+                    "idBarcode": [
+                      "33433032883625"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000279"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "223 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p.221.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Thaqāfah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi"
+          ],
+          "shelfMark": [
+            "*OFS 84-1997"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ḥāwī, Īlīyā Salīm."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFS 84-1997"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000012"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100005"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200011"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Thaqāfah, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000012",
+            "urn:oclc:NYPG001000005-B",
+            "urn:undefined:NNSZ00100005",
+            "urn:undefined:(WaOLN)nyp0200011"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Ḥuṭayʼah, Jarwal ibn Aws, -650?"
+          ],
+          "titleDisplay": [
+            "al-Ḥuṭayʼah : fī sīratihi wa-nafsīyatihi wa-shiʻrihi / bi-qalam Īlīyā Ḥāwī."
+          ],
+          "uri": "b10000012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000012"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000003",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFS 84-1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFS 84-1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433014514719"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFS 84-1997"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433014514719"
+                    ],
+                    "idBarcode": [
+                      "33433014514719"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFS 84-001997"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000013",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "32 p. of music : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Popular music.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Arr. for piano with chord symbols; superlinear German words.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Popular music",
+            "Popular music -- Germany (East)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Harth Musik Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "shelfMark": [
+            "JMF 83-366"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-366"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000013"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000005-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100555"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200012"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000005-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Leipzig : Harth Musik Verlag, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000013",
+            "urn:oclc:NYPG001000005-C",
+            "urn:undefined:NNSZ00100555",
+            "urn:undefined:(WaOLN)nyp0200012"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Popular music -- Germany (East)"
+          ],
+          "titleDisplay": [
+            "Disko Treff 1 : Klavier."
+          ],
+          "uri": "b10000013",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Leipzig"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Disko Treff eins."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000013"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942026",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-366"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-366",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032712204"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-366"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032712204"
+                    ],
+                    "idBarcode": [
+                      "33433032712204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000366"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000014",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "520 p. : ill., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on cover: Islamic unity or the Mutual approach among Muslim sects.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Panislamism",
+            "Islam",
+            "Islam -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Muʼassasat al-Aʻlamī lil-Maṭbūʻāt"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah"
+          ],
+          "shelfMark": [
+            "*OGC 84-1996"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Shīrāzī, ʻAbd al-Karīm Bī Āzār."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGC 84-1996"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000014"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100006"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200013"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Bayrūt : Muʼassasat al-Aʻlamī lil-Maṭbūʻāt, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000014",
+            "urn:oclc:NYPG001000006-B",
+            "urn:undefined:NNSZ00100006",
+            "urn:undefined:(WaOLN)nyp0200013"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Panislamism.",
+            "Islam -- 20th century."
+          ],
+          "titleDisplay": [
+            "al-Waḥdah al-Islāmīyah : aw al-taqrīb bayna al-madhāhib al-sabʻah, wathāʼiq khaṭīrah wa-buḥūth ʻilmīyah li-aʻāẓim ʻulamāʼ al-Muslimīn min al-sunnah wa-al-shīʻah / Jamʻ wa-tartīb ʻAbd al-Karīm Bī Āzār al-Shīrāzī."
+          ],
+          "uri": "b10000014",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Islamic unity."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10000014"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OGC 84-1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OGC 84-1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022691780"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OGC 84-1996"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022691780"
+                    ],
+                    "idBarcode": [
+                      "33433022691780"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OGC 84-001996"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000015",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "25 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For organ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Caption title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "\"A McAfee Music Publication.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: DM 220.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Organ)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Belwin-Mills"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Suite no. 1 : 1977"
+          ],
+          "shelfMark": [
+            "JNG 83-102"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hampton, Calvin."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JNG 83-102"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000015"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000006-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "DM 220. Belwin-Mills"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100556"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200014"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000006-C"
+          ],
+          "uniformTitle": [
+            "Suite, organ, no. 1"
+          ],
+          "updatedAt": 1678726416948,
+          "publicationStatement": [
+            "Melville, NY : Belwin-Mills, [1980?]"
+          ],
+          "identifier": [
+            "urn:bnum:10000015",
+            "urn:oclc:NYPG001000006-C",
+            "urn:undefined:DM 220. Belwin-Mills",
+            "urn:undefined:NNSZ00100556",
+            "urn:undefined:(WaOLN)nyp0200014"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Organ)"
+          ],
+          "titleDisplay": [
+            "Suite no. 1 : 1977 / Calvin Hampton."
+          ],
+          "uri": "b10000015",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Melville, NY"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Suite, no. 1"
+          ],
+          "tableOfContents": [
+            "Fanfares -- Antiphon -- Toccata."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000015"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000016",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "111 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuṟuntokai"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Manṅkaḷa Nūlakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nalla Kuṟuntokaiyil nāṉilam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1937"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Cellappaṉ, Cilampoli, 1929-"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "74913402"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1937"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000016"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74913402"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100007"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200015"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Ceṉṉai, Manṅkaḷa Nūlakam, 1959 [i.e. 1967]"
+          ],
+          "identifier": [
+            "urn:bnum:10000016",
+            "urn:lccn:74913402",
+            "urn:oclc:NYPG001000007-B",
+            "urn:undefined:NNSZ00100007",
+            "urn:undefined:(WaOLN)nyp0200015"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuṟuntokai."
+          ],
+          "titleDisplay": [
+            "Nalla Kuṟuntokaiyil nāṉilam. [Eḻutiyavar] Cu. Cellappaṉ."
+          ],
+          "uri": "b10000016",
+          "lccClassification": [
+            "PL4758.9.K794 Z6 1967"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000016"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783785",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1937"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1937",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301580"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1937"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301580"
+                    ],
+                    "idBarcode": [
+                      "33433061301580"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001937"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000017",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (17 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For baritone and piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Words printed also as text.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 3:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Corbière, Tristan, 1845-1875",
+            "Corbière, Tristan, 1845-1875 -- Musical settings",
+            "Songs (Medium voice) with piano"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Lettre du Mexique : pour baryton et piano, 1942"
+          ],
+          "shelfMark": [
+            "JMG 83-395"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Escher, Rudolf."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Corbière, Tristan, 1845-1875."
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-395"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000017"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000007-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100557"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200016"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000007-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000017",
+            "urn:oclc:NYPG001000007-C",
+            "urn:undefined:NNSZ00100557",
+            "urn:undefined:(WaOLN)nyp0200016"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Corbière, Tristan, 1845-1875 -- Musical settings.",
+            "Songs (Medium voice) with piano."
+          ],
+          "titleDisplay": [
+            "Lettre du Mexique : pour baryton et piano, 1942 / Rudolf Escher ; poème de Tristan Corbière."
+          ],
+          "uri": "b10000017",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000017"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-395"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-395",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032735007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-395"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032735007"
+                    ],
+                    "idBarcode": [
+                      "33433032735007"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000395"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "68 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Lebanon"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār al-Ṭalīʻah"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā"
+          ],
+          "shelfMark": [
+            "*OFX 84-1995"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Bashshūr, Najlāʼ Naṣīr."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "78970449"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1995"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000018"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78970449"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100008"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200017"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Bayrūt : Dār al-Ṭalīʻah, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000018",
+            "urn:lccn:78970449",
+            "urn:oclc:NYPG001000008-B",
+            "urn:undefined:NNSZ00100008",
+            "urn:undefined:(WaOLN)nyp0200017"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Lebanon."
+          ],
+          "titleDisplay": [
+            "al-Marʼah al-Lubnānīyah : wāqiʻuhā wa-qaḍāyāhā / Najlāʼ Naṣīr Bashshūr."
+          ],
+          "uri": "b10000018",
+          "lccClassification": [
+            "HQ1728 .B37"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10000018"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000004",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031718"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1995"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031718"
+                    ],
+                    "idBarcode": [
+                      "33433002031718"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001995"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000019",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For piano.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: M 18.487.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Waltzes (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Zwölf Walzer und ein Epilog : für Klavier"
+          ],
+          "shelfMark": [
+            "JMG 83-111"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Benary, Peter."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-111"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000019"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000008-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Möseler M 18.487."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100558"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200018"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000008-C"
+          ],
+          "uniformTitle": [
+            "Walzer und ein Epilog"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000019",
+            "urn:oclc:NYPG001000008-C",
+            "urn:undefined:Möseler M 18.487.",
+            "urn:undefined:NNSZ00100558",
+            "urn:undefined:(WaOLN)nyp0200018"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Waltzes (Piano)"
+          ],
+          "titleDisplay": [
+            "Zwölf Walzer und ein Epilog : für Klavier / Peter Benary."
+          ],
+          "uri": "b10000019",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Walzer und ein Epilog",
+            "Walzer und ein Epilog."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000019"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942028",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-111"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-111",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-111"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845053"
+                    ],
+                    "idBarcode": [
+                      "33433032845053"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000111"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000020",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xvi, 172, 320 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tolkāppiyar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Aṇṇāmalaip Palkalaik Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tolkāppiyam."
+          ],
+          "shelfMark": [
+            "*OLB 84-1936"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "creatorLiteral": [
+            "Veḷḷaivāraṇaṉ, Ka."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "74914844"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1936"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000020"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74914844"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100009"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200019"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "[Aṇṇāmalainakar] Aṇṇāmalaip Palkalaik Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000020",
+            "urn:lccn:74914844",
+            "urn:oclc:NYPG001000009-B",
+            "urn:undefined:NNSZ00100009",
+            "urn:undefined:(WaOLN)nyp0200019"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tolkāppiyar."
+          ],
+          "titleDisplay": [
+            "Tolkāppiyam. [Eḻutiyavar] Ka. Veḷḷaivāraṇaṉ."
+          ],
+          "uri": "b10000020",
+          "lccClassification": [
+            "PL4754.T583 V4 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Aṇṇāmalainakar]"
+          ],
+          "titleAlt": [
+            "Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Tolkāppiyam.--Tolkāppiyam nutaliyaporuḷ."
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000020"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783786",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1936 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1936 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301572"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1936"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301572"
+                    ],
+                    "idBarcode": [
+                      "33433061301572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-1936 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000021",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (51 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For orchestra.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: NM 384.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Orchestral music",
+            "Orchestral music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Verlag Neue Musik"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aurora : sinfonischer Prolog : Partitur"
+          ],
+          "shelfMark": [
+            "JMG 83-113"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Weitzendorf, Heinz."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-113"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000021"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000009-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NM 384. Verlag Neue Musik"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100559"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200020"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000009-C"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Berlin : Verlag Neue Musik, c1978."
+          ],
+          "identifier": [
+            "urn:bnum:10000021",
+            "urn:oclc:NYPG001000009-C",
+            "urn:undefined:NM 384. Verlag Neue Musik",
+            "urn:undefined:NNSZ00100559",
+            "urn:undefined:(WaOLN)nyp0200020"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Orchestral music -- Scores."
+          ],
+          "titleDisplay": [
+            "Aurora : sinfonischer Prolog : Partitur / Heinz Weitzendorf."
+          ],
+          "uri": "b10000021",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Berlin"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000021"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942029",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-113"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-113",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032845079"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-113"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032845079"
+                    ],
+                    "idBarcode": [
+                      "33433032845079"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000113"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000022",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "19, 493 p."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "First published in 1942.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Grammar"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLB 84-1935"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Puttamittiraṉār, active 11th century."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "73913714"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 1388"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Peruntēvaṉār, active 11th century.",
+            "Kōvintarāja Mutaliyār, Kā. Ra., 1874-1952."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1935"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000022"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73913714"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100010"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200021"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000022",
+            "urn:lccn:73913714",
+            "urn:oclc:NYPG001000010-B",
+            "urn:undefined:NNSZ00100010",
+            "urn:undefined:(WaOLN)nyp0200021"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Poṉpaṟṟi kāvalar puttamittiraṉār iyaṟṟiya Vīracōḻiyam; Peruntēvaṉār iyaṟṟiya uraiyuṭaṉ. Patippāciriyar Kā. Ra. Kōvintarāca Mutaliyār."
+          ],
+          "uri": "b10000022",
+          "lccClassification": [
+            "PL4754 .P8 1970"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "titleAlt": [
+            "Viracōḻiyam."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000022"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783787",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1935"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1935",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301564"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1935"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301564"
+                    ],
+                    "idBarcode": [
+                      "33433061301564"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001935"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000023",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (18 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For band or wind ensemble.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Based on the composer's Veni creator spiritus.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: KC913.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Band music",
+            "Band music -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Shawnee Press"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Musica sacra"
+          ],
+          "shelfMark": [
+            "JMF 83-38"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Zaninelli, Luigi."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-38"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000023"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000010-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "KC913 Shawnee Press"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100560"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200022"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000010-C"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Delaware Water Gap, Pa. : Shawnee Press, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000023",
+            "urn:oclc:NYPG001000010-C",
+            "urn:undefined:KC913 Shawnee Press",
+            "urn:undefined:NNSZ00100560",
+            "urn:undefined:(WaOLN)nyp0200022"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Band music -- Scores."
+          ],
+          "titleDisplay": [
+            "Musica sacra / Luigi Zaninelli."
+          ],
+          "uri": "b10000023",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Delaware Water Gap, Pa."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10000023"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942030",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-38"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-38",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709028"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-38"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709028"
+                    ],
+                    "idBarcode": [
+                      "33433032709028"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000038"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000024",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Bahrain",
+            "Bahrain -- History",
+            "Bahrain -- History -- 20th century",
+            "Bahrain -- Economic conditions",
+            "Bahrain -- Social conditions"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Dār Ibn Khaldūn"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1976
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī"
+          ],
+          "shelfMark": [
+            "*OFK 84-1944"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Rumayḥī, Muḥammad Ghānim."
+          ],
+          "createdString": [
+            "1976"
+          ],
+          "idLccn": [
+            "79971032"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1976
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFK 84-1944"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000024"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79971032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200023"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[Bayrūt] : Dār Ibn Khaldūn, 1976."
+          ],
+          "identifier": [
+            "urn:bnum:10000024",
+            "urn:lccn:79971032",
+            "urn:oclc:NYPG001000011-B",
+            "urn:undefined:NNSZ00100011",
+            "urn:undefined:(WaOLN)nyp0200023"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1976"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Bahrain -- History -- 20th century.",
+            "Bahrain -- Economic conditions.",
+            "Bahrain -- Social conditions."
+          ],
+          "titleDisplay": [
+            "al-Baḥrayn : mushkilāt al-taghyīr al-siyāsī wa-al-ijtimāʻī / Muḥammad al-Rumayḥī."
+          ],
+          "uri": "b10000024",
+          "lccClassification": [
+            "DS247.B28 R85"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Bayrūt]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000024"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000005",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFK 84-1944"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFK 84-1944",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005548676"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFK 84-1944"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005548676"
+                    ],
+                    "idBarcode": [
+                      "33433005548676"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFK 84-001944"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000025",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei Sonatinen für Klavier"
+          ],
+          "shelfMark": [
+            "JMF 83-107"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Stockmeier, Wolfgang."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 179"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-107"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000025"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000011-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100561"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200024"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000011-C"
+          ],
+          "uniformTitle": [
+            "Sonatinas, piano"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000025",
+            "urn:oclc:NYPG001000011-C",
+            "urn:undefined:NNSZ00100561",
+            "urn:undefined:(WaOLN)nyp0200024"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Drei Sonatinen für Klavier / Wolfgang Stockmeier."
+          ],
+          "uri": "b10000025",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatinas"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000025"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942031",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-107"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-107",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709697"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-107"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709697"
+                    ],
+                    "idBarcode": [
+                      "33433032709697"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000107"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000026",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "222 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. 217-220.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Women",
+            "Women -- Syria"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975"
+          ],
+          "shelfMark": [
+            "*OFX 84-1953"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Razzāz, Nabīlah."
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76960987"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFX 84-1953"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000026"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960987"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200025"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Dimashq : Wizārat al-Thaqāfah wa-al-Irshād al-Qawmī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000026",
+            "urn:lccn:76960987",
+            "urn:oclc:NYPG001000012-B",
+            "urn:undefined:NNSZ00100012",
+            "urn:undefined:(WaOLN)nyp0200025"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Women -- Syria."
+          ],
+          "titleDisplay": [
+            "Mushārakat al-marʼah fī al-ḥayāh al-ʻāmmah fī Sūrīyah mundhu al-istiqlāl 1945 wa-ḥattá 1975 / Nabīlah al-Razzāz."
+          ],
+          "uri": "b10000026",
+          "lccClassification": [
+            "HQ402 .R39"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Dimashq"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10000026"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000006",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFX 84-1953"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFX 84-1953",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433002031700"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OFX 84-1953"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433002031700"
+                    ],
+                    "idBarcode": [
+                      "33433002031700"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFX 84-001953"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000027",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "15 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Violin)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Möseler Verlag"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Drei kleine Sonaten : für Violine solo"
+          ],
+          "shelfMark": [
+            "JMF 83-95"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Köhler, Friedemann."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "seriesStatement": [
+            "Hausmusik ; 172"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-95"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000027"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000012-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100562"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200026"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000012-C"
+          ],
+          "uniformTitle": [
+            "Kleine Sonaten, violin"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Wolfenbüttel : Möseler Verlag, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000027",
+            "urn:oclc:NYPG001000012-C",
+            "urn:undefined:NNSZ00100562",
+            "urn:undefined:(WaOLN)nyp0200026"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Violin)"
+          ],
+          "titleDisplay": [
+            "Drei kleine Sonaten : für Violine solo / Friedemann Köhler."
+          ],
+          "uri": "b10000027",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wolfenbüttel"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Kleine Sonaten"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000027"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-95"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-95",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-95"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709572"
+                    ],
+                    "idBarcode": [
+                      "33433032709572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000095"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000028",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "9, 3, 3, 324 p., [1] leaf of plates : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Prastuta śodha-prabandha Rājasthāna Viśvavidyālaya, Jayapura kī Pī-eca.Ḍī-upāthi ke nimitta viśvavidyālaya anudāna āyoga kī risarca phailośipa ke antargata likhā gayā thā.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: p. [321]-324.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sūryamalla Miśraṇa, 1815-1868"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Rājasthāna Sāhitya Akādamī (Saṅgama)"
+          ],
+          "language": [
+            {
+              "id": "lang:hin",
+              "label": "Hindi"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vaṃśabhāskara : eka adhyayana"
+          ],
+          "shelfMark": [
+            "*OKTM 84-1945"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Khāna, Ālama Śāha, 1936-2003."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75903689"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKTM 84-1945"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000028"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75903689"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100013"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200027"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Udayapura : Rājasthāna Sāhitya Akādamī (Saṅgama), 1973."
+          ],
+          "identifier": [
+            "urn:bnum:10000028",
+            "urn:lccn:75903689",
+            "urn:oclc:NYPG001000013-B",
+            "urn:undefined:NNSZ00100013",
+            "urn:undefined:(WaOLN)nyp0200027"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sūryamalla Miśraṇa, 1815-1868."
+          ],
+          "titleDisplay": [
+            "Vaṃśabhāskara : eka adhyayana / lekhaka Ālamaśāha Khāna."
+          ],
+          "uri": "b10000028",
+          "lccClassification": [
+            "PK2708.9.S9 V334"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Udayapura"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25cm."
+          ]
+        },
+        "sort": [
+          "b10000028"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942033",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKTM 84-1945"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKTM 84-1945",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011094210"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKTM 84-1945"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011094210"
+                    ],
+                    "idBarcode": [
+                      "33433011094210"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKTM 84-001945"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000029",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "16 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: 8:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: Wilhelm Hansen edition no. 4372.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Publisher's no.: 29589.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Organ music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "W. Hansen ; Distribution, Magnamusic-Baton"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cruor : for organ solo, 1977"
+          ],
+          "shelfMark": [
+            "JMF 83-93"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lorentzen, Bent."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "82771131"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-93"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000029"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "82771131"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000013-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Wilhelm Hansen edition no. 4372."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "29589."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100563"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200028"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000013-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Copenhagen ; New York : W. Hansen ; [s.l.] : Distribution, Magnamusic-Baton, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000029",
+            "urn:lccn:82771131",
+            "urn:oclc:NYPG001000013-C",
+            "urn:undefined:Wilhelm Hansen edition no. 4372.",
+            "urn:undefined:29589.",
+            "urn:undefined:NNSZ00100563",
+            "urn:undefined:(WaOLN)nyp0200028"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Organ music."
+          ],
+          "titleDisplay": [
+            "Cruor : for organ solo, 1977 / B. Lorentzen."
+          ],
+          "uri": "b10000029",
+          "lccClassification": [
+            "M11 .L"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Copenhagen ; New York : [s.l.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000029"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942034",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-93"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-93",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709556"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-93"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709556"
+                    ],
+                    "idBarcode": [
+                      "33433032709556"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000093"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000030",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21, 264 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Āryasamāja-śatābdī-saṃskaraṇam.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Authorship uncertain. Attributed variously to Āpiśali, Pānini and Śākaṭāyana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit: introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit language",
+            "Sanskrit language -- Suffixes and prefixes"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; prāptisthānam, Rāmalāla Kapūra Ṭrasṭa"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Uṇādi-koṣaḥ"
+          ],
+          "shelfMark": [
+            "*OKA 84-1931"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75902275"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Āpiśali.",
+            "Pāṇini.",
+            "Śākatāyana.",
+            "Dayananda Sarasvati, Swami, 1824-1883.",
+            "Yudhiṣṭhira Mīmāṃsaka, 1909-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKA 84-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000030"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902275"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100014"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200029"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-B"
+          ],
+          "uniformTitle": [
+            "Uṇādisūtra."
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Karanāla : Ra.Ba.Cau. Nārāyaṇasiṃha Dharmārtha Ṭrasṭa ; Bahālagaḍha, Harayāṇa : prāptisthānam, Rāmalāla Kapūra Ṭrasṭa, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000030",
+            "urn:lccn:75902275",
+            "urn:oclc:NYPG001000014-B",
+            "urn:undefined:NNSZ00100014",
+            "urn:undefined:(WaOLN)nyp0200029"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit language -- Suffixes and prefixes."
+          ],
+          "titleDisplay": [
+            "Uṇādi-koṣaḥ / Dayānanda Sarasvatī Svāminā viracitayā Vaidika-laukika-koṣābhidhayā vyākhyayā sahitaḥ vividhābhi-ṣṭippaṇībhiḥ sūcībhiśca saṃyutaḥ ; sampādakaḥ Yudhiṣṭhiro Mīmāṃsakaḥ."
+          ],
+          "uri": "b10000030",
+          "lccClassification": [
+            "PK551 .U73"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Karanāla : Bahālagaḍha, Harayāṇa"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10000030"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000007",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKA 84-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKA 84-1931",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433012968222"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKA 84-1931"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433012968222"
+                    ],
+                    "idBarcode": [
+                      "33433012968222"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKA 84-001931"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000031",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "21 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Piano music"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "W. Müller"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1979
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Neun Miniaturen : für Klavier : op. 52"
+          ],
+          "shelfMark": [
+            "JMG 83-17"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Petersen, Wilhelm, 1890-1957."
+          ],
+          "createdString": [
+            "1979"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1979
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-17"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000031"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000014-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "W. Müller WM 1713 SM."
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200030"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000014-C"
+          ],
+          "uniformTitle": [
+            "Miniaturen"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Heidelberg : W. Müller, c1979."
+          ],
+          "identifier": [
+            "urn:bnum:10000031",
+            "urn:oclc:NYPG001000014-C",
+            "urn:undefined:W. Müller WM 1713 SM.",
+            "urn:undefined:NNSZ00100564",
+            "urn:undefined:(WaOLN)nyp0200030"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1979"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Piano music."
+          ],
+          "titleDisplay": [
+            "Neun Miniaturen : für Klavier : op. 52 / Wilhelm Petersen."
+          ],
+          "uri": "b10000031",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Heidelberg"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Miniaturen",
+            "Miniaturen."
+          ],
+          "dimensions": [
+            "32 cm."
+          ]
+        },
+        "sort": [
+          "b10000031"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942035",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-17"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-17",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841631"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841631"
+                    ],
+                    "idBarcode": [
+                      "33433032841631"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000017"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000032",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "14, 405, 7 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jahrom (Iran : Province)",
+            "Jahrom (Iran : Province) -- Biography",
+            "Khafr (Iran)",
+            "Khafr (Iran) -- Biography"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Kitābfurūshī-i Khayyām"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr"
+          ],
+          "shelfMark": [
+            "*OMP 84-2007"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Ishrāq, Muḥammad Karīm."
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OMP 84-2007"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000032"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100015"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200031"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Tihrān : Kitābfurūshī-i Khayyām, 1351 [1972]"
+          ],
+          "identifier": [
+            "urn:bnum:10000032",
+            "urn:oclc:NYPG001000015-B",
+            "urn:undefined:NNSZ00100015",
+            "urn:undefined:(WaOLN)nyp0200031"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jahrom (Iran : Province) -- Biography.",
+            "Khafr (Iran) -- Biography."
+          ],
+          "titleDisplay": [
+            "Buzurgān-i Jahrum : mushtamil bar sharḥ-i aḥvāl va ā̲sār-i rijāl va sukhanvarān va dānishmandān va khushnivīsān va pizishkān-i Jahrum va Khafr / taʼlīf-i Muḥammad Karīm Ishrāq."
+          ],
+          "uri": "b10000032",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Tihrān"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22cm"
+          ]
+        },
+        "sort": [
+          "b10000032"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000008",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OMP 84-2007"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OMP 84-2007",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013173012"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OMP 84-2007"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013173012"
+                    ],
+                    "idBarcode": [
+                      "33433013173012"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OMP 84-002007"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000033",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (20 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For voice and organ.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sacred songs (Medium voice) with organ",
+            "Psalms (Music)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Agápe"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Psalm settings"
+          ],
+          "shelfMark": [
+            "JMG 83-59"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Nelhybel, Vaclav."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-59"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000033"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000015-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100565"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200032"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000015-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Carol Stream, Ill. : Agápe, c1981."
+          ],
+          "identifier": [
+            "urn:bnum:10000033",
+            "urn:oclc:NYPG001000015-C",
+            "urn:undefined:NNSZ00100565",
+            "urn:undefined:(WaOLN)nyp0200032"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sacred songs (Medium voice) with organ.",
+            "Psalms (Music)"
+          ],
+          "titleDisplay": [
+            "Psalm settings / Vaclav Nelhybel."
+          ],
+          "uri": "b10000033",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Carol Stream, Ill."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Hear me when I call -- Be not far from me -- Hear my voice -- The Lord is my rock."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000033"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942037",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-59",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-59"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942036",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-59"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-59",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842035"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-59"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842035"
+                    ],
+                    "idBarcode": [
+                      "33433032842035"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000059"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000034",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "366 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Caption title: Brhatkathāślokasaṁgrahaḥ.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Colophon: Iti Śrībhaṭṭabudhasvāminā krte ślokasaṁgrahe Brhatkathāyāṁ--",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references and index.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Text in Sanskrit; apparatus in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Prithivi Prakashan"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brhatkathāślokasaṁgraha : a study"
+          ],
+          "shelfMark": [
+            "*OKR 84-2006"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Budhasvāmin."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "74903273"
+          ],
+          "seriesStatement": [
+            "Indian civilization series ; no. 4"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Guṇāḍhya.",
+            "Agrawala, Vasudeva Sharana.",
+            "Agrawala, Prithvi Kumar."
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKR 84-2006"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000034"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "74903273"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100016"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200033"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Varanasi : Prithivi Prakashan, 1974."
+          ],
+          "identifier": [
+            "urn:bnum:10000034",
+            "urn:lccn:74903273",
+            "urn:oclc:NYPG001000016-B",
+            "urn:undefined:NNSZ00100016",
+            "urn:undefined:(WaOLN)nyp0200033"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Brhatkathāślokasaṁgraha : a study / by V.S. Agrawala ; with Sanskrit text, edited by P.K. Agrawala."
+          ],
+          "uri": "b10000034",
+          "lccClassification": [
+            "PK3794.B84 B7 1974"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Varanasi"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000034"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKR 84-2006"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKR 84-2006",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011528696"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKR 84-2006"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011528696"
+                    ],
+                    "idBarcode": [
+                      "33433011528696"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKR 84-002006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000035",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "22 p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Suite.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 12:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Serenade voor piano : 1980"
+          ],
+          "shelfMark": [
+            "JMG 83-6"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Kasbergen, Marinus, 1936-"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-6"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000035"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000016-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100566"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200034"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000016-C"
+          ],
+          "uniformTitle": [
+            "Serenade, piano"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000035",
+            "urn:oclc:NYPG001000016-C",
+            "urn:undefined:NNSZ00100566",
+            "urn:undefined:(WaOLN)nyp0200034"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Piano)"
+          ],
+          "titleDisplay": [
+            "Serenade voor piano : 1980 / Marinus Kasbergen."
+          ],
+          "uri": "b10000035",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Serenade"
+          ],
+          "tableOfContents": [
+            "Varianten -- Nocturne -- Toccata I -- Intermezzo -- Toccata II."
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000035"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942038",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841490"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-6"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841490"
+                    ],
+                    "idBarcode": [
+                      "33433032841490"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1123",
+                        "label": "Music Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1123||Music Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mym32",
+                        "label": "Performing Arts Research Collections - Music"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mym32||Performing Arts Research Collections - Music"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-6",
+                        "type": "bf:ShelfMark"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-6"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000006"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000036",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "viii, 38 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; prefatory matter in Sanskrit or Telegu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nārāyaṇatīrtha, 17th cent",
+            "Nārāyaṇatīrtha, 17th cent -- In literature"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "s.n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1972
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic]"
+          ],
+          "shelfMark": [
+            "*OKB 84-1928"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Lakshmikantaiah, Garikapati, 1900-"
+          ],
+          "createdString": [
+            "1972"
+          ],
+          "idLccn": [
+            "75902755"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1972
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKB 84-1928"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000036"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75902755"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100017"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200035"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-B"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "[s.1. : s.n.], 1972"
+          ],
+          "identifier": [
+            "urn:bnum:10000036",
+            "urn:lccn:75902755",
+            "urn:oclc:NYPG001000017-B",
+            "urn:undefined:NNSZ00100017",
+            "urn:undefined:(WaOLN)nyp0200035"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1972"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nārāyaṇatīrtha, 17th cent -- In literature."
+          ],
+          "titleDisplay": [
+            "Srīnārāyaṇatīrthayatīndracaritram[sic] / praṇetā Garikapāṭi Lakṣmīkāntaḥ."
+          ],
+          "uri": "b10000036",
+          "lccClassification": [
+            "PK3799.L28 S68"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[s.1."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000036"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKB 84-1928"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKB 84-1928",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058548433"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKB 84-1928"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058548433"
+                    ],
+                    "idBarcode": [
+                      "33433058548433"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKB 84-001928"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000037",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "13a p. of music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 15:00.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Suites (Guitar)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Donemus"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Eight studies for guitar : in form of a suite : 1979"
+          ],
+          "shelfMark": [
+            "JMG 83-5"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hekster, Walter."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-5"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000037"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000017-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100567"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200036"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000017-C"
+          ],
+          "uniformTitle": [
+            "Studies, guitar"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Amsterdam : Donemus, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000037",
+            "urn:oclc:NYPG001000017-C",
+            "urn:undefined:NNSZ00100567",
+            "urn:undefined:(WaOLN)nyp0200036"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Suites (Guitar)"
+          ],
+          "titleDisplay": [
+            "Eight studies for guitar : in form of a suite : 1979 / Walter Hekster."
+          ],
+          "uri": "b10000037",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Studies"
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10000037"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032841482"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-5"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032841482"
+                    ],
+                    "idBarcode": [
+                      "33433032841482"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000005"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000038",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "4, 160 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit, with verse and prose translations in Hindi; prefatory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sanskrit poetry",
+            "Sanskrit poetry -- Himachal Pradesh"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Himācala Kalā-Saṃskrti-Bhāṣā Akādamī"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana"
+          ],
+          "shelfMark": [
+            "*OKP 84-1932"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "76900772"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Prarthi, Lall Chand, 1916-"
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKP 84-1932"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000038"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76900772"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200037"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-B"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "Śimalā : Himācala Kalā-Saṃskrti-Bhāṣā Akādamī, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10000038",
+            "urn:lccn:76900772",
+            "urn:oclc:NYPG001000018-B",
+            "urn:undefined:NNSZ00100018",
+            "urn:undefined:(WaOLN)nyp0200037"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sanskrit poetry -- Himachal Pradesh."
+          ],
+          "titleDisplay": [
+            "Rtambharā : Himācala ke ādhunika Saṃskrta kaviyoṃ kī kavitāyoṃ kā saṅkalana / mukhya sampādaka Lāla Canda Prārthī ; sampādaka maṇḍala, Manasā Rāma Śarmā 'Arūṇa'...[et al.]."
+          ],
+          "uri": "b10000038",
+          "lccClassification": [
+            "PK3800.H52 R7"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Śimalā"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10000038"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783788",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKP 84-1932"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKP 84-1932",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058153572"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKP 84-1932"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058153572"
+                    ],
+                    "idBarcode": [
+                      "33433058153572"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKP 84-001932"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000039",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "49 p. of music ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Sonatas (Piano)"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "C.F. Peters"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Five sonatas for pianoforte"
+          ],
+          "shelfMark": [
+            "JMG 83-66"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Hässler, Johann Wilhelm, 1747-1822."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Oberdoerffer, Fritz."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000039"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000018-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Edition Peters no. 66799. C.F. Peters"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100568"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200038"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000018-C"
+          ],
+          "uniformTitle": [
+            "Sonatas, piano. Selections"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "New York : C.F. Peters, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000039",
+            "urn:oclc:NYPG001000018-C",
+            "urn:undefined:Edition Peters no. 66799. C.F. Peters",
+            "urn:undefined:NNSZ00100568",
+            "urn:undefined:(WaOLN)nyp0200038"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Sonatas (Piano)"
+          ],
+          "titleDisplay": [
+            "Five sonatas for pianoforte / Johann Wilhelm Hässler ; edited by Fritz Oberdoerffer."
+          ],
+          "uri": "b10000039",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Sonatas"
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10000039"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMG 83-66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMG 83-66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032842100"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMG 83-66"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032842100"
+                    ],
+                    "idBarcode": [
+                      "33433032842100"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMG 83-000066"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000040",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "146 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār."
+          ],
+          "shelfMark": [
+            "*OLB 84-1947"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Pulavar Arasu, 1900-"
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "idLccn": [
+            "78913375"
+          ],
+          "seriesStatement": [
+            "Kaḻaka veḷiyīṭu, 672"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-1947"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000040"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "78913375"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100019"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200039"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-B"
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Ceṉṉai, Tirunelvēlit Teṉṉintiya Caivacittānta Nūṟpatippuk Kaḻakam, 1970."
+          ],
+          "identifier": [
+            "urn:bnum:10000040",
+            "urn:lccn:78913375",
+            "urn:oclc:NYPG001000019-B",
+            "urn:undefined:NNSZ00100019",
+            "urn:undefined:(WaOLN)nyp0200039"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kaliyāṇacuntaraṉār, Tiru. Vi., 1883-1953."
+          ],
+          "titleDisplay": [
+            "Tiru. Vi. Kaliyāṇacuntaraṉār. Āciriyar Pulavar Aracu."
+          ],
+          "uri": "b10000040",
+          "lccClassification": [
+            "PL4758.9.K223 Z83"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "18 cm."
+          ]
+        },
+        "sort": [
+          "b10000040"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783789",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLB 84-1947"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLB 84-1947",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061301622"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-1947"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061301622"
+                    ],
+                    "idBarcode": [
+                      "33433061301622"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-001947"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000041",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 score (23 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 5 clarinets.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Woodwind quintets (Clarinets (5))",
+            "Woodwind quintets (Clarinets (5)) -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Primavera"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Encounter"
+          ],
+          "shelfMark": [
+            "JMF 83-66"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Usher, Julia."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "idLccn": [
+            "81770739"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMF 83-66"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000041"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81770739"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000019-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100569"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200040"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000019-C"
+          ],
+          "updatedAt": 1674870747963,
+          "publicationStatement": [
+            "London : Primavera, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000041",
+            "urn:lccn:81770739",
+            "urn:oclc:NYPG001000019-C",
+            "urn:undefined:NNSZ00100569",
+            "urn:undefined:(WaOLN)nyp0200040"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Woodwind quintets (Clarinets (5)) -- Scores."
+          ],
+          "titleDisplay": [
+            "Encounter / Julia Usher."
+          ],
+          "uri": "b10000041",
+          "lccClassification": [
+            "M557.2.U8 E5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Greeting -- Circular argument -- Escape."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10000041"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942042",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMF 83-66"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMF 83-66",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032709291"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMF 83-66"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032709291"
+                    ],
+                    "idBarcode": [
+                      "33433032709291"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMF 83-000066"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000042",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "2, 108 p."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "Hindi and Sanskrit: pref. in Hindi.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Advaita",
+            "Vedanta"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Devabhāṣā Prakāśana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1971
+          ],
+          "dateEndString": [
+            "1972"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita."
+          ],
+          "shelfMark": [
+            "*OKN 84-1926"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902870"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Brahmashram, Śwami, 1915-"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 84-1926"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000042"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902870"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100020"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200041"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-B"
+          ],
+          "uniformTitle": [
+            "Mahābhārata. Sanatsugātīya."
+          ],
+          "dateEndYear": [
+            1972
+          ],
+          "updatedAt": 1674870747855,
+          "publicationStatement": [
+            "Prayāga, Devabhāṣā Prakāśana, Samvat 2028, i.e. 1971 or 2]"
+          ],
+          "identifier": [
+            "urn:bnum:10000042",
+            "urn:lccn:72902870",
+            "urn:oclc:NYPG001000020-B",
+            "urn:undefined:NNSZ00100020",
+            "urn:undefined:(WaOLN)nyp0200041"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Advaita.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Sanatsujātīyadarśanam; Mahābhārata-Udyoga parva ke antargata brahmavidyā kā sandarbha. Śabdārtha evaṃ subodha Hindī-bhāṣya se samanvita. Vyākhyātā Svāmī Brahmāśrama."
+          ],
+          "uri": "b10000042",
+          "lccClassification": [
+            "B132.V3 M264"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Prayāga"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000042"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783790",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OKN 84-1926"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OKN 84-1926",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058618392"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OKN 84-1926"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058618392"
+                    ],
+                    "idBarcode": [
+                      "33433058618392"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OKN 84-001926"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000043",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "1 miniature score (28 p.) ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "For 2 flutes, 2 oboes, 2 clarinets, 2 horns, and 2 bassoons.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Duration: ca. 5:00-6:00.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Pl. no.: D.15 579.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Wind ensembles",
+            "Wind ensembles -- Scores"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Verlag Doblinger"
+          ],
+          "language": [
+            {
+              "id": "lang:zxx",
+              "label": "No linguistic content"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Capriccio : für 10 Blasinstrumente"
+          ],
+          "shelfMark": [
+            "JMC 83-9"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Eröd, Iván."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Doblingers Studienpartituren ; Stp. 410"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMC 83-9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000043"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG001000020-C"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "Stp. 410 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "D.15 579 Verlag Doblinger"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00100570"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0200042"
+            }
+          ],
+          "idOclc": [
+            "NYPG001000020-C"
+          ],
+          "updatedAt": 1674870752089,
+          "publicationStatement": [
+            "Wien : Verlag Doblinger, c1980."
+          ],
+          "identifier": [
+            "urn:bnum:10000043",
+            "urn:oclc:NYPG001000020-C",
+            "urn:undefined:Stp. 410 Verlag Doblinger",
+            "urn:undefined:D.15 579 Verlag Doblinger",
+            "urn:undefined:NNSZ00100570",
+            "urn:undefined:(WaOLN)nyp0200042"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:not",
+              "label": "Notated music"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Wind ensembles -- Scores."
+          ],
+          "titleDisplay": [
+            "Capriccio : für 10 Blasinstrumente / Iván Eröd."
+          ],
+          "uri": "b10000043",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Wien"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10000043"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10000010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:7",
+                        "label": "printed music, non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:7||printed music, non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JMC 83-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JMC 83-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004744128"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JMC 83-9"
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004744128"
+                    ],
+                    "idBarcode": [
+                      "33433004744128"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Notated music"
+                    ],
+                    "shelfMark_sort": "aJMC 83-000009"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-efcd64aead2119e3b2912e9f7ac73d65.json
+++ b/test/fixtures/query-efcd64aead2119e3b2912e9f7ac73d65.json
@@ -1,0 +1,26491 @@
+{
+  "took": 1102,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 5460269,
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10000109",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "xxii, 321 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. [305]-321).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Americans",
+            "Americans -- History",
+            "Americans -- History -- China",
+            "Americans -- History -- China -- 19th century",
+            "Public opinion",
+            "Public opinion -- United States",
+            "Public opinion -- United States -- History",
+            "Public opinion -- United States -- History -- 19th century",
+            "United States",
+            "United States -- Chinese influences",
+            "United States -- Intellectual life",
+            "United States -- Intellectual life -- 19th century",
+            "China",
+            "China -- History",
+            "China -- History -- 19th century",
+            "China -- Description and travel",
+            "China -- In popular culture",
+            "United States -- Relations",
+            "United States -- Relations -- China",
+            "China -- Relations",
+            "China -- Relations -- United States"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Columbia University Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            2008
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The romance of China : excursions to China in U.S. culture, 1776-1876"
+          ],
+          "shelfMark": [
+            "JFE 09-1362"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Haddad, John Rogers."
+          ],
+          "createdString": [
+            "2008"
+          ],
+          "idLccn": [
+            "2008037637"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            2008
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFE 09-1362"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10000109"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9780231130943 (cloth : alk. paper)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "0231130945 (cloth : alk. paper)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "2008037637"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "184821618"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "184821618"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)184821618"
+            }
+          ],
+          "idOclc": [
+            "184821618"
+          ],
+          "updatedAt": 1674870755402,
+          "publicationStatement": [
+            "New York : Columbia University Press, c2008."
+          ],
+          "identifier": [
+            "urn:bnum:10000109",
+            "urn:isbn:9780231130943 (cloth : alk. paper)",
+            "urn:isbn:0231130945 (cloth : alk. paper)",
+            "urn:lccn:2008037637",
+            "urn:oclc:184821618",
+            "urn:undefined:(OCoLC)184821618"
+          ],
+          "idIsbn": [
+            "9780231130943 (cloth : alk. paper)",
+            "0231130945 (cloth : alk. paper)"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2008"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Americans -- History -- China -- 19th century.",
+            "Public opinion -- United States -- History -- 19th century.",
+            "United States -- Chinese influences.",
+            "United States -- Intellectual life -- 19th century.",
+            "China -- History -- 19th century.",
+            "China -- Description and travel.",
+            "China -- In popular culture.",
+            "United States -- Relations -- China.",
+            "China -- Relations -- United States."
+          ],
+          "titleDisplay": [
+            "The romance of China : excursions to China in U.S. culture, 1776-1876 / John Rogers Haddad."
+          ],
+          "uri": "b10000109",
+          "lccClassification": [
+            "E183.8.C5 H175 2008"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Xanadu : an envoy at the throne of a monarch -- Romantic domesticity : a Chinese world invented at home -- Pursuing the China effect : a country described through marketing -- China in miniature : Nathan Dunn's Chinese museum -- A floating ethnology : the strange voyage of the Chinese junk Keying -- God's China : the Middle Kingdom of Samuel Wells Williams -- The cultural fruits of diplomacy : Chinese museum and panorama -- The ugly face of China : Bayard Taylor's travels in Asia -- Traditional China and Chinese Yankees : the Centennial Exposition of 1876."
+          ],
+          "idIsbn_clean": [
+            "9780231130943",
+            "0231130945"
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10000109"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23117386",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1101",
+                        "label": "General Research Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1101||General Research Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal82",
+                        "label": "Schwarzman Building - Main Reading Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal82||Schwarzman Building - Main Reading Room 315"
+                    ],
+                    "shelfMark": [
+                      "JFE 09-1362"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JFE 09-1362",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084847221"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "JFE 09-1362"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084847221"
+                    ],
+                    "idBarcode": [
+                      "33433084847221"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJFE 09-001362"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13783799",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OLF 82-5145"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLF 82-5145",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061318089"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*OLF 82-5145"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061318089"
+                    ],
+                    "idBarcode": [
+                      "33433061318089"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLF 82-005145"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001333",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., folded maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Geomorphology",
+            "Geomorphology -- Libya"
+          ],
+          "publisherLiteral": [
+            "al-Jāmiʻah al-Lībīyah, Kullīyat al-Ādāb,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Abḥāth fī zhiyūmūrfūlūzhīyat al-arāḍī al-Lībīyah"
+          ],
+          "shelfMark": [
+            "*OFO 82-5116"
+          ],
+          "creatorLiteral": [
+            "Jawdah, Jawdah Ḥasanayn."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "75960642"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFO 82-5116"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001333"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75960642"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201348"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201331"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636070536203,
+          "publicationStatement": [
+            "[Binghāzī] : al-Jāmiʻah al-Lībīyah, Kullīyat al-Ādāb, 1973-"
+          ],
+          "identifier": [
+            "urn:bnum:10001333",
+            "urn:lccn:75960642",
+            "urn:undefined:NNSZ00201348",
+            "urn:undefined:(WaOLN)nyp0201331"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Geomorphology -- Libya."
+          ],
+          "titleDisplay": [
+            "Abḥāth fī zhiyūmūrfūlūzhīyat al-arāḍī al-Lībīyah / Jawdah Ḥasanayn Jawdah."
+          ],
+          "uri": "b10001333",
+          "lccClassification": [
+            "GB440.L5 J38"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Binghāzī] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24cm."
+          ]
+        },
+        "sort": [
+          "b10001333"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586197"
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5116 al-Juzʼān 1-2."
+                    ],
+                    "shelfMark_sort": "a*OFO 82-5116 al-Juzʼān 1-2. v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10000872",
+                    "shelfMark": [
+                      "*OFO 82-5116 al-Juzʼān 1-2. v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFO 82-5116 al-Juzʼān 1-2. v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586197"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433005586197"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005586189"
+                    ],
+                    "physicalLocation": [
+                      "*OFO 82-5116 al-Juzʼān 1-2."
+                    ],
+                    "shelfMark_sort": "a*OFO 82-5116 al-Juzʼān 1-2. v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10000871",
+                    "shelfMark": [
+                      "*OFO 82-5116 al-Juzʼān 1-2. v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFO 82-5116 al-Juzʼān 1-2. v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005586189"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433005586189"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001377",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "71 p. : ill., music ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references (p. 69).",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Silbermann, Gottfried, 1683-1753",
+            "Organ (Musical instrument)",
+            "Organ (Musical instrument) -- Instruction and study",
+            "Improvisation (Music)",
+            "Improvisation (Music) -- Instruction and study",
+            "Organ music",
+            "Organ music -- Interpretation (Phrasing, dynamics, etc.)",
+            "Organ builders",
+            "Organ builders -- Germany"
+          ],
+          "publisherLiteral": [
+            "Verlag Klaus-Jürgen Kamprad"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "createdYear": [
+            2007
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Choralimprovisation auf Orgeln Gottfried Silbermanns"
+          ],
+          "shelfMark": [
+            "JMG 09-710"
+          ],
+          "creatorLiteral": [
+            "Wagler, Dietrich, 1940-"
+          ],
+          "createdString": [
+            "2007"
+          ],
+          "seriesStatement": [
+            "Freiberger Studien zur Orgel ; 10"
+          ],
+          "contributorLiteral": [
+            "Gottfried-Silbermann-Gesellschaft."
+          ],
+          "dateStartYear": [
+            2007
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JMG 09-710"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001377"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9783930550494 (pbk.)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "3930550490 (pbk.)"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "439765611"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)439765611"
+            }
+          ],
+          "idOclc": [
+            "439765611"
+          ],
+          "updatedAt": 1652323426362,
+          "publicationStatement": [
+            "[Altenburg] : Verlag Klaus-Jürgen Kamprad, c2007."
+          ],
+          "identifier": [
+            "urn:bnum:10001377",
+            "urn:isbn:9783930550494 (pbk.)",
+            "urn:isbn:3930550490 (pbk.)",
+            "urn:oclc:439765611",
+            "urn:undefined:(OCoLC)439765611"
+          ],
+          "idIsbn": [
+            "9783930550494 (pbk.)",
+            "3930550490 (pbk.)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2007"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Silbermann, Gottfried, 1683-1753.",
+            "Organ (Musical instrument) -- Instruction and study.",
+            "Improvisation (Music) -- Instruction and study.",
+            "Organ music -- Interpretation (Phrasing, dynamics, etc.)",
+            "Organ builders -- Germany."
+          ],
+          "titleDisplay": [
+            "Choralimprovisation auf Orgeln Gottfried Silbermanns / Dietrich Wagler ; [Hrsg.: Gottfried-Silbermann-Gesellschaft]."
+          ],
+          "uri": "b10001377",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Altenburg]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "9783930550494",
+            "3930550490"
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10001377"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433089337251"
+                    ],
+                    "physicalLocation": [
+                      "JMG 09-710"
+                    ],
+                    "shelfMark_sort": "aJMG 09-000710",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i24299761",
+                    "shelfMark": [
+                      "JMG 09-710"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JMG 09-710"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433089337251"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcpm2||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433089337251"
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcpm2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NP"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001657",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on p. [4] of cover: Village gazetteer.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Bar asās-i natāyij-i sarshumārī-i ʻumūmī-i Ābānʼmāh-i 1345.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "English and Persian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iran",
+            "Iran -- Gazetteers",
+            "Villages",
+            "Villages -- Iran",
+            "Villages -- Iran -- Statistics"
+          ],
+          "publisherLiteral": [
+            "Markaz-i Āmār-i Īrān,"
+          ],
+          "language": [
+            {
+              "id": "lang:per",
+              "label": "Persian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Farhang-i ābādīhā-yi kishvar."
+          ],
+          "shelfMark": [
+            "Map Div. 84-146"
+          ],
+          "creatorLiteral": [
+            "Markaz-i Āmār-i Īrān."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "81464564"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Map Div. 84-146"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001657"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "81464564"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201692"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201655"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636095534719,
+          "publicationStatement": [
+            "Tihrān : Markaz-i Āmār-i Īrān, 1347- [1969-]"
+          ],
+          "identifier": [
+            "urn:bnum:10001657",
+            "urn:lccn:81464564",
+            "urn:undefined:NNSZ00201692",
+            "urn:undefined:(WaOLN)nyp0201655"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iran -- Gazetteers.",
+            "Villages -- Iran -- Statistics."
+          ],
+          "titleDisplay": [
+            "Farhang-i ābādīhā-yi kishvar."
+          ],
+          "uri": "b10001657",
+          "lccClassification": [
+            "DS253 .M37"
+          ],
+          "numItems": [
+            11
+          ],
+          "numAvailable": [
+            11
+          ],
+          "placeOfPublication": [
+            "Tihrān :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Village gazetteer."
+          ],
+          "tableOfContents": [
+            "Jild-i 2. Ustān-i Āẕarbāyjān-i Gharbī--Jild-i 3-5. Ustān-i Khurāsān--Jild-1 6. Ustān-i Kurdistān--Jild-i 9. Farmāndārī-i Kull-i Luristān--Jild-i 10. Farmāndārīhā-yi Kull-i Banādir va Jazāʼir-i Khalīj-i Fārs va Daryā-yi Ummān--Jild-i 11. Ustān-i Māzandarān--Jild-i 14. Ustān-i Markazī--Jild-i 15. Ustān-i Gilān--Jild-i 17. Farmāndārī-i Kull-i Simnān."
+          ],
+          "dimensions": [
+            "42x54 cm."
+          ]
+        },
+        "sort": [
+          "b10001657"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 11,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 10
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030870"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000017",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784147",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 17"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 17"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030870"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 17"
+                    ],
+                    "idBarcode": [
+                      "33433057030870"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030862"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000015",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784146",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 15"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 15"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030862"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 15"
+                    ],
+                    "idBarcode": [
+                      "33433057030862"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030854"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000014",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784145",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 14"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030854"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 14"
+                    ],
+                    "idBarcode": [
+                      "33433057030854"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030847"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000010",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784144",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 10"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030847"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10"
+                    ],
+                    "idBarcode": [
+                      "33433057030847"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030839"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000009",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784143",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 9"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030839"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 9"
+                    ],
+                    "idBarcode": [
+                      "33433057030839"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030821"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000006",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784142",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 6"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030821"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "idBarcode": [
+                      "33433057030821"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030813"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000005",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784141",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 5"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030813"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "idBarcode": [
+                      "33433057030813"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030805"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784140",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030805"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433057030805"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030797"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784139",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030797"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433057030797"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030789"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784138",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030789"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433057030789"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1106",
+                        "label": "Lionel Pincus and Princess Firyal Map Division"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057030771"
+                    ],
+                    "physicalLocation": [
+                      "Map Div. 84-146"
+                    ],
+                    "shelfMark_sort": "aMap Div. 84-146 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784137",
+                    "shelfMark": [
+                      "Map Div. 84-146 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "Map Div. 84-146 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057030771"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmp2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433057030771"
+                    ],
+                    "owner_packed": [
+                      "orgs:1106||Lionel Pincus and Princess Firyal Map Division"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmp2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10001844",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: The Brahmasūtra Śāṅkarbhāṣya.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Hindu philosophy",
+            "Vedanta"
+          ],
+          "publisherLiteral": [
+            "Chaukhambā Vidyābhavana"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1964
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Brahmasūtraśāṅkarabhāṣyam. 'Brahmatatvavimarśinī' Hindīvyākhyāsahitam."
+          ],
+          "shelfMark": [
+            "*OKN 82-2276"
+          ],
+          "creatorLiteral": [
+            "Bādarāyaṇa."
+          ],
+          "createdString": [
+            "1964"
+          ],
+          "idLccn": [
+            "sa 65007118"
+          ],
+          "seriesStatement": [
+            "Vidyābhavara Saṃskrta granthamālā, 124"
+          ],
+          "contributorLiteral": [
+            "Sastri, Hanumanadas, Swami.",
+            "Śaṅkarācārya."
+          ],
+          "dateStartYear": [
+            1964
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKN 82-2276"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10001844"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sa 65007118"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00201882"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0201842"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636079011965,
+          "publicationStatement": [
+            "Vārāṇasī, Chaukhambā Vidyābhavana [1964-"
+          ],
+          "identifier": [
+            "urn:bnum:10001844",
+            "urn:lccn:sa 65007118",
+            "urn:undefined:NNSZ00201882",
+            "urn:undefined:(WaOLN)nyp0201842"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1964"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Hindu philosophy.",
+            "Vedanta."
+          ],
+          "titleDisplay": [
+            "Brahmasūtraśāṅkarabhāṣyam. 'Brahmatatvavimarśinī' Hindīvyākhyāsahitam. Vyākhyākāra [sic] Svāmī Hanumānadāsa Shaṭśāstrī. Bhūmikā-lekhaka Vīramaṇi Prasāda Upādhyāya."
+          ],
+          "uri": "b10001844",
+          "lccClassification": [
+            "B132.V3 B22"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Vārāṇasī,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Brahmasūtra Śaṅkarbhāṣya."
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10001844"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433058617816"
+                    ],
+                    "physicalLocation": [
+                      "*OKN 82-2276"
+                    ],
+                    "shelfMark_sort": "a*OKN 82-002276",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13784177",
+                    "shelfMark": [
+                      "*OKN 82-2276"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKN 82-2276"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433058617816"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433058617816"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003410",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. facsims."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Added t.p.: Imam Ṭaḥāwī's Disagreement of jurists (Ikhtilāf al-fuqahāʼ)",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Introd. in Arabic and English ; text in Arabic.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: v. 1, p. [313]-314.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Islamic law"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ikhtilāf al-fuqahāʼ,"
+          ],
+          "shelfMark": [
+            "*OGM 84-702"
+          ],
+          "creatorLiteral": [
+            "Ṭaḥāwī, Aḥmad ibn Muḥammad, 852?-933."
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72930954"
+          ],
+          "seriesStatement": [
+            "Maṭbūʻāt Maʻhad al-Abḥāth al-Islāmīyāh. Publication no. 23"
+          ],
+          "contributorLiteral": [
+            "Maʻṣūmī, M. Ṣaghīr Ḥasan (Muḥammad Ṣaghīr Ḥasan)"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGM 84-702"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003410"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72930954"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303765"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203402"
+            }
+          ],
+          "uniformTitle": [
+            "Publication (Islamic Research Institute (Pakistan)) ; \\no.23."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636104747880,
+          "publicationStatement": [
+            "Islām Ābād [1971-"
+          ],
+          "identifier": [
+            "urn:bnum:10003410",
+            "urn:lccn:72930954",
+            "urn:undefined:NNSZ00303765",
+            "urn:undefined:(WaOLN)nyp0203402"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Islamic law."
+          ],
+          "titleDisplay": [
+            "Ikhtilāf al-fuqahāʼ, lil-Imām Abī Jaʻfar Aḥmad ibn Muḥammad al-Ṭaḥāwī. Ḥaqqaqahu wa-ʻallaqa ʻalayhi Muḥammad Ṣaghīr Ḥasan al-Maʻṣūmī."
+          ],
+          "uri": "b10003410",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Islām Ābād"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003410"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001944960"
+                    ],
+                    "physicalLocation": [
+                      "*OGM 84-702"
+                    ],
+                    "shelfMark_sort": "a*OGM 84-000702",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002358",
+                    "shelfMark": [
+                      "*OGM 84-702"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OGM 84-702"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001944960"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001944960"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003414",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title: Skandamahāpurāṇam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Added t.p. in English or Hindi.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 1:2. Saṃskaraṇam; v. 2-: 1. Saṃskaraṇam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Sanskrit; introductory matter in Hindi or Sanskrit.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Manasukharāya Mora,"
+          ],
+          "language": [
+            {
+              "id": "lang:san",
+              "label": "Sanskrit"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Skandamahāpurāṇam"
+          ],
+          "shelfMark": [
+            "*OKOK 84-641"
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "73902099"
+          ],
+          "seriesStatement": [
+            "Gurumaṇḍalagranthamālāyāḥ ; puṣpam 20"
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OKOK 84-641"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003414"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73902099"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303769"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203406"
+            }
+          ],
+          "uniformTitle": [
+            "Puranas Skanda Purāṇa."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636124303127,
+          "publicationStatement": [
+            "Kalakattā : Manasukharāya Mora, 1960-"
+          ],
+          "identifier": [
+            "urn:bnum:10003414",
+            "urn:lccn:73902099",
+            "urn:undefined:NNSZ00303769",
+            "urn:undefined:(WaOLN)nyp0203406"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Skandamahāpurāṇam  / Śrāmanmaharṣikrṣṇadvaipāyanavyāsaviracitam."
+          ],
+          "uri": "b10003414",
+          "lccClassification": [
+            "PK3621 .S5 1960"
+          ],
+          "numItems": [
+            6
+          ],
+          "numAvailable": [
+            6
+          ],
+          "placeOfPublication": [
+            "Kalakattā :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Skanda-Purāṇam."
+          ],
+          "tableOfContents": [
+            "1. Māheśvarakhaṇḍātmakaḥ.--2. Vaiṣṇavakhaṇḍātmakaḥ.--3. Brahmakhandātmakaḥ.--4. Kāśīkhaṇḍātmakaḥ.--5. Avantīkhaṇḍātmakah. 2 pts."
+          ],
+          "dimensions": [
+            "20 cm."
+          ]
+        },
+        "sort": [
+          "b10003414"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 6,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221423"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000005 pt 2",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002364",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 5 pt 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 5 pt 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221423"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt 2"
+                    ],
+                    "idBarcode": [
+                      "33433013221423"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221415"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000005 pt 1",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002363",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 5 pt 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 5 pt 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221415"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5 pt 1"
+                    ],
+                    "idBarcode": [
+                      "33433013221415"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221407"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002362",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221407"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433013221407"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221399"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002365",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221399"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433013221399"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221381"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002361",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221381"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433013221381"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013221373"
+                    ],
+                    "physicalLocation": [
+                      "*OKOK 84-641"
+                    ],
+                    "shelfMark_sort": "a*OKOK 84-641 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002360",
+                    "shelfMark": [
+                      "*OKOK 84-641 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OKOK 84-641 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013221373"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433013221373"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003502",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Partly translations from German poetry (with German texts included).",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Originally published in 1856, under title: Dziesmiņas latviešu valodai pārtulkotas; original t.p. included.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Liesma,"
+          ],
+          "language": [
+            {
+              "id": "lang:lav",
+              "label": "Latvian"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Dziesmiņas"
+          ],
+          "shelfMark": [
+            "*QYN 82-2046"
+          ],
+          "creatorLiteral": [
+            "Alunāns, Juris, 1832-1864."
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "seriesStatement": [
+            "Literārā mantojuma mazā bibliotēka"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*QYN 82-2046"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003502"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00303857"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203494"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636091475285,
+          "publicationStatement": [
+            "Riga : Liesma, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10003502",
+            "urn:undefined:NNSZ00303857",
+            "urn:undefined:(WaOLN)nyp0203494"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Dziesmiņas / Juris Alunāns."
+          ],
+          "uri": "b10003502",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Riga :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "17 cm."
+          ]
+        },
+        "sort": [
+          "b10003502"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013501782"
+                    ],
+                    "physicalLocation": [
+                      "*QYN 82-2046 Dala 1."
+                    ],
+                    "shelfMark_sort": "a*QYN 82-2046 Dala 1.",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002421",
+                    "shelfMark": [
+                      "*QYN 82-2046 Dala 1."
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*QYN 82-2046 Dala 1."
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013501782"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433013501782"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003671",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Egypt",
+            "Egypt -- Politics and government",
+            "Egypt -- Politics and government -- 640-1882"
+          ],
+          "publisherLiteral": [
+            "Maktabat al-Anjlū al-Miṣrīyah,"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1973
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Nuẓum al-Fāṭimīyīn wa-rusūmuhum fī Miṣr. Institutions et cérémonial des Faṭimides en Égypte."
+          ],
+          "shelfMark": [
+            "*OFP 82-1931"
+          ],
+          "creatorLiteral": [
+            "Mājid, ʻAbd al-Munʻim."
+          ],
+          "createdString": [
+            "1973"
+          ],
+          "idLccn": [
+            "73960873"
+          ],
+          "dateStartYear": [
+            1973
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFP 82-1931"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003671"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "73960873"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304029"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203663"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636119319155,
+          "publicationStatement": [
+            "al-Qāhirah, Maktabat al-Anjlū al-Miṣrīyah, 1973-"
+          ],
+          "identifier": [
+            "urn:bnum:10003671",
+            "urn:lccn:73960873",
+            "urn:undefined:NNSZ00304029",
+            "urn:undefined:(WaOLN)nyp0203663"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1973"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Egypt -- Politics and government -- 640-1882."
+          ],
+          "titleDisplay": [
+            "Nuẓum al-Fāṭimīyīn wa-rusūmuhum fī Miṣr. Institutions et cérémonial des Faṭimides en Égypte. Taʼlīf ʻAbd al-Munʻim Mājid."
+          ],
+          "uri": "b10003671",
+          "lccClassification": [
+            "JQ3824 .M34 1973"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "al-Qāhirah,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Institutions et cérémonial des Fatimides en Égypte."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10003671"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001937121"
+                    ],
+                    "physicalLocation": [
+                      "*OFP 82-1931"
+                    ],
+                    "shelfMark_sort": "a*OFP 82-001931",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002566",
+                    "shelfMark": [
+                      "*OFP 82-1931"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OFP 82-1931"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001937121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001937121"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10003719",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 2 & 4: pariṣkarta Puripanda.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Telugu.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Telugu literature",
+            "Telugu literature -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Āndhrapradēś Sāhitya Akāḍami"
+          ],
+          "language": [
+            {
+              "id": "lang:tel",
+              "label": "Telugu"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Sārasvata vyāsamulu; Telumgu kavitvapu tīru tennulu."
+          ],
+          "shelfMark": [
+            "*OLC 83-35"
+          ],
+          "creatorLiteral": [
+            "Subrahmanyam, G. V., 1935-"
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "idLccn": [
+            "71912553"
+          ],
+          "contributorLiteral": [
+            "Appalaswamy, Puripanda, 1904-",
+            "Āndhra Pradēśa Sāhitya Akāḍami."
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLC 83-35"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10003719"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "71912553"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304078"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0203711"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636132209400,
+          "publicationStatement": [
+            "Haidrābādu, Āndhrapradēś Sāhitya Akāḍami [1969-"
+          ],
+          "identifier": [
+            "urn:bnum:10003719",
+            "urn:lccn:71912553",
+            "urn:undefined:NNSZ00304078",
+            "urn:undefined:(WaOLN)nyp0203711"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Telugu literature -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Sārasvata vyāsamulu; Telumgu kavitvapu tīru tennulu. Saṅkalanakarta Ji. Vi. Subrahmaṇyaṃ."
+          ],
+          "uri": "b10003719",
+          "lccClassification": [
+            "PL4780.05 S79"
+          ],
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            5
+          ],
+          "placeOfPublication": [
+            "Haidrābādu,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10003719"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197476"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000005",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002605",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 5"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197476"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "idBarcode": [
+                      "33433011197476"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197468"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002604",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197468"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433011197468"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197450"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002603",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197450"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433011197450"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197443"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002602",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197443"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433011197443"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433011197435"
+                    ],
+                    "physicalLocation": [
+                      "*OLC 83-35"
+                    ],
+                    "shelfMark_sort": "a*OLC 83-35 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10002601",
+                    "shelfMark": [
+                      "*OLC 83-35 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLC 83-35 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433011197435"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433011197435"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004373",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vols. 3- have imprint: Mysore : Sahyādri Prakāśana.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kuvempu, 1904-1994"
+          ],
+          "publisherLiteral": [
+            "Karnāṭaka Sahakārī Prakāśana Mandira"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1971
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu."
+          ],
+          "shelfMark": [
+            "*OLA 83-3417"
+          ],
+          "creatorLiteral": [
+            "Javare Gowda, Deve Gowda, 1918-"
+          ],
+          "createdString": [
+            "1971"
+          ],
+          "idLccn": [
+            "72902119"
+          ],
+          "dateStartYear": [
+            1971
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-3417"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004373"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "72902119"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00304738"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204365"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636109940889,
+          "publicationStatement": [
+            "Beṅgaḷūru] Karnāṭaka Sahakārī Prakāśana Mandira [1971]-"
+          ],
+          "identifier": [
+            "urn:bnum:10004373",
+            "urn:lccn:72902119",
+            "urn:undefined:NNSZ00304738",
+            "urn:undefined:(WaOLN)nyp0204365"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1971"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kuvempu, 1904-1994."
+          ],
+          "titleDisplay": [
+            "Kuvempu sāhitya: Kelavu adhyayanagaḷu. [Lēkhaka] Dējagau."
+          ],
+          "uri": "b10004373",
+          "lccClassification": [
+            "PL4659.P797 S7934"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Beṅgaḷūru]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004373"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433001707623"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "shelfMark_sort": "a*OLA 83-3417 Library has: Vol. 1, 3.",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003188",
+                    "shelfMark": [
+                      "*OLA 83-3417 Library has: Vol. 1, 3."
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-3417 Library has: Vol. 1, 3."
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433001707623"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433001707623"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057523718"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-341"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-341 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i12858227",
+                    "shelfMark": [
+                      "*OLA 83-341 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-341 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057523718"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433057523718"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004816",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "publisherLiteral": [
+            "Martins Livreiro-Editor,"
+          ],
+          "language": [
+            {
+              "id": "lang:por",
+              "label": "Portuguese"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A outra face de J. Simões Lopes Neto"
+          ],
+          "shelfMark": [
+            "JFK 84-291"
+          ],
+          "creatorLiteral": [
+            "Lopes Neto, J. Simões (João Simões), 1865-1916."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "idLccn": [
+            "84227211"
+          ],
+          "contributorLiteral": [
+            "Moreira, Angelo Pires."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 84-291"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004816"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84227211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204806"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636069640817,
+          "publicationStatement": [
+            "Porto Alegre, RGSul [i.e. Rio Grande do Sul], Brasil : Martins Livreiro-Editor, 1983-"
+          ],
+          "identifier": [
+            "urn:bnum:10004816",
+            "urn:lccn:84227211",
+            "urn:undefined:(WaOLN)nyp0204806"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "A outra face de J. Simões Lopes Neto / [editor] Angelo Pires Moreira."
+          ],
+          "uri": "b10004816",
+          "lccClassification": [
+            "PQ9697.L7223 A6 1983"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Porto Alegre, RGSul [i.e. Rio Grande do Sul], Brasil :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10004816"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003418559"
+                    ],
+                    "physicalLocation": [
+                      "JFK 84-291"
+                    ],
+                    "shelfMark_sort": "aJFK 84-291 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003383",
+                    "shelfMark": [
+                      "JFK 84-291 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFK 84-291 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003418559"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433003418559"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10004947",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Geografi︠i︡a.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 170.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts",
+            "Geography",
+            "Geography -- Textbooks"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1926
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cografija [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-221 no. 8"
+          ],
+          "creatorLiteral": [
+            "Räshad, Gafyr."
+          ],
+          "createdString": [
+            "1926"
+          ],
+          "dateStartYear": [
+            1926
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-221 no. 8"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10004947"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406058"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0204937"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636082403668,
+          "publicationStatement": [
+            "Baqï : Azärnäshr, 1926-"
+          ],
+          "identifier": [
+            "urn:bnum:10004947",
+            "urn:undefined:NNSZ00406058",
+            "urn:undefined:(WaOLN)nyp0204937"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1926"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts.",
+            "Geography -- Textbooks."
+          ],
+          "titleDisplay": [
+            "Cografija [microform] / Gafyr Räshad."
+          ],
+          "uri": "b10004947",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Baqï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Geografi︠i︡a."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10004947"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105673499"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-221"
+                    ],
+                    "shelfMark_sort": "a*ZO-221 11 Azerbaijani monographs",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30081242",
+                    "shelfMark": [
+                      "*ZO-221 11 Azerbaijani monographs"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZO-221 11 Azerbaijani monographs"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105673499"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "11 Azerbaijani monographs"
+                    ],
+                    "idBarcode": [
+                      "33433105673499"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005127",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of cover title: Zähmät mäqtäbläri uçun tädris vä pedagozhi qitablarï.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Cover colophon title in Russian: Nachalʹnyĭ kurs geografii.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 151.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts",
+            "Geography",
+            "Geography -- Textbooks"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1928
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cografija [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-216 no. 15"
+          ],
+          "creatorLiteral": [
+            "Ivanov, G."
+          ],
+          "createdString": [
+            "1928"
+          ],
+          "dateStartYear": [
+            1928
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-216 no. 15"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005127"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406243"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205116"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636082403606,
+          "publicationStatement": [
+            "Baqï : Azärnäshr, 1928-"
+          ],
+          "identifier": [
+            "urn:bnum:10005127",
+            "urn:undefined:NNSZ00406243",
+            "urn:undefined:(WaOLN)nyp0205116"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1928"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts.",
+            "Geography -- Textbooks."
+          ],
+          "titleDisplay": [
+            "Cografija [microform] / Ivanof ; çäviräni Äsädylla Äbdurrähim-zadä."
+          ],
+          "uri": "b10005127",
+          "numItems": [
+            0
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Baqï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Nachalʹnyĭ kurs geografii."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10005127"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005211",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Khaos.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 586.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Azerbaijani.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Azerbaijani language",
+            "Azerbaijani language -- Texts"
+          ],
+          "publisherLiteral": [
+            "Azärnäshr,"
+          ],
+          "language": [
+            {
+              "id": "lang:aze",
+              "label": "Azerbaijani"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1929
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Xaos [microform]"
+          ],
+          "shelfMark": [
+            "*ZO-220 no. 9"
+          ],
+          "creatorLiteral": [
+            "Shirvanzade, 1858-1935."
+          ],
+          "createdString": [
+            "1929"
+          ],
+          "dateStartYear": [
+            1929
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-220 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00406328"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205200"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636144501921,
+          "publicationStatement": [
+            "Bagï : Azärnäshr, 1929"
+          ],
+          "identifier": [
+            "urn:bnum:10005211",
+            "urn:undefined:NNSZ00406328",
+            "urn:undefined:(WaOLN)nyp0205200"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1929"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Azerbaijani language -- Texts."
+          ],
+          "titleDisplay": [
+            "Xaos [microform] / Shirvanzada ; ermeni dilinden ceviräni F. Ismixanov ; tärcimäsinin redaktory Säid Mirkasïmzada."
+          ],
+          "uri": "b10005211",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bagï :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Khaos."
+          ],
+          "dimensions": [
+            "23cm."
+          ]
+        },
+        "sort": [
+          "b10005211"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105674059"
+                    ],
+                    "physicalLocation": [
+                      "*ZO-220"
+                    ],
+                    "shelfMark_sort": "a*ZO-220 collection of 10 titles (monographs)",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30087469",
+                    "shelfMark": [
+                      "*ZO-220 collection of 10 titles (monographs)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*ZO-220 collection of 10 titles (monographs)"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105674059"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "collection of 10 titles (monographs)"
+                    ],
+                    "idBarcode": [
+                      "33433105674059"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005860",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "In Swahili.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Swahili language",
+            "Swahili language -- Texts"
+          ],
+          "publisherLiteral": [
+            "s.n.,"
+          ],
+          "language": [
+            {
+              "id": "lang:swa",
+              "label": "Swahili"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Mfuatano wa muundo na kazi za vyombo vya Serikali ya mapinduzi ya Zanzibar."
+          ],
+          "shelfMark": [
+            "Sc Ser.-N .Z288"
+          ],
+          "creatorLiteral": [
+            "Zanzibar."
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-N .Z288"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005860"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507074"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205850"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636116169694,
+          "publicationStatement": [
+            "[Zanzibar : s.n., 1980-    ]"
+          ],
+          "identifier": [
+            "urn:bnum:10005860",
+            "urn:undefined:NNSZ00507074",
+            "urn:undefined:(WaOLN)nyp0205850"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Swahili language -- Texts."
+          ],
+          "titleDisplay": [
+            "Mfuatano wa muundo na kazi za vyombo vya Serikali ya mapinduzi ya Zanzibar."
+          ],
+          "uri": "b10005860",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Zanzibar :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Kitabu cha 1-9."
+          ],
+          "dimensions": [
+            "13-31 cm."
+          ]
+        },
+        "sort": [
+          "b10005860"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10942241",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-N .Z288 Kituba cha 1-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-N .Z288 Kituba cha 1-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030859007"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-N .Z288"
+                    ],
+                    "enumerationChronology": [
+                      "Kituba cha 1-9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030859007"
+                    ],
+                    "idBarcode": [
+                      "33433030859007"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-N .Z288 Kituba cha 1-000009"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005862",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Editor: Gerald A. McWorter.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- Study and teaching",
+            "African Americans -- Study and teaching -- Congresses",
+            "Black people",
+            "Black people -- Study and teaching",
+            "Black people -- Study and teaching -- Congresses"
+          ],
+          "publisherLiteral": [
+            "Afro-American Studies and Research Program, University of Illinois,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Proceedings"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .N3674"
+          ],
+          "creatorLiteral": [
+            "National Council for Black Studies (U.S.). Conference (6th : 1982 : Chicago, Ill.)"
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "contributorLiteral": [
+            "McWorter, Gerald A."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .N3674"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005862"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507076"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205852"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1144093",
+              "shelfMark": [
+                "Sc Ser.-M .N3674"
+              ]
+            }
+          ],
+          "updatedAt": 1643270732538,
+          "publicationStatement": [
+            "Urbana, Ill. : Afro-American Studies and Research Program, University of Illinois, [1983?-]"
+          ],
+          "identifier": [
+            "urn:bnum:10005862",
+            "urn:undefined:NNSZ00507076",
+            "urn:undefined:(WaOLN)nyp0205852"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- Study and teaching -- Congresses.",
+            "Black people -- Study and teaching -- Congresses."
+          ],
+          "titleDisplay": [
+            "Proceedings / National Council for Black Studies, 6th annual national conference."
+          ],
+          "uri": "b10005862",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Urbana, Ill. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "no. 1. Race/class.--no. 2. Studies on Black children and their families.--no. 3. Philosophical perspectives in Black studies.--no. 4. Black liberation movement.--no. 5. Social science and the Black experience."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10005862"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447316",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .N3674: 6th. 1982 no. 3-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .N3674: 6th. 1982 no. 3-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072219805"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .N3674: 6th. 1982"
+                    ],
+                    "enumerationChronology": [
+                      "no. 3-5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072219805"
+                    ],
+                    "idBarcode": [
+                      "33433072219805"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .N3674: 6th. 1982 no. 000003-5"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746590",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .N3674: 6th. 1982 no. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .N3674: 6th. 1982 no. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072219797"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .N3674: 6th. 1982"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072219797"
+                    ],
+                    "idBarcode": [
+                      "33433072219797"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .N3674: 6th. 1982 no. 000001-2"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005898",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Creole dialects, French",
+            "Creole dialects, French -- Haiti",
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers",
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers -- French"
+          ],
+          "publisherLiteral": [
+            "I.L.A. de Port-au-Prince,"
+          ],
+          "language": [
+            {
+              "id": "lang:crp",
+              "label": "Creoles and Pidgins (Other)"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1984
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Leson kreyòl pou etranje ki pale franse \\"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .M468"
+          ],
+          "creatorLiteral": [
+            "Mirville, Ernst."
+          ],
+          "createdString": [
+            "1984"
+          ],
+          "seriesStatement": [
+            "Collection Coucoville",
+            "Siwolin; \\t.2"
+          ],
+          "contributorLiteral": [
+            "Institut de linguistique appliquée de Port-au-Prince."
+          ],
+          "dateStartYear": [
+            1984
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .M468"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005898"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507113"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205888"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1144290",
+              "shelfMark": [
+                "Sc Ser.-M .M468"
+              ]
+            }
+          ],
+          "updatedAt": 1636113236627,
+          "publicationStatement": [
+            "Port-au-Prince : I.L.A. de Port-au-Prince, 1984-"
+          ],
+          "identifier": [
+            "urn:bnum:10005898",
+            "urn:undefined:NNSZ00507113",
+            "urn:undefined:(WaOLN)nyp0205888"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1984"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Creole dialects, French -- Haiti -- Textbooks for foreign speakers -- French."
+          ],
+          "titleDisplay": [
+            "Leson kreyòl pou etranje ki pale franse \\ Ernst Mirville."
+          ],
+          "uri": "b10005898",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Port-au-Prince :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10005898"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900486",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .M468 t. 2, ptie 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .M468 t. 2, ptie 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017863220"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .M468"
+                    ],
+                    "enumerationChronology": [
+                      "t. 2, ptie 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017863220"
+                    ],
+                    "idBarcode": [
+                      "33433017863220"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .M468 t. 2, ptie 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10005907",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Discography: p. 115-122.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jazz",
+            "Jazz -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Producciones Don Pedro,"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "En torno al jazz"
+          ],
+          "shelfMark": [
+            "Sc Ser.-L .V354"
+          ],
+          "creatorLiteral": [
+            "Vélez, Ana."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-L .V354"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10005907"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507122"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0205897"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636093384929,
+          "publicationStatement": [
+            "San Juan, P.R. : Producciones Don Pedro, 1978-"
+          ],
+          "identifier": [
+            "urn:bnum:10005907",
+            "urn:undefined:NNSZ00507122",
+            "urn:undefined:(WaOLN)nyp0205897"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jazz -- History and criticism."
+          ],
+          "titleDisplay": [
+            "En torno al jazz / Ana Vélez."
+          ],
+          "uri": "b10005907",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "San Juan, P.R. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1. Musica de nuestro siglo -- v. 2. Impacto social y trascendencia."
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "sort": [
+          "b10005907"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900496",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V354 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V354 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017895651"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V354"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017895651"
+                    ],
+                    "idBarcode": [
+                      "33433017895651"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V354 v. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900495",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V354 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V354 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433030890481"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V354"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433030890481"
+                    ],
+                    "idBarcode": [
+                      "33433030890481"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V354 v. 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006011",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tem language"
+          ],
+          "publisherLiteral": [
+            "Experiment in International Living,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Tem"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .T425"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Peace Corps language handbook series"
+          ],
+          "contributorLiteral": [
+            "Der-Houssikian, Haig."
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .T425"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006011"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507231"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206003"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636132578775,
+          "publicationStatement": [
+            "Brattleboro, vt. : Experiment in International Living, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10006011",
+            "urn:undefined:NNSZ00507231",
+            "urn:undefined:(WaOLN)nyp0206003"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tem language."
+          ],
+          "titleDisplay": [
+            "Tem / developed by the Experiment in International Living...for ACTION/Peace Corps."
+          ],
+          "uri": "b10006011",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Brattleboro, vt. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Communication and culture handbook/by Haig Der-Houssikian.--"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006011"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23169346",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .T425"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .T425",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076233265"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .T425"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076233265"
+                    ],
+                    "idBarcode": [
+                      "33433076233265"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .T000425"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006012",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kabre language"
+          ],
+          "publisherLiteral": [
+            "Experiment in International Living,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1980
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kabiye"
+          ],
+          "shelfMark": [
+            "Sc F 84-135"
+          ],
+          "createdString": [
+            "1980"
+          ],
+          "seriesStatement": [
+            "Peace Corps language handbook series"
+          ],
+          "contributorLiteral": [
+            "Experiment in International Living.",
+            "Jassor, Essogoye.",
+            "Sedlak, Philip Alan Stephen, 1939-"
+          ],
+          "dateStartYear": [
+            1980
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc F 84-135"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006012"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507232"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206004"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108841395,
+          "publicationStatement": [
+            "Brattleboro, Vt. : Experiment in International Living, 1980-"
+          ],
+          "identifier": [
+            "urn:bnum:10006012",
+            "urn:undefined:NNSZ00507232",
+            "urn:undefined:(WaOLN)nyp0206004"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1980"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kabre language."
+          ],
+          "titleDisplay": [
+            "Kabiye / developed by the Experiment in International Living...for ACTION/Peace Corps."
+          ],
+          "uri": "b10006012",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Brattleboro, Vt. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Special skills handbook/compiled by Philip A.S. Sedlak; assisted by Essogoye Jassor.--"
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006012"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900585",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 84-135"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 84-135",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036872368"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 84-135"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036872368"
+                    ],
+                    "idBarcode": [
+                      "33433036872368"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 84-000135"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006018",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"Corrections to volume I\": v. 2, p. 69.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iota Phi Lambda"
+          ],
+          "publisherLiteral": [
+            "The Sorority,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1959
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "A History of Iota Phi Lambda Sorority."
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .H592"
+          ],
+          "createdString": [
+            "1959"
+          ],
+          "contributorLiteral": [
+            "Greene, Ethel K.",
+            "Sims, Sarah B."
+          ],
+          "dateStartYear": [
+            1959
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .H592"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006018"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507238"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206010"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1142937",
+              "shelfMark": [
+                "Sc Ser.-M .H592"
+              ]
+            }
+          ],
+          "updatedAt": 1636069378411,
+          "publicationStatement": [
+            "Washington : The Sorority, 1959-"
+          ],
+          "identifier": [
+            "urn:bnum:10006018",
+            "urn:undefined:NNSZ00507238",
+            "urn:undefined:(WaOLN)nyp0206010"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1959"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iota Phi Lambda."
+          ],
+          "titleDisplay": [
+            "A History of Iota Phi Lambda Sorority."
+          ],
+          "uri": "b10006018",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Washington :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1929-1958/Ethel K. Greene.--1959-1969/Sarah B. Sims."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006018"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746595",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .H592 v. 1, 2 (1928-19, 1959-69)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .H592 v. 1, 2 (1928-19, 1959-69)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061038323"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .H592"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1, 2 (1928-19, 1959-69)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061038323"
+                    ],
+                    "idBarcode": [
+                      "33433061038323"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .H592 v. 000001, 2 (1928-19, 1959-69)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006159",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "African Americans",
+            "African Americans -- Civil rights",
+            "Civil rights",
+            "Civil rights -- United States",
+            "Violence",
+            "Violence -- United States"
+          ],
+          "publisherLiteral": [
+            "American Foundation for Negro Affairs,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Law and disorder [microform] : a research position paper"
+          ],
+          "shelfMark": [
+            "Sc Micro R-4202, no. 16"
+          ],
+          "creatorLiteral": [
+            "American Foundation for Negro Affairs. Commission on Judiciary and Law. Subcommittee on National Goals."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro R-4202, no. 16"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006159"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507384"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206150"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636111916018,
+          "publicationStatement": [
+            "Philadelphia, Pa. : American Foundation for Negro Affairs, 1970-"
+          ],
+          "identifier": [
+            "urn:bnum:10006159",
+            "urn:undefined:NNSZ00507384",
+            "urn:undefined:(WaOLN)nyp0206150"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "African Americans -- Civil rights.",
+            "Civil rights -- United States.",
+            "Violence -- United States."
+          ],
+          "titleDisplay": [
+            "Law and disorder [microform] : a research position paper / [Commission on Judiciary and Law, Subcommittee on National Goals]."
+          ],
+          "uri": "b10006159",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Philadelphia, Pa. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 x 28 cm."
+          ]
+        },
+        "sort": [
+          "b10006159"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i24023455",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Micro R-4202"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Micro R-4202",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059035760"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Micro R-4202"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059035760"
+                    ],
+                    "idBarcode": [
+                      "33433059035760"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Micro R-004202"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006540",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Vol. 2 issued without edition statement has imprint date 1972.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and indexes.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Germany",
+            "Germany -- History",
+            "Germany -- History -- Allied occupation, 1945-",
+            "World War, 1939-1945",
+            "World War, 1939-1945 -- Germany"
+          ],
+          "publisherLiteral": [
+            "Selbstverlag,"
+          ],
+          "language": [
+            {
+              "id": "lang:ger",
+              "label": "German"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Was geschah nach 1945?"
+          ],
+          "shelfMark": [
+            "JFK 84-184"
+          ],
+          "creatorLiteral": [
+            "Roth, Heinz."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "seriesStatement": [
+            "Auf der Suche nach der Wahrheit / Heinz Roth ; Bd. 4-5",
+            "Roth, Heinz. Auf der Suche nach der Wahrheit ; \\Bd. 4-5."
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFK 84-184"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006540"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507771"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206529"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636143161690,
+          "publicationStatement": [
+            "Odenhausen/Lumda : Selbstverlag, [197-?-"
+          ],
+          "identifier": [
+            "urn:bnum:10006540",
+            "urn:undefined:NNSZ00507771",
+            "urn:undefined:(WaOLN)nyp0206529"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Germany -- History -- Allied occupation, 1945-",
+            "World War, 1939-1945 -- Germany."
+          ],
+          "titleDisplay": [
+            "Was geschah nach 1945? / Heinz Roth."
+          ],
+          "uri": "b10006540",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Odenhausen/Lumda :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Was geschah nach neunzehnhundertfünfundvierzig."
+          ],
+          "tableOfContents": [
+            "T.1. Der Zusammenbruch -- T.2. Kriegsverbrecherprozesse u.a."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006540"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433003841073"
+                    ],
+                    "physicalLocation": [
+                      "JFK 84-184"
+                    ],
+                    "shelfMark_sort": "aJFK 84-184 v. 000001-2",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003927",
+                    "shelfMark": [
+                      "JFK 84-184 v. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFK 84-184 v. 1-2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433003841073"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-2"
+                    ],
+                    "idBarcode": [
+                      "33433003841073"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006622",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Caldas (Colombia : Department)",
+            "Caldas (Colombia : Department) -- History"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Biblioteca de Escritores Caldenses"
+          ],
+          "language": [
+            {
+              "id": "lang:spa",
+              "label": "Spanish"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Historia del Gran Caldas"
+          ],
+          "shelfMark": [
+            "HDK 84-1693"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "creatorLiteral": [
+            "Ríos Tobón, Ricardo de los."
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "HDK 84-1693"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006622"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG005000779-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507853"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206611"
+            }
+          ],
+          "idOclc": [
+            "NYPG005000779-B"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1676385946742,
+          "publicationStatement": [
+            "Manizales, Colombia : Biblioteca de Escritores Caldenses, 1933-"
+          ],
+          "identifier": [
+            "urn:bnum:10006622",
+            "urn:oclc:NYPG005000779-B",
+            "urn:undefined:NNSZ00507853",
+            "urn:undefined:(WaOLN)nyp0206611"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Caldas (Colombia : Department) -- History."
+          ],
+          "titleDisplay": [
+            "Historia del Gran Caldas / Ricardo de los Ríos Tobón."
+          ],
+          "uri": "b10006622",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            0
+          ],
+          "placeOfPublication": [
+            "Manizales, Colombia"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v. 1. Origenes y colonización hasta 1850."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10006622"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746647",
+                    "status": [
+                      {
+                        "id": "status:co",
+                        "label": "Loaned"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:co||Loaned"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:32",
+                        "label": "google project, book"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:32||google project, book"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "HDK 84-1693 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "HDK 84-1693 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433097665214"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "HDK 84-1693"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433097665214"
+                    ],
+                    "idBarcode": [
+                      "33433097665214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dueDate": [
+                      "2023-02-15"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aHDK 84-1693 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006687",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., ports, ;"
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Skiđuhreppur (Iceland)",
+            "Öxnadalshreppur (Iceland)"
+          ],
+          "publisherLiteral": [
+            "Bókaútgáfan Skjaldborg,"
+          ],
+          "language": [
+            {
+              "id": "lang:ice",
+              "label": "Icelandic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ritsafn"
+          ],
+          "shelfMark": [
+            "JFL 84-217"
+          ],
+          "creatorLiteral": [
+            "Eiður Guðmundsson, 1888-1984."
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 84-217"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006687"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507920"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206676"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127047675,
+          "publicationStatement": [
+            "Akureyri : Bókaútgáfan Skjaldborg, 1982-"
+          ],
+          "identifier": [
+            "urn:bnum:10006687",
+            "urn:undefined:NNSZ00507920",
+            "urn:undefined:(WaOLN)nyp0206676"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Skiđuhreppur (Iceland)",
+            "Öxnadalshreppur (Iceland)"
+          ],
+          "titleDisplay": [
+            "Ritsafn / Eidur Gudmundsson Púfnav;ollum."
+          ],
+          "uri": "b10006687",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Akureyri :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Mannfelliviun mikli -- 2. Búskaparsaga i Skriđuhreppi forna."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10006687"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069567"
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-217"
+                    ],
+                    "shelfMark_sort": "aJFL 84-217 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003946",
+                    "shelfMark": [
+                      "JFL 84-217 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFL 84-217 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069567"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433004069567"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069559"
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-217"
+                    ],
+                    "shelfMark_sort": "aJFL 84-217 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003945",
+                    "shelfMark": [
+                      "JFL 84-217 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFL 84-217 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069559"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433004069559"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006688",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Iceland",
+            "Iceland -- Economic conditions",
+            "Iceland -- History",
+            "Iceland -- Social conditions"
+          ],
+          "publisherLiteral": [
+            "Mál og Menning,"
+          ],
+          "language": [
+            {
+              "id": "lang:ice",
+              "label": "Icelandic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ritsafn"
+          ],
+          "shelfMark": [
+            "JFL 84-216"
+          ],
+          "creatorLiteral": [
+            "Sverrir Kristjánsson, 1908-"
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JFL 84-216"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006688"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507921"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206677"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636127047675,
+          "publicationStatement": [
+            "Reykjavík : Mál og Menning, 1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10006688",
+            "urn:undefined:NNSZ00507921",
+            "urn:undefined:(WaOLN)nyp0206677"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Iceland -- Economic conditions.",
+            "Iceland -- History.",
+            "Iceland -- Social conditions."
+          ],
+          "titleDisplay": [
+            "Ritsafn / Sverrir Kristjánsson."
+          ],
+          "uri": "b10006688",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Reykjavík :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10006688"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069542"
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-216"
+                    ],
+                    "shelfMark_sort": "aJFL 84-216 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003948",
+                    "shelfMark": [
+                      "JFL 84-216 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFL 84-216 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069542"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433004069542"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433004069534"
+                    ],
+                    "physicalLocation": [
+                      "JFL 84-216"
+                    ],
+                    "shelfMark_sort": "aJFL 84-216 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10003947",
+                    "shelfMark": [
+                      "JFL 84-216 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JFL 84-216 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433004069534"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433004069534"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006705",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. (some col.);"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Vernacular architecture",
+            "Vernacular architecture -- Greece",
+            "Architecture, Domestic",
+            "Architecture, Domestic -- Greece"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ekdot. Oikos \"Melissa,\""
+          ],
+          "language": [
+            {
+              "id": "lang:gre",
+              "label": "Greek, Modern (1453- )"
+            }
+          ],
+          "numItemsTotal": [
+            7
+          ],
+          "createdYear": [
+            1982
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Hellēnikē paradosiakē architektonikē"
+          ],
+          "shelfMark": [
+            "3-MQW+ 84-2551"
+          ],
+          "numItemVolumesParsed": [
+            7
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "idLccn": [
+            "83177376"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Philippidēs, Dēmētrēs."
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "3-MQW+ 84-2551"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006705"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83177376"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG005000864-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206694"
+            }
+          ],
+          "idOclc": [
+            "NYPG005000864-B"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1675271456381,
+          "publicationStatement": [
+            "Athēna : Ekdot. Oikos \"Melissa,\" c1982-"
+          ],
+          "identifier": [
+            "urn:bnum:10006705",
+            "urn:lccn:83177376",
+            "urn:oclc:NYPG005000864-B",
+            "urn:undefined:(WaOLN)nyp0206694"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Vernacular architecture -- Greece.",
+            "Architecture, Domestic -- Greece."
+          ],
+          "titleDisplay": [
+            "Hellēnikē paradosiakē architektonikē / symvoulos kai syntonistēs tēs ekdosēs, Dēmētrēs Philippidēs ; [phōtographies, V. Voutsas]."
+          ],
+          "uri": "b10006705",
+          "lccClassification": [
+            "NA1091 .H44 1982"
+          ],
+          "numItems": [
+            7
+          ],
+          "numAvailable": [
+            7
+          ],
+          "placeOfPublication": [
+            "Athēna"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "t. 1. Anatoliko Aigaio. Sporades. Heptanēsa -- t. 2. Kyklades -- t. 3. Dōdekanēsa-Krētē -- t. 4. Peloponnēsos I -- t. 5 Peloponnesos II, Sterea Hellada -- t. 6. Thessalia-Ēpeiros -- t. 7. Makedonia I."
+          ],
+          "dimensions": [
+            "31 cm."
+          ]
+        },
+        "sort": [
+          "b10006705"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 7,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746675",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 7"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 7",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160679"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 7"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160679"
+                    ],
+                    "idBarcode": [
+                      "33433105160679"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 7,
+                        "lte": 7
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         7-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000007"
+                  },
+                  "sort": [
+                    "         7-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746674",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 6",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160661"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 6"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160661"
+                    ],
+                    "idBarcode": [
+                      "33433105160661"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 6,
+                        "lte": 6
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         6-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000006"
+                  },
+                  "sort": [
+                    "         6-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746673",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160653"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160653"
+                    ],
+                    "idBarcode": [
+                      "33433105160653"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 5
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000005"
+                  },
+                  "sort": [
+                    "         5-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746672",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160646"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160646"
+                    ],
+                    "idBarcode": [
+                      "33433105160646"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 4,
+                        "lte": 4
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         4-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000004"
+                  },
+                  "sort": [
+                    "         4-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746671",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160638"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160638"
+                    ],
+                    "idBarcode": [
+                      "33433105160638"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 3,
+                        "lte": 3
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         3-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000003"
+                  },
+                  "sort": [
+                    "         3-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746670",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160620"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160620"
+                    ],
+                    "idBarcode": [
+                      "33433105160620"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000002"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746669",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "3-MQW+ 84-2551 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "3-MQW+ 84-2551 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105160612"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "3-MQW+ 84-2551"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105160612"
+                    ],
+                    "idBarcode": [
+                      "33433105160612"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a3-MQW+ 84-2551 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10006715",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. (some ed.);"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title on spine: 2222.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Austria",
+            "Austria -- Relations",
+            "Austria -- Relations -- United States",
+            "United States",
+            "United States -- Relations",
+            "United States -- Relations -- Austria"
+          ],
+          "publisherLiteral": [
+            "The author,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1970
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Quadruple 2"
+          ],
+          "shelfMark": [
+            "ICM (Austria) 85-584"
+          ],
+          "creatorLiteral": [
+            "Humes, John P."
+          ],
+          "createdString": [
+            "1970"
+          ],
+          "dateStartYear": [
+            1970
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "ICM (Austria) 85-584"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10006715"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00507948"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0206704"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636124417162,
+          "publicationStatement": [
+            "[S.l. : The author, 197-]"
+          ],
+          "identifier": [
+            "urn:bnum:10006715",
+            "urn:undefined:NNSZ00507948",
+            "urn:undefined:(WaOLN)nyp0206704"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1970"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Austria -- Relations -- United States.",
+            "United States -- Relations -- Austria."
+          ],
+          "titleDisplay": [
+            "Quadruple 2 / by John P. Humes."
+          ],
+          "uri": "b10006715",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[S.l. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "2222.",
+            "Quadruple two."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10006715"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14746681",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "ICM (Austria) 85-584 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "ICM (Austria) 85-584 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433090390752"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "ICM (Austria) 85-584"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433090390752"
+                    ],
+                    "idBarcode": [
+                      "33433090390752"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aICM (Austria) 85-584 v. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10007240",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Imprint on cover: Tañcāvūr Mahārājā Carapōjiyiṉ Caracuvati Makāl Nūl Nilaiyam.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Glossaries, vocabularies, etc"
+          ],
+          "publisherLiteral": [
+            "Tañcai Caracuvati Makāl Nūl Nilaiya Nirvākak Kuḻu"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1975
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Āciriya nikaṇṭu : cēntaṉ tivākaram, piṅkala nikaṇṭu, cūṭāmaṇi, kayātaram ākiya nikaṇṭukaḷiṉ oppumaip pakutikaḷuṭaṉ"
+          ],
+          "shelfMark": [
+            "*OLB 84-3259"
+          ],
+          "createdString": [
+            "1975"
+          ],
+          "idLccn": [
+            "77902870"
+          ],
+          "seriesStatement": [
+            "Tañcai Caracuvati Makāl veḷiyīṭu; 156"
+          ],
+          "contributorLiteral": [
+            "Chokkalingam."
+          ],
+          "dateStartYear": [
+            1975
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 84-3259"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10007240"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "77902870"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00508482"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0207225"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1653404639464,
+          "publicationStatement": [
+            "[Tañcāvūr] : Tañcai Caracuvati Makāl Nūl Nilaiya Nirvākak Kuḻu, 1975."
+          ],
+          "identifier": [
+            "urn:bnum:10007240",
+            "urn:lccn:77902870",
+            "urn:undefined:NNSZ00508482",
+            "urn:undefined:(WaOLN)nyp0207225"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1975"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Glossaries, vocabularies, etc."
+          ],
+          "titleDisplay": [
+            "Āciriya nikaṇṭu : cēntaṉ tivākaram, piṅkala nikaṇṭu, cūṭāmaṇi, kayātaram ākiya nikaṇṭukaḷiṉ oppumaip pakutikaḷuṭaṉ / patippāciriyar Vī. Cokkaliṅkam."
+          ],
+          "uri": "b10007240",
+          "lccClassification": [
+            "PL4757 .A5"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[Tañcāvūr]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "sort": [
+          "b10007240"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061354662"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-003259",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13785014",
+                    "shelfMark": [
+                      "*OLB 84-3259"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061354662"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433061354662"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061303693"
+                    ],
+                    "physicalLocation": [
+                      "*OLB 84-3259"
+                    ],
+                    "shelfMark_sort": "a*OLB 84-003259",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13785013",
+                    "shelfMark": [
+                      "*OLB 84-3259"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLB 84-3259"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061303693"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433061303693"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10007516",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Egypt",
+            "Egypt -- History",
+            "Egypt -- History -- 20th century"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "al-Mu'assasah al-Àrabīyah lil-Dirāsāt wa-al-Nashr"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "numItemsTotal": [
+            5
+          ],
+          "createdYear": [
+            1974
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Qiṣṣat thawrat 23 Yūliyū"
+          ],
+          "shelfMark": [
+            "*OFP 84-3195"
+          ],
+          "numItemVolumesParsed": [
+            5
+          ],
+          "creatorLiteral": [
+            "Ḥamrūsh, Aḥmad."
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "76960179"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OFP 84-3195"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10007516"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76960179"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG005001687-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00508761"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0207500"
+            }
+          ],
+          "idOclc": [
+            "NYPG005001687-B"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1675263928305,
+          "publicationStatement": [
+            "Bayrūt : al-Mu'assasah al-Àrabīyah lil-Dirāsāt wa-al-Nashr, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10007516",
+            "urn:lccn:76960179",
+            "urn:oclc:NYPG005001687-B",
+            "urn:undefined:NNSZ00508761",
+            "urn:undefined:(WaOLN)nyp0207500"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Egypt -- History -- 20th century."
+          ],
+          "titleDisplay": [
+            "Qiṣṣat thawrat 23 Yūliyū / Aḥmad Ḥamrūsh."
+          ],
+          "uri": "b10007516",
+          "lccClassification": [
+            "DT107.825 .H35"
+          ],
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            5
+          ],
+          "placeOfPublication": [
+            "Bayrūt"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "Juz' 1. Miṣr wa-al-Àskarīyūn. -- Juz' 2. Mujtamà Jamāl Àbd al-Nāṣir. -- Juz' 3. Àbd al-Nāṣir wa-al-Àrab. -- Juz' 4. Shuhūd thawrat Yūliyū.--Juz' 5. Kharīf Àbd al-Nāṣir."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10007516"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004361",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 84-3195 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 84-3195 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005566249"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "physicalLocation": [
+                      "*OFP 84-3195"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005566249"
+                    ],
+                    "idBarcode": [
+                      "33433005566249"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 5
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFP 84-3195 v. 000005"
+                  },
+                  "sort": [
+                    "         5-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004360",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 84-3195 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 84-3195 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005566231"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "physicalLocation": [
+                      "*OFP 84-3195"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005566231"
+                    ],
+                    "idBarcode": [
+                      "33433005566231"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 4,
+                        "lte": 4
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         4-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFP 84-3195 v. 000004"
+                  },
+                  "sort": [
+                    "         4-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004359",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 84-3195 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 84-3195 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005566223"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "physicalLocation": [
+                      "*OFP 84-3195"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005566223"
+                    ],
+                    "idBarcode": [
+                      "33433005566223"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 3,
+                        "lte": 3
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         3-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFP 84-3195 v. 000003"
+                  },
+                  "sort": [
+                    "         3-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004358",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 84-3195 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 84-3195 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005566215"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "physicalLocation": [
+                      "*OFP 84-3195"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005566215"
+                    ],
+                    "idBarcode": [
+                      "33433005566215"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFP 84-3195 v. 000002"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10004357",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*OFP 84-3195 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OFP 84-3195 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005566207"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OFP 84-3195"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005566207"
+                    ],
+                    "idBarcode": [
+                      "33433005566207"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OFP 84-3195 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10007874",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Translation of: Towards one Nigeria.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Nigeria",
+            "Nigeria -- History",
+            "Nigeria -- History -- Civil War, 1967-1970",
+            "Nigeria -- History -- Civil War, 1967-1970 -- Sources"
+          ],
+          "publisherLiteral": [
+            "Federal Ministry of Information,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Vers l'unité du Nigèria."
+          ],
+          "shelfMark": [
+            "Sc Ser.-L .V377"
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "contributorLiteral": [
+            "Nigeria. Federal Ministry of Information."
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-L .V377"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10007874"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0207856"
+            }
+          ],
+          "uniformTitle": [
+            "Towards one Nigeria. French"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636140076962,
+          "publicationStatement": [
+            "[Lagos : Federal Ministry of Information, [1967?-]"
+          ],
+          "identifier": [
+            "urn:bnum:10007874",
+            "urn:undefined:(WaOLN)nyp0207856"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Nigeria -- History -- Civil War, 1967-1970 -- Sources."
+          ],
+          "titleDisplay": [
+            "Vers l'unité du Nigèria."
+          ],
+          "uri": "b10007874",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Lagos :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Towards one Nigeria."
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10007874"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900848",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-L .V377 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-L .V377 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433034815294"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-L .V377"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433034815294"
+                    ],
+                    "idBarcode": [
+                      "33433034815294"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-L .V377 v. 000003"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008327",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Editors vary.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kannada.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Folk literature, Kannada",
+            "Folk literature, Kannada -- History and criticism"
+          ],
+          "publisherLiteral": [
+            "Kannaḍa Adhyayana Pīṭha, Karnāṭaka Viśvavidyālaya,"
+          ],
+          "language": [
+            {
+              "id": "lang:kan",
+              "label": "Kannada"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1974
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Jānapada sāhityadarśana"
+          ],
+          "shelfMark": [
+            "*OLA 83-2636"
+          ],
+          "createdString": [
+            "1974"
+          ],
+          "idLccn": [
+            "75904046"
+          ],
+          "seriesStatement": [
+            "Jānapada sammēḷana smaraṇe ; 1-2, 4"
+          ],
+          "contributorLiteral": [
+            "Hiremath, Rudrayya Chandrayya, 1922-"
+          ],
+          "dateStartYear": [
+            1974
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLA 83-2636"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008327"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75904046"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00609733"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0208308"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636108824394,
+          "publicationStatement": [
+            "Dhāravāḍa : Kannaḍa Adhyayana Pīṭha, Karnāṭaka Viśvavidyālaya, 1974-"
+          ],
+          "identifier": [
+            "urn:bnum:10008327",
+            "urn:lccn:75904046",
+            "urn:undefined:NNSZ00609733",
+            "urn:undefined:(WaOLN)nyp0208308"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1974"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Folk literature, Kannada -- History and criticism."
+          ],
+          "titleDisplay": [
+            "Jānapada sāhityadarśana / sampādakaru Ār. Si. Hirēmaṭha."
+          ],
+          "uri": "b10008327",
+          "lccClassification": [
+            "PL4654 .J3"
+          ],
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Dhāravāḍa :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "22 cm."
+          ]
+        },
+        "sort": [
+          "b10008327"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433013119130"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-2636"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-2636 v. 000004",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10004641",
+                    "shelfMark": [
+                      "*OLA 83-2636 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-2636 v. 4"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433013119130"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "idBarcode": [
+                      "33433013119130"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544246"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-2636"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-2636 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10004640",
+                    "shelfMark": [
+                      "*OLA 83-2636 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-2636 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544246"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433005544246"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005544238"
+                    ],
+                    "physicalLocation": [
+                      "*OLA 83-2636"
+                    ],
+                    "shelfMark_sort": "a*OLA 83-2636 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10004639",
+                    "shelfMark": [
+                      "*OLA 83-2636 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLA 83-2636 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005544238"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433005544238"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008347",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: v.2, p. 375.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Arabic",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Qurʼan",
+            "Qurʼan -- Commentaries"
+          ],
+          "publisherLiteral": [
+            "[s. n.],"
+          ],
+          "language": [
+            {
+              "id": "lang:ara",
+              "label": "Arabic"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1969
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Aḍwāʼ ʻalá mutashābihāt al-Qurʼān ; yaḥtawī ʻalá 1600 suʼāl wa-jawāb"
+          ],
+          "shelfMark": [
+            "*OGDM 82-3193"
+          ],
+          "creatorLiteral": [
+            "Yāsīn, Khalīl."
+          ],
+          "createdString": [
+            "1969"
+          ],
+          "dateStartYear": [
+            1969
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OGDM 82-3193"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008347"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00609754"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0208328"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636071205334,
+          "publicationStatement": [
+            "Bayrūt : [s. n.], 1969-"
+          ],
+          "identifier": [
+            "urn:bnum:10008347",
+            "urn:undefined:NNSZ00609754",
+            "urn:undefined:(WaOLN)nyp0208328"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1969"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Qurʼan -- Commentaries."
+          ],
+          "titleDisplay": [
+            "Aḍwāʼ ʻalá mutashābihāt al-Qurʼān ; yaḥtawī ʻalá 1600 suʼāl wa-jawāb / bi-qalam  Khalīl Yāsīn."
+          ],
+          "uri": "b10008347",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Bayrūt :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10008347"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433005577105"
+                    ],
+                    "physicalLocation": [
+                      "*OGDM 82-3193"
+                    ],
+                    "shelfMark_sort": "a*OGDM 82-003193",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i10004653",
+                    "shelfMark": [
+                      "*OGDM 82-3193"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OGDM 82-3193"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433005577105"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "idBarcode": [
+                      "33433005577105"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008408",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. 1-5 : ill., maps ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "One folded map inserted in v. 1; 3 folded maps inserted in v. 3; one folded map inserted in v. 4.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "10 folded maps accompany atlas; issued together in a case.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Errata slip inserted in v. 3.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographies and index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Excavations (Archaeology)",
+            "Excavations (Archaeology) -- Ingal",
+            "Niger",
+            "Niger -- Antiquities",
+            "Niger -- Antiquities -- Maps",
+            "Ingal (Niger)",
+            "Ingal (Niger) -- Antiquities",
+            "Ingal (Niger) -- Antiquities -- Maps",
+            "Teguidda-n-Tessoumt (Niger)",
+            "Teguidda-n-Tessoumt (Niger) -- Antiquities",
+            "Teguidda-n-Tessoumt (Niger) -- Antiquities -- Maps",
+            "Ingal Region (Niger)",
+            "Ingal Region (Niger) -- Antiquities"
+          ],
+          "publisherLiteral": [
+            "Institut de recherches en sciences humaines"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1983
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "La Région d'In Gall--Tegidda n Tesemt (Niger) : programme archéologique d'urgence, 1977-1981."
+          ],
+          "shelfMark": [
+            "Sc F 87-35"
+          ],
+          "createdString": [
+            "1983"
+          ],
+          "idLccn": [
+            "84121246"
+          ],
+          "seriesStatement": [
+            "Etudes nigériennes ; no 47-52"
+          ],
+          "contributorLiteral": [
+            "Grébénart, Danilo.",
+            "Paris, François, 1946-",
+            "Poncet, Yveline.",
+            "Université de Niamey. Institut de recherches en sciences humaines."
+          ],
+          "dateStartYear": [
+            1983
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc F 87-35"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008408"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "2859210601 (v. 4)"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "9782859210601 (v. 4)"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "84121246"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "12840091"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)12840091"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "285920482 (v. 1)"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "285920490 (v. 2)"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "285920504 (v. 3)"
+            },
+            {
+              "type": "bf:Isbn",
+              "identifierStatus": "canceled/invalid",
+              "value": "285921061X (v. 5)"
+            }
+          ],
+          "idOclc": [
+            "12840091"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1652373102187,
+          "publicationStatement": [
+            "Niamey : Institut de recherches en sciences humaines, 1983-<1992>"
+          ],
+          "identifier": [
+            "urn:bnum:10008408",
+            "urn:isbn:2859210601 (v. 4)",
+            "urn:isbn:9782859210601 (v. 4)",
+            "urn:lccn:84121246",
+            "urn:oclc:12840091",
+            "urn:undefined:(OCoLC)12840091",
+            "b10008408#1.0004",
+            "b10008408#1.0005",
+            "b10008408#1.0006",
+            "b10008408#1.0007",
+            "urn:isbn:285920482 (v. 1)",
+            "urn:isbn:285920490 (v. 2)",
+            "urn:isbn:285920504 (v. 3)",
+            "urn:isbn:285921061X (v. 5)"
+          ],
+          "idIsbn": [
+            "2859210601 (v. 4)",
+            "9782859210601 (v. 4)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1983"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Excavations (Archaeology) -- Ingal.",
+            "Niger -- Antiquities -- Maps.",
+            "Ingal (Niger) -- Antiquities.",
+            "Ingal (Niger) -- Antiquities -- Maps.",
+            "Teguidda-n-Tessoumt (Niger) -- Antiquities.",
+            "Teguidda-n-Tessoumt (Niger) -- Antiquities -- Maps.",
+            "Ingal Region (Niger) -- Antiquities."
+          ],
+          "titleDisplay": [
+            "La Région d'In Gall--Tegidda n Tesemt (Niger) : programme archéologique d'urgence, 1977-1981."
+          ],
+          "uri": "b10008408",
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            5
+          ],
+          "placeOfPublication": [
+            "Niamey"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "no. 47. Atlas / conçu et réalisé par Yveline Poncet -- 1. (no. 48) Introduction : méthodologie, environnements -- 2. (no. 49) Le Néolithique final et les débuts de la métallurgie / Danilo Grébénart -- 3.  (no. 50) Les sépultures, du Néolithique final à l'islam / François Paris -- 4. (no. 51) Azelik-Takadda et          l'implantation sédentaire Médiévale -- 5. (no. 52) Les populations actuelles."
+          ],
+          "idIsbn_clean": [
+            "28592106014",
+            "97828592106014"
+          ],
+          "dimensions": [
+            "24 cm. +"
+          ]
+        },
+        "sort": [
+          "b10008408"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540453",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 87-35 t. 4-5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 87-35 t. 4-5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057875258"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 87-35"
+                    ],
+                    "enumerationChronology": [
+                      "t. 4-5"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057875258"
+                    ],
+                    "idBarcode": [
+                      "33433057875258"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 87-35 t. 4-000005"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540452",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 87-35 t. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 87-35 t. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057875068"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 87-35"
+                    ],
+                    "enumerationChronology": [
+                      "t. 3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057875068"
+                    ],
+                    "idBarcode": [
+                      "33433057875068"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 87-35 t. 000003"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540451",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 87-35 t. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 87-35 t. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057875050"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 87-35"
+                    ],
+                    "enumerationChronology": [
+                      "t. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057875050"
+                    ],
+                    "idBarcode": [
+                      "33433057875050"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 87-35 t. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11900890",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 87-35 t. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 87-35 t. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433057875217"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 87-35"
+                    ],
+                    "enumerationChronology": [
+                      "t. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433057875217"
+                    ],
+                    "idBarcode": [
+                      "33433057875217"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 87-35 t. 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447322",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:25",
+                        "label": "atlas"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:25||atlas"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc F 87-35 Atlas"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc F 87-35 Atlas",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433036872814"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc F 87-35"
+                    ],
+                    "enumerationChronology": [
+                      "Atlas"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433036872814"
+                    ],
+                    "idBarcode": [
+                      "33433036872814"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc F 87-35 Atlas"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008416",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"No 71.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Bibliography",
+              "label": "Bibliography: t. 1, p. 288.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "French language",
+            "French language -- Study and teaching",
+            "French language -- Study and teaching -- Senegal"
+          ],
+          "publisherLiteral": [
+            "Centre de linguistique appliquée de Dakar,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1978
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "La grammaire en question"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .B575"
+          ],
+          "creatorLiteral": [
+            "Blondé, Jacques."
+          ],
+          "createdString": [
+            "1978"
+          ],
+          "seriesStatement": [
+            "L'Enseignement du français au Sénégal"
+          ],
+          "contributorLiteral": [
+            "Centre de linguistique appliquée de Dakar."
+          ],
+          "dateStartYear": [
+            1978
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .B575"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008416"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00709824"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0208396"
+            }
+          ],
+          "uniformTitle": [
+            "Enseignement du français au Sénégal."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1141798",
+              "shelfMark": [
+                "Sc Ser.-M .B575"
+              ]
+            }
+          ],
+          "updatedAt": 1636111100976,
+          "publicationStatement": [
+            "[Dakar] : Centre de linguistique appliquée de Dakar, 1978-"
+          ],
+          "identifier": [
+            "urn:bnum:10008416",
+            "urn:undefined:NNSZ00709824",
+            "urn:undefined:(WaOLN)nyp0208396"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1978"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "French language -- Study and teaching -- Senegal."
+          ],
+          "titleDisplay": [
+            "La grammaire en question / par Jacques Blondé."
+          ],
+          "uri": "b10008416",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Dakar] :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10008416"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785304",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .B575 t. 1 (1978)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .B575 t. 1 (1978)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433021653690"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .B575"
+                    ],
+                    "enumerationChronology": [
+                      "t. 1 (1978)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433021653690"
+                    ],
+                    "idBarcode": [
+                      "33433021653690"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .B575 t. 1 (1978)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10008989",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "At head of title: Florentina Studiorum Universitas.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Novellae constitutiones"
+          ],
+          "publisherLiteral": [
+            "Cisalpino-Goliardica"
+          ],
+          "language": [
+            {
+              "id": "lang:grc",
+              "label": "Greek, Ancient (to 1453)"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1986
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Novellae : pars graeca"
+          ],
+          "shelfMark": [
+            "JLN 88-42"
+          ],
+          "creatorLiteral": [
+            "Bartoletti Colombo, Anna Maria."
+          ],
+          "createdString": [
+            "1986"
+          ],
+          "seriesStatement": [
+            "Legum Iustiniani imperatoris vocabularium"
+          ],
+          "contributorLiteral": [
+            "Archi, Gian Gualberto."
+          ],
+          "dateStartYear": [
+            1986
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLN 88-42"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10008989"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "8820505517 (v. 1)"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0208964"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1652373994811,
+          "publicationStatement": [
+            "Milano : Cisalpino-Goliardica, c1986-"
+          ],
+          "identifier": [
+            "urn:bnum:10008989",
+            "urn:isbn:8820505517 (v. 1)",
+            "urn:undefined:(WaOLN)nyp0208964"
+          ],
+          "idIsbn": [
+            "8820505517 (v. 1)"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1986"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Novellae constitutiones."
+          ],
+          "titleDisplay": [
+            "Novellae : pars graeca / Iohanne Gualberto Archi moderante, curavit Anna Maria Bartoletti Colombo."
+          ],
+          "uri": "b10008989",
+          "numItems": [
+            5
+          ],
+          "numAvailable": [
+            5
+          ],
+          "placeOfPublication": [
+            "Milano"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "88205055171"
+          ],
+          "dimensions": [
+            "35 cm."
+          ]
+        },
+        "sort": [
+          "b10008989"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 5,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433079237768"
+                    ],
+                    "physicalLocation": [
+                      "JLN 88-42"
+                    ],
+                    "shelfMark_sort": "aJLN 88-42 v. 000005",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i17447326",
+                    "shelfMark": [
+                      "JLN 88-42 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JLN 88-42 v. 5"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079237768"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "idBarcode": [
+                      "33433079237768"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433079237776"
+                    ],
+                    "physicalLocation": [
+                      "JLN 88-42"
+                    ],
+                    "shelfMark_sort": "aJLN 88-42 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i17447327",
+                    "shelfMark": [
+                      "JLN 88-42 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JLN 88-42 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079237776"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433079237776"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433079237784"
+                    ],
+                    "physicalLocation": [
+                      "JLN 88-42"
+                    ],
+                    "shelfMark_sort": "aJLN 88-42 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i17447328",
+                    "shelfMark": [
+                      "JLN 88-42 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JLN 88-42 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079237784"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433079237784"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433079237792"
+                    ],
+                    "physicalLocation": [
+                      "JLN 88-42"
+                    ],
+                    "shelfMark_sort": "aJLN 88-42 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i17447325",
+                    "shelfMark": [
+                      "JLN 88-42 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JLN 88-42 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433079237792"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433079237792"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433033482716"
+                    ],
+                    "physicalLocation": [
+                      "JLN 88-42 Library has: t. 1-6."
+                    ],
+                    "shelfMark_sort": "aJLN 88-42 Library has: t. 1-6. T. 000006",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i12540484",
+                    "shelfMark": [
+                      "JLN 88-42 Library has: t. 1-6. T. 6"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JLN 88-42 Library has: t. 1-6. T. 6"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433033482716"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "T. 6"
+                    ],
+                    "idBarcode": [
+                      "33433033482716"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009049",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "3 v. (loose-leaf) : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Loose-leaves for updating.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes index.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Computer industry",
+            "Computer industry -- Technological innovations",
+            "Computers",
+            "Computers -- Catalogs"
+          ],
+          "publisherLiteral": [
+            "Datapro Research Corp. ;"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Datapro reports on minicomputers"
+          ],
+          "shelfMark": [
+            "JSF 85-437"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "contributorLiteral": [
+            "Datapro Research Corporation.",
+            "Heminway, Mary C."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JSF 85-437"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009049"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00810570"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209024"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1644359525726,
+          "publicationStatement": [
+            "Delran, N.J. : Datapro Research Corp. ; c1985-"
+          ],
+          "identifier": [
+            "urn:bnum:10009049",
+            "urn:undefined:NNSZ00810570",
+            "urn:undefined:(WaOLN)nyp0209024"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Computer industry -- Technological innovations.",
+            "Computers -- Catalogs."
+          ],
+          "titleDisplay": [
+            "Datapro reports on minicomputers / group managing editor, Mary C. Heminway."
+          ],
+          "uri": "b10009049",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Delran, N.J. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Reports on minicomputers."
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10009049"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059486757"
+                    ],
+                    "physicalLocation": [
+                      "JSF 85-437"
+                    ],
+                    "shelfMark_sort": "aJSF 85-437 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13785402",
+                    "shelfMark": [
+                      "JSF 85-437 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JSF 85-437 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059486757"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433059486757"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059486500"
+                    ],
+                    "physicalLocation": [
+                      "JSF 85-437"
+                    ],
+                    "shelfMark_sort": "aJSF 85-437 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13785401",
+                    "shelfMark": [
+                      "JSF 85-437 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JSF 85-437 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059486500"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433059486500"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433037693862"
+                    ],
+                    "physicalLocation": [
+                      "JSF 85-437"
+                    ],
+                    "shelfMark_sort": "aJSF 85-437 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i12540492",
+                    "shelfMark": [
+                      "JSF 85-437 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JSF 85-437 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433037693862"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433037693862"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009050",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "3 v. (loose-leaf) : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Loose-leaves for updating.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Computer programs",
+            "Computer programs -- Directories",
+            "Microcomputers",
+            "Microcomputers -- Programming",
+            "Microcomputers -- Programming -- Directories",
+            "Programming languages (Electronic computers)",
+            "Programming languages (Electronic computers) -- Directories"
+          ],
+          "publisherLiteral": [
+            "Datapro Research Corp.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1985
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Datapro directory of microcomputer software"
+          ],
+          "shelfMark": [
+            "JSF 85-438"
+          ],
+          "createdString": [
+            "1985"
+          ],
+          "contributorLiteral": [
+            "Datapro Research Corporation.",
+            "Muldowney, William J."
+          ],
+          "dateStartYear": [
+            1985
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JSF 85-438"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009050"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00810571"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209025"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636086399858,
+          "publicationStatement": [
+            "Delran, N.J. : Datapro Research Corp., c1985-"
+          ],
+          "identifier": [
+            "urn:bnum:10009050",
+            "urn:undefined:NNSZ00810571",
+            "urn:undefined:(WaOLN)nyp0209025"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1985"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Computer programs -- Directories.",
+            "Microcomputers -- Programming -- Directories.",
+            "Programming languages (Electronic computers) -- Directories."
+          ],
+          "titleDisplay": [
+            "Datapro directory of microcomputer software / managing editor, William J. Muldowney."
+          ],
+          "uri": "b10009050",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Delran, N.J. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Directory of microcomputer software.",
+            "Microcomputer software."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10009050"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059486724"
+                    ],
+                    "physicalLocation": [
+                      "JSF 85-438"
+                    ],
+                    "shelfMark_sort": "aJSF 85-438 v. 000003",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13785404",
+                    "shelfMark": [
+                      "JSF 85-438 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JSF 85-438 v. 3"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059486724"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "idBarcode": [
+                      "33433059486724"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059486450"
+                    ],
+                    "physicalLocation": [
+                      "JSF 85-438"
+                    ],
+                    "shelfMark_sort": "aJSF 85-438 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13785403",
+                    "shelfMark": [
+                      "JSF 85-438 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JSF 85-438 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059486450"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433059486450"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433037693870"
+                    ],
+                    "physicalLocation": [
+                      "JSF 85-438"
+                    ],
+                    "shelfMark_sort": "aJSF 85-438 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i12540493",
+                    "shelfMark": [
+                      "JSF 85-438 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "JSF 85-438 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433037693870"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433037693870"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009141",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Bibliography",
+              "label": "Includes bibliographical references.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Tamil language",
+            "Tamil language -- Grammar"
+          ],
+          "publisherLiteral": [
+            "viṟpaṉai urimai: Pāri Nilaiyam,"
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1967
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Ilakkaṇat tokai."
+          ],
+          "shelfMark": [
+            "*OLB 85-879"
+          ],
+          "creatorLiteral": [
+            "Subramanian, S. V."
+          ],
+          "createdString": [
+            "1967"
+          ],
+          "idLccn": [
+            "75910470"
+          ],
+          "dateStartYear": [
+            1967
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLB 85-879"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009141"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "75910470"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00810664"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209116"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636105084628,
+          "publicationStatement": [
+            "Ceṉṉai, viṟpaṉai urimai: Pāri Nilaiyam, 1967-"
+          ],
+          "identifier": [
+            "urn:bnum:10009141",
+            "urn:lccn:75910470",
+            "urn:undefined:NNSZ00810664",
+            "urn:undefined:(WaOLN)nyp0209116"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1967"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Tamil language -- Grammar."
+          ],
+          "titleDisplay": [
+            "Ilakkaṇat tokai. [Tokuppāciriyar] Ca. Vē. Cuppiramaṇiyaṉ."
+          ],
+          "uri": "b10009141",
+          "lccClassification": [
+            "PL4754 .S78"
+          ],
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "1. Eḻuttu. -- 2. Col."
+          ],
+          "dimensions": [
+            "19 cm."
+          ]
+        },
+        "sort": [
+          "b10009141"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061304865"
+                    ],
+                    "physicalLocation": [
+                      "*OLB 85-879"
+                    ],
+                    "shelfMark_sort": "a*OLB 85-879 v. 000002",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13785411",
+                    "shelfMark": [
+                      "*OLB 85-879 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLB 85-879 v. 2"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061304865"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "idBarcode": [
+                      "33433061304865"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433061304857"
+                    ],
+                    "physicalLocation": [
+                      "*OLB 85-879"
+                    ],
+                    "shelfMark_sort": "a*OLB 85-879 v. 000001",
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i13785410",
+                    "shelfMark": [
+                      "*OLB 85-879 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*OLB 85-879 v. 1"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433061304857"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "idBarcode": [
+                      "33433061304857"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009318",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "10 v. in 7."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Tamil.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "language": [
+            {
+              "id": "lang:tam",
+              "label": "Tamil"
+            }
+          ],
+          "numItemsTotal": [
+            7
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1960
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Villiputtūrār iyaṟṟiya Makāpāratam; Vai. Mu. Kōpālakiruṣṇamācāriyar iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "shelfMark": [
+            "*OLY 87-5294"
+          ],
+          "numItemVolumesParsed": [
+            7
+          ],
+          "creatorLiteral": [
+            "Kōpāla Kiruṣṇamācāryar, Vai. Mu., 1882-1956."
+          ],
+          "createdString": [
+            "1960"
+          ],
+          "idLccn": [
+            "76909632"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Kiruṣṇamācāriyar, C.",
+            "Villiputtūrāḻvār."
+          ],
+          "dateStartYear": [
+            1960
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*OLY 87-5294"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009318"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "76909632"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG009000066-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00910847"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209293"
+            }
+          ],
+          "idOclc": [
+            "NYPG009000066-B"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1675264547472,
+          "publicationStatement": [
+            "Ceṉṉai, 1960-1968 [v.1. 1963]"
+          ],
+          "identifier": [
+            "urn:bnum:10009318",
+            "urn:lccn:76909632",
+            "urn:oclc:NYPG009000066-B",
+            "urn:undefined:NNSZ00910847",
+            "urn:undefined:(WaOLN)nyp0209293"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1960"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Villiputtūrār iyaṟṟiya Makāpāratam; Vai. Mu. Kōpālakiruṣṇamācāriyar iyaṟṟiya uraiyuṭaṉ."
+          ],
+          "uri": "b10009318",
+          "lccClassification": [
+            "PL4758.9.V492 V534 1960"
+          ],
+          "numItems": [
+            7
+          ],
+          "numAvailable": [
+            7
+          ],
+          "placeOfPublication": [
+            "Ceṉṉai"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "sort": [
+          "b10009318"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 7,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785440",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 9-10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 9-10",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585376"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 9-10"
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585376"
+                    ],
+                    "idBarcode": [
+                      "33433059585376"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 9,
+                        "lte": 10
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         9-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000009-10"
+                  },
+                  "sort": [
+                    "         9-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785439",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 6-8"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 6-8",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585368"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 6-8"
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585368"
+                    ],
+                    "idBarcode": [
+                      "33433059585368"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 6,
+                        "lte": 8
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         6-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000006-8"
+                  },
+                  "sort": [
+                    "         6-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785438",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 5"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 5",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585350"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 5"
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585350"
+                    ],
+                    "idBarcode": [
+                      "33433059585350"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 5
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000005"
+                  },
+                  "sort": [
+                    "         5-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785437",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 4"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 4",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585343"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 4"
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585343"
+                    ],
+                    "idBarcode": [
+                      "33433059585343"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 4,
+                        "lte": 4
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         4-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000004"
+                  },
+                  "sort": [
+                    "         4-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785436",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585335"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 3"
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585335"
+                    ],
+                    "idBarcode": [
+                      "33433059585335"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 3,
+                        "lte": 3
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         3-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000003"
+                  },
+                  "sort": [
+                    "         3-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785435",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585327"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585327"
+                    ],
+                    "idBarcode": [
+                      "33433059585327"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 2,
+                        "lte": 2
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         2-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000002"
+                  },
+                  "sort": [
+                    "         2-"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785434",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mal92",
+                        "label": "Schwarzman Building M2 - General Research Room 315"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mal92||Schwarzman Building M2 - General Research Room 315"
+                    ],
+                    "shelfMark": [
+                      "*OLY 87-5294 v. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*OLY 87-5294 v. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433059585319"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1"
+                    ],
+                    "physicalLocation": [
+                      "*OLY 87-5294"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433059585319"
+                    ],
+                    "idBarcode": [
+                      "33433059585319"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 1
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*OLY 87-5294 v. 000001"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009600",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill."
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Colophon title in Russian: Uchebnik Kir. ︠i︡azyka dl︠i︡a trudovykh shkol.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Allworth no. 1685.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "In Kirghiz.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Kyrgyz language",
+            "Kyrgyz language -- Texts",
+            "Kyrgyz language -- Textbooks for foreign speakers",
+            "Kyrgyz language -- Textbooks for foreign speakers -- Russian"
+          ],
+          "publisherLiteral": [
+            "Qïrghïzïstan Memleket Basmasï"
+          ],
+          "language": [
+            {
+              "id": "lang:kir",
+              "label": "Kyrgyz"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1930
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Orus emgek mektebteri ycyn qïrghïz tilinin oquu kitebi"
+          ],
+          "shelfMark": [
+            "*ZO-258 no. 1"
+          ],
+          "creatorLiteral": [
+            "Çangïbajuluu, M."
+          ],
+          "createdString": [
+            "1930"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1930
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*ZO-258 no. 1"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009600"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00911072"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209576"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1664461892774,
+          "publicationStatement": [
+            "Prunza : Qïrghïzïstan Memleket Basmasï, 1930-"
+          ],
+          "identifier": [
+            "urn:bnum:10009600",
+            "urn:undefined:NNSZ00911072",
+            "urn:undefined:(WaOLN)nyp0209576"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1930"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Kyrgyz language -- Texts.",
+            "Kyrgyz language -- Textbooks for foreign speakers -- Russian."
+          ],
+          "titleDisplay": [
+            "Orus emgek mektebteri ycyn qïrghïz tilinin oquu kitebi [microform] / M. Çangïbaj uluu."
+          ],
+          "uri": "b10009600",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Prunza"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "Uchebnik kirgizskogo ︠i︡azyka dl︠i︡a trudovykh shkol."
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10009600"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30068355",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "*ZO-258, no. 1 no. 1-22"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*ZO-258, no. 1 no. 1-22",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105667400"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "*ZO-258, no. 1"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-22"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105667400"
+                    ],
+                    "idBarcode": [
+                      "33433105667400"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "a*ZO-258, no. 000001 no. 1-22"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009763",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., facsims., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Suppl. 2 has title: Book of Jared; vol. 3 (the second supplement), continuing the record of descedants of John Jared (1837 [sic]-1805) and his wives Hannah Whitacre and Rachel Palmer.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Jared family",
+            "Jared, John, 1737-1805",
+            "Jared, John, 1737-1805 -- Family"
+          ],
+          "publisherLiteral": [
+            "E. M. Hall,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1981
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The book of Jared supplement[s] : a family record showing descendants of John Jared, 1737-1805, Hannah Whitacre, Rachel Palmer"
+          ],
+          "shelfMark": [
+            "APV (Jared) 85-2860 Suppl."
+          ],
+          "creatorLiteral": [
+            "Hall, Eleanor McAllister, 1910-"
+          ],
+          "createdString": [
+            "1981"
+          ],
+          "dateStartYear": [
+            1981
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "APV (Jared) 85-2860 Suppl."
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009763"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ00911239"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209739"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636133579155,
+          "publicationStatement": [
+            "Salt Lake City, Utah (7234 So. 2825 East, Salt Lake City 84121) : E. M. Hall, c1981-"
+          ],
+          "identifier": [
+            "urn:bnum:10009763",
+            "urn:undefined:NNSZ00911239",
+            "urn:undefined:(WaOLN)nyp0209739"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1981"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Jared family.",
+            "Jared, John, 1737-1805 -- Family."
+          ],
+          "titleDisplay": [
+            "The book of Jared supplement[s] : a family record showing descendants of John Jared, 1737-1805, Hannah Whitacre, Rachel Palmer / [compiled by Eleanor M. Hall]."
+          ],
+          "uri": "b10009763",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Salt Lake City, Utah (7234 So. 2825 East, Salt Lake City 84121) :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10009763"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27564651",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093160152"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APV (Jared) 85-2860 Suppl. Suppl. 1-2."
+                    ],
+                    "enumerationChronology": [
+                      "Suppl. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093160152"
+                    ],
+                    "idBarcode": [
+                      "33433093160152"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27564640",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 1"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 1",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093160145"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APV (Jared) 85-2860 Suppl. Suppl. 1-2."
+                    ],
+                    "enumerationChronology": [
+                      "Suppl. 1"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093160145"
+                    ],
+                    "idBarcode": [
+                      "33433093160145"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPV (Jared) 85-2860 Suppl. Suppl. 1-2. Suppl. 000001"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747026",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APV (Jared) 85-2860 Suppl. Suppl. 1-2 Suppl. "
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APV (Jared) 85-2860 Suppl. Suppl. 1-2 Suppl. ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433093160137"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APV (Jared) 85-2860 Suppl. Suppl. 1-2"
+                    ],
+                    "enumerationChronology": [
+                      "Suppl. "
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433093160137"
+                    ],
+                    "idBarcode": [
+                      "33433093160137"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPV (Jared) 85-2860 Suppl. Suppl. 1-2 Suppl. "
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10009901",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : port. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Paging in reverse.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Ansaru Allah Community]"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1977
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The holy Qur'an : the last testament"
+          ],
+          "shelfMark": [
+            "Sc Ser.-M .K786"
+          ],
+          "numItemVolumesParsed": [
+            1
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "seriesStatement": [
+            "Edition; 41-",
+            "Nubian Islamic Hebrews. Edition 41-"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "ʻIsá Abd Allāh Muḥammad al-Mahdī, 1945-"
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Ser.-M .K786"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10009901"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG009000597-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0209877"
+            }
+          ],
+          "idOclc": [
+            "NYPG009000597-B"
+          ],
+          "uniformTitle": [
+            "Qurʼan. English & Arabic."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:scf",
+                  "label": "Schomburg Center - Research & Reference"
+                }
+              ],
+              "uri": "h1143677",
+              "shelfMark": [
+                "Sc Ser.-M .K786"
+              ]
+            }
+          ],
+          "updatedAt": 1669058699563,
+          "publicationStatement": [
+            "[Brooklyn, N.Y.] : Ansaru Allah Community], 1977-"
+          ],
+          "identifier": [
+            "urn:bnum:10009901",
+            "urn:oclc:NYPG009000597-B",
+            "urn:undefined:(WaOLN)nyp0209877"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "The holy Qur'an : the last testament / English translation and commentary by Al Hajj Al Imam Isa Abd'Allah Muhammad al Mahdi."
+          ],
+          "uri": "b10009901",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "[Brooklyn, N.Y.]"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "27 cm."
+          ]
+        },
+        "sort": [
+          "b10009901"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747080",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1114",
+                        "label": "Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:scff2",
+                        "label": "Schomburg Center - Research & Reference"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:scff2||Schomburg Center - Research & Reference"
+                    ],
+                    "shelfMark": [
+                      "Sc Ser.-M .K786 v. 1-3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "Sc Ser.-M .K786 v. 1-3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433070348341"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-3"
+                    ],
+                    "physicalLocation": [
+                      "Sc Ser.-M .K786"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433070348341"
+                    ],
+                    "idBarcode": [
+                      "33433070348341"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 3
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aSc Ser.-M .K786 v. 000001-3"
+                  },
+                  "sort": [
+                    "         1-"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010070",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Supplement",
+              "label": "Issues for 1968-69 include supplement: Quality.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Issued By",
+              "label": "Issued by the institute in collaboration with the General Confederation of Italian Industry.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Fall 1958-"
+          ],
+          "subjectLiteral_exploded": [
+            "Industries",
+            "Industries -- Italy",
+            "Industries -- Italy -- Periodicals",
+            "Italy",
+            "Italy -- Commerce",
+            "Italy -- Commerce -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Istituto Nazionale per il Commercio Estero"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            2
+          ],
+          "createdYear": [
+            1958
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Italy presents."
+          ],
+          "shelfMark": [
+            "JLM 81-304"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1958"
+          ],
+          "idLccn": [
+            "63053813"
+          ],
+          "idIssn": [
+            "0021-3160"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Istituto nazionale per il commercio estero (Italy)",
+            "Confederazione generale dell'industria italiana."
+          ],
+          "dateStartYear": [
+            1958
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JLM 81-304"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010070"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0021-3160"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "63053813"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1754066"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1754066"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG010-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210046"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)1754066"
+            }
+          ],
+          "idOclc": [
+            "1754066",
+            "NYPG010-S"
+          ],
+          "uniformTitle": [
+            "Quality."
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1670258911038,
+          "publicationStatement": [
+            "Rome : Istituto Nazionale per il Commercio Estero, 1958-"
+          ],
+          "identifier": [
+            "urn:bnum:10010070",
+            "urn:issn:0021-3160",
+            "urn:lccn:63053813",
+            "urn:oclc:1754066",
+            "urn:oclc:NYPG010-S",
+            "urn:undefined:(WaOLN)nyp0210046",
+            "urn:undefined:(OCoLC)1754066"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1958"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Industries -- Italy -- Periodicals.",
+            "Italy -- Commerce -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Italy presents."
+          ],
+          "uri": "b10010070",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "Rome"
+          ],
+          "titleAlt": [
+            "Italian trade magazine."
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "29 cm."
+          ]
+        },
+        "sort": [
+          "b10010070"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540520",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-304 1970-1972"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-304 1970-1972",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017526959"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1970-1972"
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-304"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017526959"
+                    ],
+                    "idBarcode": [
+                      "33433017526959"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJLM 81-304 1970-001972"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12540519",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JLM 81-304 1967-1969"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JLM 81-304 1967-1969",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433017526942"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1967-1969"
+                    ],
+                    "physicalLocation": [
+                      "JLM 81-304"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433017526942"
+                    ],
+                    "idBarcode": [
+                      "33433017526942"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJLM 81-304 1967-001969"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010482",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. : ill., facsims., ports. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "K.A.R.D.: Karow, Adamson, Rubidoux, Dye--V. 2, Pref.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 12 published in Kent, Washington.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Vol. 12: \"John A. & Judy K. Dye.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "Includes indexes.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Adams family"
+          ],
+          "publisherLiteral": [
+            "J. Dye,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1982
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "The K.A.R.D. files--Adamson ancestry"
+          ],
+          "shelfMark": [
+            "APV (Adamson) 85-544"
+          ],
+          "creatorLiteral": [
+            "Dye, John."
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "contributorLiteral": [
+            "Dye, Judy."
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "APV (Adamson) 85-544"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010482"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210458"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1-12-"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "No. 13",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "APV (Adamson) 85-544 Library has: Vol. 1-13."
+                }
+              ],
+              "physicalLocation": [
+                "APV (Adamson) 85-544 Library has: Vol. 1-13."
+              ],
+              "location": [
+                {
+                  "code": "loc:mag",
+                  "label": "Schwarzman Building - Milstein Division Room 121"
+                }
+              ],
+              "uri": "h1031668",
+              "shelfMark": [
+                "APV (Adamson) 85-544 Library has: Vol. 1-13."
+              ]
+            }
+          ],
+          "updatedAt": 1636135853428,
+          "publicationStatement": [
+            "Spokane, Wash. : J. Dye, [1982]-"
+          ],
+          "identifier": [
+            "urn:bnum:10010482",
+            "urn:undefined:(WaOLN)nyp0210458"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Adams family."
+          ],
+          "titleDisplay": [
+            "The K.A.R.D. files--Adamson ancestry / John and Judy Dye."
+          ],
+          "uri": "b10010482",
+          "numItems": [
+            3
+          ],
+          "numAvailable": [
+            3
+          ],
+          "placeOfPublication": [
+            "Spokane, Wash. :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "titleAlt": [
+            "KARD files--Adamson ancestry."
+          ],
+          "dimensions": [
+            "28 cm."
+          ]
+        },
+        "sort": [
+          "b10010482"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 3,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i26428980",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APV (Adamson) 85-544 v. 10-13 (Mar. 1989-Sept. 1996)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APV (Adamson) 85-544 v. 10-13 (Mar. 1989-Sept. 1996)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433091335061"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APV (Adamson) 85-544"
+                    ],
+                    "enumerationChronology": [
+                      "v. 10-13 (Mar. 1989-Sept. 1996)"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433091335061"
+                    ],
+                    "idBarcode": [
+                      "33433091335061"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPV (Adamson) 85-544 v. 000010-13 (Mar. 1989-Sept. 1996)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i26428927",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APV (Adamson) 85-544  v. 4-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APV (Adamson) 85-544  v. 4-9",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433091335053"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APV (Adamson) 85-544 "
+                    ],
+                    "enumerationChronology": [
+                      "v. 4-9"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433091335053"
+                    ],
+                    "idBarcode": [
+                      "33433091335053"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPV (Adamson) 85-544 v. 000004-9"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747104",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APV (Adamson) 85-544 v. 1-3"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APV (Adamson) 85-544 v. 1-3",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433091335046"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APV (Adamson) 85-544"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-3"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433091335046"
+                    ],
+                    "idBarcode": [
+                      "33433091335046"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPV (Adamson) 85-544 v. 000001-3"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010483",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Photocopy.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "vol. 1-2: \"July 18, 1941.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Church records and registers",
+            "Church records and registers -- Herkimer",
+            "Church records and registers -- Herkimer -- Indexes",
+            "Herkimer (N.Y.)",
+            "Herkimer (N.Y.) -- Genealogy",
+            "Herkimer (N.Y.) -- Genealogy -- Indexes",
+            "Reformed Protestant Dutch Church (Herkimer, N.Y.)"
+          ],
+          "publisherLiteral": [
+            "The Dept.],"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1941
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Index of records Reformed Protestant Dutch Church of Herkimer"
+          ],
+          "shelfMark": [
+            "APR (Herkimer, N.Y.) 85-424 Index"
+          ],
+          "createdString": [
+            "1941"
+          ],
+          "contributorLiteral": [
+            "Montgomery County (N.Y.). Dept. of History and Archives.",
+            "Reformed Protestant Dutch Church (Herkimer, N.Y.). Records of the Reformed Protestant Dutch Church of Herkimer in the Town of Herkimer, Herkimer County, N.Y."
+          ],
+          "dateStartYear": [
+            1941
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "APR (Herkimer, N.Y.) 85-424 Index"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010483"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01012132"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210459"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636105431482,
+          "publicationStatement": [
+            "[New York : The Dept.], 1941-"
+          ],
+          "identifier": [
+            "urn:bnum:10010483",
+            "urn:undefined:NNSZ01012132",
+            "urn:undefined:(WaOLN)nyp0210459"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1941"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Church records and registers -- Herkimer -- Indexes.",
+            "Herkimer (N.Y.) -- Genealogy -- Indexes.",
+            "Reformed Protestant Dutch Church (Herkimer, N.Y.)"
+          ],
+          "titleDisplay": [
+            "Index of records Reformed Protestant Dutch Church of Herkimer / compiled by the Montgomery Department of History and Archives."
+          ],
+          "uri": "b10010483",
+          "numItems": [
+            2
+          ],
+          "numAvailable": [
+            2
+          ],
+          "placeOfPublication": [
+            "[New York :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "33 cm."
+          ]
+        },
+        "sort": [
+          "b10010483"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 2,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i24831672",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mag92",
+                        "label": "Schwarzman Building M2 - Milstein Division Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mag92||Schwarzman Building M2 - Milstein Division Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Herkimer, N.Y.) 85-424 Index v. 2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Herkimer, N.Y.) 85-424 Index v. 2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433085274375"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Herkimer, N.Y.) 85-424 Index"
+                    ],
+                    "enumerationChronology": [
+                      "v. 2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433085274375"
+                    ],
+                    "idBarcode": [
+                      "33433085274375"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Herkimer, N.Y.) 85-424 Index v. 000002"
+                  },
+                  "sort": [
+                    null
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i11901094",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1105",
+                        "label": "Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1105||Irma and Paul Milstein Division of United States History, Local History and Genealogy"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:2",
+                        "label": "book non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:2||book non-circ"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:magg2",
+                        "label": "Schwarzman Building - Milstein Division Mezzanine Room 121"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:magg2||Schwarzman Building - Milstein Division Mezzanine Room 121"
+                    ],
+                    "shelfMark": [
+                      "APR (Herkimer, N.Y.) 85-424 Index v. 1-2"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "APR (Herkimer, N.Y.) 85-424 Index v. 1-2",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433032068110"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "APR (Herkimer, N.Y.) 85-424 Index"
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-2"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433032068110"
+                    ],
+                    "idBarcode": [
+                      "33433032068110"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "shelfMark_sort": "aAPR (Herkimer, N.Y.) 85-424 Index v. 000001-2"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010674",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ill."
+          ],
+          "note": [
+            {
+              "noteType": "Language",
+              "label": "In Italian.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "anno 1-    magg./giugno 1977-"
+          ],
+          "subjectLiteral_exploded": [
+            "Music",
+            "Music -- Periodicals",
+            "Sound recordings",
+            "Sound recordings -- Reviews"
+          ],
+          "numItemDatesParsed": [
+            118
+          ],
+          "publisherLiteral": [
+            "Ed. Diapason Milano]"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "numItemsTotal": [
+            118
+          ],
+          "createdYear": [
+            1977
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Musica."
+          ],
+          "shelfMark": [
+            "*LA 81-296"
+          ],
+          "numItemVolumesParsed": [
+            83
+          ],
+          "createdString": [
+            "1977"
+          ],
+          "idLccn": [
+            "79649506 /MN"
+          ],
+          "idIssn": [
+            "0392-5544"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1977
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*LA 81-296"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010674"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0392-5544"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "79649506 /MN"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "5909505"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "5909505"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG011-S"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0000035"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)5909505"
+            }
+          ],
+          "idOclc": [
+            "5909505",
+            "NYPG011-S"
+          ],
+          "uniformTitle": [
+            "Musica (Milan, Italy)"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1:1(May/Jun 1977)-12:53(Dec/Jan 1988/89),13:55(Apr/May 1989)-21:105(Oct/Dec 1997)-25:132(Dec 2001/Jan 2002),27:165(Apr 2005)-32:212(Dec/Jan 2010)",
+                "v. 32, no. 213 (2010-02) - v. 38, no. 269 (2015-09); v. 38, no. 271 (2015-11) - v. 40, no. 294 (2018-03); v. 41, no. 296 (2018-05) - v. 42, no. 343 (2023-02)"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 41 No. 304 (Mar. 2019)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 41 No. 305 (Apr. 2019)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 41 No. 306 (May. 2019)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 41 No. 307 (Jun. 2019)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 41 No. 308 (Jul. 2019)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 309 (Sep. 2019)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 41 No. 310 (Oct. 2019)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 311 (Nov. 2019)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 312 (Dec. 2019)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 313 (Feb. 2020)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 314 (Mar. 2020)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 315 (Apr. 2020)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 316 (May. 2020)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 317 (Jun. 2020)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 318 (Jul. 2020)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 319 (Sep. 2020)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 320 (Oct. 2020)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 321 (Nov. 2020)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 322 (Dec. 2020)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 323 (Feb. 2021)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 324 (Mar. 2021)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 325 (Apr. 2021)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 326 (May. 2021)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 327 (Jun. 2021)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 328 (Jul. 2021)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 329 (Sep. 2021)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 330 (Oct. 2021)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 331 (Nov. 2021)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 332 (Dec. 2021)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 333 (Feb. 2022)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 334 (Mar. 2022)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 335 (Apr. 2022)",
+                  "position": "32",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 336 (May. 2022)",
+                  "position": "33",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 337 (Jun. 2022)",
+                  "position": "34",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 338 (Jul. 2022)",
+                  "position": "35",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 339 (Sep. 2022)",
+                  "position": "36",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 340 (Oct. 2022)",
+                  "position": "37",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 341 (Nov. 2022)",
+                  "position": "38",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 342 (Dec. 2022)",
+                  "position": "39",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 343 (Feb. 2023)",
+                  "position": "40",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 42 No. 344 (Mar. 2023)",
+                  "position": "41",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 42 No. 345 (Apr. 2023)",
+                  "position": "42",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 42 No. 346 (May. 2023)",
+                  "position": "43",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 42 No. 347 (Jun. 2023)",
+                  "position": "44",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 42 No. 348 (Jul. 2023)",
+                  "position": "45",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 42 No. 349 (Aug. 2023)",
+                  "position": "46",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 42 No. 350 (Sep. 2023)",
+                  "position": "47",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 42 No. 351 (Oct. 2023)",
+                  "position": "48",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 43 No. 352 (Nov. 2023)",
+                  "position": "49",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 43 No. 353 (Dec. 2023)",
+                  "position": "50",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 43 No. 354 (Jan. 2024)",
+                  "position": "51",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "*LA 81-296"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "*LA 81-296"
+                }
+              ],
+              "notes": [
+                "CURRENT ISSUES IN R&H ARCHIVES"
+              ],
+              "physicalLocation": [
+                "*LA 81-296"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:myh",
+                  "label": "Performing Arts Research Collections - Recorded Sound"
+                }
+              ],
+              "uri": "h1036576",
+              "shelfMark": [
+                "*LA 81-296"
+              ]
+            }
+          ],
+          "updatedAt": 1678211442224,
+          "publicationStatement": [
+            "[Milano, Ed. Diapason Milano]"
+          ],
+          "identifier": [
+            "urn:bnum:10010674",
+            "urn:issn:0392-5544",
+            "urn:lccn:79649506 /MN",
+            "urn:oclc:5909505",
+            "urn:oclc:NYPG011-S",
+            "urn:undefined:(WaOLN)nyp0000035",
+            "urn:undefined:(OCoLC)5909505"
+          ],
+          "numCheckinCardItems": [
+            51
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1977"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Music -- Periodicals.",
+            "Sound recordings -- Reviews."
+          ],
+          "titleDisplay": [
+            "Musica."
+          ],
+          "uri": "b10010674",
+          "lccClassification": [
+            "ML5 .M713595"
+          ],
+          "numItems": [
+            67
+          ],
+          "numAvailable": [
+            107
+          ],
+          "placeOfPublication": [
+            "[Milano"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "30 cm."
+          ]
+        },
+        "sort": [
+          "b10010674"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 67,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 116
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37372229",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 41, nos. 299-303 (Sept. 2018-Feb. 2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 41, nos. 299-303 (Sept. 2018-Feb. 2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108987573"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 41, nos. 299-303 (Sept. 2018-Feb. 2019)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108987573"
+                    ],
+                    "idBarcode": [
+                      "33433108987573"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 41,
+                        "lte": 41
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2019"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        41-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000041, nos. 299-303 (Sept. 2018-Feb. 2019)"
+                  },
+                  "sort": [
+                    "        41-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 115
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37372228",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 40, nos. 293-298, inc. (Feb.-Aug. 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 40, nos. 293-298, inc. (Feb.-Aug. 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108987565"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 40, nos. 293-298, inc. (Feb.-Aug. 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108987565"
+                    ],
+                    "idBarcode": [
+                      "33433108987565"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 40,
+                        "lte": 40
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        40-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000040, nos. 293-298, inc. (Feb.-Aug. 2018)"
+                  },
+                  "sort": [
+                    "        40-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 114
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37369430",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 40, nos. 288-292 (July 2017-Jan. 2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 40, nos. 288-292 (July 2017-Jan. 2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108987557"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 40, nos. 288-292 (July 2017-Jan. 2018)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108987557"
+                    ],
+                    "idBarcode": [
+                      "33433108987557"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 40,
+                        "lte": 40
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2017",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        40-2017"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000040, nos. 288-292 (July 2017-Jan. 2018)"
+                  },
+                  "sort": [
+                    "        40-2017"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 113
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37369426",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 39-40, nos. 283-287 (Feb.-June 2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 39-40, nos. 283-287 (Feb.-June 2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108987540"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 39-40, nos. 283-287 (Feb.-June 2017)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108987540"
+                    ],
+                    "idBarcode": [
+                      "33433108987540"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 39,
+                        "lte": 40
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2017",
+                        "lte": "2017"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        39-2017"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000039-40, nos. 283-287 (Feb.-June 2017)"
+                  },
+                  "sort": [
+                    "        39-2017"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 112
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37369420",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 39, nos. 278-282 (July 2016-Jan. 2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 39, nos. 278-282 (July 2016-Jan. 2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433108987532"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 39, nos. 278-282 (July 2016-Jan. 2017)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433108987532"
+                    ],
+                    "idBarcode": [
+                      "33433108987532"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 39,
+                        "lte": 39
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2017"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        39-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000039, nos. 278-282 (July 2016-Jan. 2017)"
+                  },
+                  "sort": [
+                    "        39-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 111
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34627481",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 38-39, nos. 273-277 (Feb.-June 2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 38-39, nos. 273-277 (Feb.-June 2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433104416387"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 38-39, nos. 273-277 (Feb.-June 2016)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433104416387"
+                    ],
+                    "idBarcode": [
+                      "33433104416387"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 38,
+                        "lte": 39
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        38-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000038-39, nos. 273-277 (Feb.-June 2016)"
+                  },
+                  "sort": [
+                    "        38-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 110
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34627460",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 38, nos. 268-272 (July 2015-Jan. 2016) (inc.)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 38, nos. 268-272 (July 2015-Jan. 2016) (inc.)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433104416379"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 38, nos. 268-272 (July 2015-Jan. 2016) (inc.)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433104416379"
+                    ],
+                    "idBarcode": [
+                      "33433104416379"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 38,
+                        "lte": 38
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2015",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        38-2015"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000038, nos. 268-272 (July 2015-Jan. 2016) (inc.)"
+                  },
+                  "sort": [
+                    "        38-2015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 109
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i34627409",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 37-38, nos. 263-267 (Feb.-June 2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 37-38, nos. 263-267 (Feb.-June 2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433104416361"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 37-38, nos. 263-267 (Feb.-June 2015)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433104416361"
+                    ],
+                    "idBarcode": [
+                      "33433104416361"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 37,
+                        "lte": 38
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2015",
+                        "lte": "2015"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        37-2015"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000037-38, nos. 263-267 (Feb.-June 2015)"
+                  },
+                  "sort": [
+                    "        37-2015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 108
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32547828",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:102",
+                        "label": "Book, paperback"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:102||Book, paperback"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 37, nos. 258-262 (July 2014-Jan. 2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 37, nos. 258-262 (July 2014-Jan. 2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064479821"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 37, nos. 258-262 (July 2014-Jan. 2015)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064479821"
+                    ],
+                    "idBarcode": [
+                      "33433064479821"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 37,
+                        "lte": 37
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2015"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        37-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000037, nos. 258-262 (July 2014-Jan. 2015)"
+                  },
+                  "sort": [
+                    "        37-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 107
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32547826",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:102",
+                        "label": "Book, paperback"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:102||Book, paperback"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 36-37, nos. 253-257 (Feb.-June 2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 36-37, nos. 253-257 (Feb.-June 2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064479813"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 36-37, nos. 253-257 (Feb.-June 2014)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064479813"
+                    ],
+                    "idBarcode": [
+                      "33433064479813"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 36,
+                        "lte": 37
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        36-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000036-37, nos. 253-257 (Feb.-June 2014)"
+                  },
+                  "sort": [
+                    "        36-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 106
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31163867",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 35-36, nos. 243-247 (Feb.-June 2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 35-36, nos. 243-247 (Feb.-June 2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064468642"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 35-36, nos. 243-247 (Feb.-June 2013)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064468642"
+                    ],
+                    "idBarcode": [
+                      "33433064468642"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 35,
+                        "lte": 36
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        35-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000035-36, nos. 243-247 (Feb.-June 2013)"
+                  },
+                  "sort": [
+                    "        35-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 105
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32547819",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:102",
+                        "label": "Book, paperback"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:102||Book, paperback"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 35, nos. 248-252 (July 2013-Jan. 2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 35, nos. 248-252 (July 2013-Jan. 2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064479805"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 35, nos. 248-252 (July 2013-Jan. 2014)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064479805"
+                    ],
+                    "idBarcode": [
+                      "33433064479805"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 35,
+                        "lte": 35
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        35-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000035, nos. 248-252 (July 2013-Jan. 2014)"
+                  },
+                  "sort": [
+                    "        35-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 104
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31163863",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 35, nos. 238-242 (July 2012-Jan. 2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 35, nos. 238-242 (July 2012-Jan. 2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064468634"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 35, nos. 238-242 (July 2012-Jan. 2013)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064468634"
+                    ],
+                    "idBarcode": [
+                      "33433064468634"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 35,
+                        "lte": 35
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        35-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000035, nos. 238-242 (July 2012-Jan. 2013)"
+                  },
+                  "sort": [
+                    "        35-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 103
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31163859",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 34-35, nos. 233-237 (Feb.-June 2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 34-35, nos. 233-237 (Feb.-June 2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064468626"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 34-35, nos. 233-237 (Feb.-June 2012)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064468626"
+                    ],
+                    "idBarcode": [
+                      "33433064468626"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 34,
+                        "lte": 35
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        34-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000034-35, nos. 233-237 (Feb.-June 2012)"
+                  },
+                  "sort": [
+                    "        34-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 102
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31163856",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 34, nos. 228-232 (July 2011-Jan. 2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 34, nos. 228-232 (July 2011-Jan. 2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064468618"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 34, nos. 228-232 (July 2011-Jan. 2012)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064468618"
+                    ],
+                    "idBarcode": [
+                      "33433064468618"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 34,
+                        "lte": 34
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        34-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000034, nos. 228-232 (July 2011-Jan. 2012)"
+                  },
+                  "sort": [
+                    "        34-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 101
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27799041",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 33-34, nos. 223-227 (Feb.-June 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 33-34, nos. 223-227 (Feb.-June 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073091195"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 33-34, nos. 223-227 (Feb.-June 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073091195"
+                    ],
+                    "idBarcode": [
+                      "33433073091195"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 33,
+                        "lte": 34
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        33-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000033-34, nos. 223-227 (Feb.-June 2011)"
+                  },
+                  "sort": [
+                    "        33-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 100
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27799039",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 33, nos. 218-222 (July 2010-Jan. 2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 33, nos. 218-222 (July 2010-Jan. 2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073091187"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 33, nos. 218-222 (July 2010-Jan. 2011)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073091187"
+                    ],
+                    "idBarcode": [
+                      "33433073091187"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 33,
+                        "lte": 33
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        33-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000033, nos. 218-222 (July 2010-Jan. 2011)"
+                  },
+                  "sort": [
+                    "        33-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 99
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27799032",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 32-33, nos. 213-217 (Feb.-June 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 32-33, nos. 213-217 (Feb.-June 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073091179"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 32-33, nos. 213-217 (Feb.-June 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073091179"
+                    ],
+                    "idBarcode": [
+                      "33433073091179"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 32,
+                        "lte": 33
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        32-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000032-33, nos. 213-217 (Feb.-June 2010)"
+                  },
+                  "sort": [
+                    "        32-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 98
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27799021",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 32, nos. 208-212 (July 2009-Jan. 2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 32, nos. 208-212 (July 2009-Jan. 2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073091161"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 32, nos. 208-212 (July 2009-Jan. 2010)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073091161"
+                    ],
+                    "idBarcode": [
+                      "33433073091161"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 32,
+                        "lte": 32
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        32-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000032, nos. 208-212 (July 2009-Jan. 2010)"
+                  },
+                  "sort": [
+                    "        32-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 97
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i27799016",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 31-32, nos. 203-207 (Feb.-June 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 31-32, nos. 203-207 (Feb.-June 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073091153"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 31-32, nos. 203-207 (Feb.-June 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073091153"
+                    ],
+                    "idBarcode": [
+                      "33433073091153"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 31,
+                        "lte": 32
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        31-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000031-32, nos. 203-207 (Feb.-June 2009)"
+                  },
+                  "sort": [
+                    "        31-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 96
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23189798",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 31, nos. 198-202 (July 2008-Jan. 2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 31, nos. 198-202 (July 2008-Jan. 2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060824954"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 31, nos. 198-202 (July 2008-Jan. 2009)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060824954"
+                    ],
+                    "idBarcode": [
+                      "33433060824954"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 31,
+                        "lte": 31
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        31-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000031, nos. 198-202 (July 2008-Jan. 2009)"
+                  },
+                  "sort": [
+                    "        31-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 95
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23189797",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 30-31, nos. 193-197 (Feb.-June 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 30-31, nos. 193-197 (Feb.-June 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060824947"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 30-31, nos. 193-197 (Feb.-June 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060824947"
+                    ],
+                    "idBarcode": [
+                      "33433060824947"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 30,
+                        "lte": 31
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        30-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000030-31, nos. 193-197 (Feb.-June 2008)"
+                  },
+                  "sort": [
+                    "        30-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 94
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i23189796",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 30, nos. 188-192 (July 2007-Jan. 2008)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 30, nos. 188-192 (July 2007-Jan. 2008)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060824939"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 30, nos. 188-192 (July 2007-Jan. 2008)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060824939"
+                    ],
+                    "idBarcode": [
+                      "33433060824939"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 30,
+                        "lte": 30
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        30-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000030, nos. 188-192 (July 2007-Jan. 2008)"
+                  },
+                  "sort": [
+                    "        30-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 93
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447363",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 29-30, nos. 183-187 (Feb.-June 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 29-30, nos. 183-187 (Feb.-June 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073125142"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 29-30, nos. 183-187 (Feb.-June 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073125142"
+                    ],
+                    "idBarcode": [
+                      "33433073125142"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 29,
+                        "lte": 30
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        29-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000029-30, nos. 183-187 (Feb.-June 2007)"
+                  },
+                  "sort": [
+                    "        29-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 92
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17447362",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 29, nos. 176-182 (May 2006-Jan. 2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 29, nos. 176-182 (May 2006-Jan. 2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433073125134"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 29, nos. 176-182 (May 2006-Jan. 2007)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433073125134"
+                    ],
+                    "idBarcode": [
+                      "33433073125134"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 29,
+                        "lte": 29
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        29-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000029, nos. 176-182 (May 2006-Jan. 2007)"
+                  },
+                  "sort": [
+                    "        29-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 91
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16656929",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 28, nos. 171 - 175 (Nov. 2005 - Apr. 2006)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 28, nos. 171 - 175 (Nov. 2005 - Apr. 2006)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433075624647"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 28, nos. 171 - 175 (Nov. 2005 - Apr. 2006)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433075624647"
+                    ],
+                    "idBarcode": [
+                      "33433075624647"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 28,
+                        "lte": 28
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        28-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000028, nos. 171 - 175 (Nov. 2005 - Apr. 2006)"
+                  },
+                  "sort": [
+                    "        28-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 90
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16656930",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 28, nos. 166-170 (Mar. - Oct. 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 28, nos. 166-170 (Mar. - Oct. 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433075624639"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 28, nos. 166-170 (Mar. - Oct. 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433075624639"
+                    ],
+                    "idBarcode": [
+                      "33433075624639"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 28,
+                        "lte": 28
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        28-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000028, nos. 166-170 (Mar. - Oct. 2005)"
+                  },
+                  "sort": [
+                    "        28-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 89
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16656928",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 27, nos. 161-165 (Nov. 2004 - Apr. 2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 27, nos. 161-165 (Nov. 2004 - Apr. 2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064471539"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 27, nos. 161-165 (Nov. 2004 - Apr. 2005)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064471539"
+                    ],
+                    "idBarcode": [
+                      "33433064471539"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 27,
+                        "lte": 27
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        27-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000027, nos. 161-165 (Nov. 2004 - Apr. 2005)"
+                  },
+                  "sort": [
+                    "        27-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 88
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16656927",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 27, nos. 156-160 (May-Oct. 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 27, nos. 156-160 (May-Oct. 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064471521"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 27, nos. 156-160 (May-Oct. 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064471521"
+                    ],
+                    "idBarcode": [
+                      "33433064471521"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 27,
+                        "lte": 27
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        27-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000027, nos. 156-160 (May-Oct. 2004)"
+                  },
+                  "sort": [
+                    "        27-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 87
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747165",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 26, nos. 151-155 (Nov. 2003 - Apr. 2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 26, nos. 151-155 (Nov. 2003 - Apr. 2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064470564"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 26, nos. 151-155 (Nov. 2003 - Apr. 2004)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064470564"
+                    ],
+                    "idBarcode": [
+                      "33433064470564"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 26,
+                        "lte": 26
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        26-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000026, nos. 151-155 (Nov. 2003 - Apr. 2004)"
+                  },
+                  "sort": [
+                    "        26-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 86
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747164",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 26, nos. 146-150 (May-Oct. 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 26, nos. 146-150 (May-Oct. 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064470556"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 26, nos. 146-150 (May-Oct. 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064470556"
+                    ],
+                    "idBarcode": [
+                      "33433064470556"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 26,
+                        "lte": 26
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        26-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000026, nos. 146-150 (May-Oct. 2003)"
+                  },
+                  "sort": [
+                    "        26-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 85
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747163",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 v. 25, nos. 142-145 (Dec. 2002/Jan. 2003 - Apr. 2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 v. 25, nos. 142-145 (Dec. 2002/Jan. 2003 - Apr. 2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064470549"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 25, nos. 142-145 (Dec. 2002/Jan. 2003 - Apr. 2003)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064470549"
+                    ],
+                    "idBarcode": [
+                      "33433064470549"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 25,
+                        "lte": 25
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        25-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 v. 000025, nos. 142-145 (Dec. 2002/Jan. 2003 - Apr. 2003)"
+                  },
+                  "sort": [
+                    "        25-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 84
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747162",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Nos. 137-141 (June-Nov. 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Nos. 137-141 (June-Nov. 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064452521"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Nos. 137-141 (June-Nov. 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064452521"
+                    ],
+                    "idBarcode": [
+                      "33433064452521"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Nos. 137-141 (June-Nov. 2002)"
+                  },
+                  "sort": [
+                    "          -2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 83
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14747161",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Nos. 132-136 (Dec. 2001/Jan. 2002 - May 2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Nos. 132-136 (Dec. 2001/Jan. 2002 - May 2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433064452513"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Nos. 132-136 (Dec. 2001/Jan. 2002 - May 2002)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433064452513"
+                    ],
+                    "idBarcode": [
+                      "33433064452513"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Nos. 132-136 (Dec. 2001/Jan. 2002 - May 2002)"
+                  },
+                  "sort": [
+                    "          -2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 82
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785677",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Nos. 127-131 (June-Nov. 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Nos. 127-131 (June-Nov. 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022621332"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Nos. 127-131 (June-Nov. 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022621332"
+                    ],
+                    "idBarcode": [
+                      "33433022621332"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Nos. 127-131 (June-Nov. 2001)"
+                  },
+                  "sort": [
+                    "          -2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 81
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785676",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Nos. 122-126 (Dec. 2000 - May 2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Nos. 122-126 (Dec. 2000 - May 2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022621456"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Nos. 122-126 (Dec. 2000 - May 2001)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022621456"
+                    ],
+                    "idBarcode": [
+                      "33433022621456"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Nos. 122-126 (Dec. 2000 - May 2001)"
+                  },
+                  "sort": [
+                    "          -2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 80
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785674",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Nos. 116-121 (Feb.-Nov. 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Nos. 116-121 (Feb.-Nov. 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022619146"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Nos. 116-121 (Feb.-Nov. 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022619146"
+                    ],
+                    "idBarcode": [
+                      "33433022619146"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Nos. 116-121 (Feb.-Nov. 2000)"
+                  },
+                  "sort": [
+                    "          -2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 117
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i13785675",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-298 Nos. 111-115 (Apr. 1999 - Jan. 2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-298 Nos. 111-115 (Apr. 1999 - Jan. 2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022619021"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Nos. 111-115 (Apr. 1999 - Jan. 2000)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-298"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022619021"
+                    ],
+                    "idBarcode": [
+                      "33433022619021"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-298 Nos. 111-115 (Apr. 1999 - Jan. 2000)"
+                  },
+                  "sort": [
+                    "          -1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 55
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858884",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 1998"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 1998",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433022582096"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1998"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433022582096"
+                    ],
+                    "idBarcode": [
+                      "33433022582096"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1998",
+                        "lte": "1998"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1998"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 001998"
+                  },
+                  "sort": [
+                    "          -1998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 66
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858883",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-Dec. 1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-Dec. 1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654123"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-Dec. 1997"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654123"
+                    ],
+                    "idBarcode": [
+                      "33433018654123"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1997",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1997"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-Dec. 001997"
+                  },
+                  "sort": [
+                    "          -1997"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 74
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858881",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654362"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1996"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654362"
+                    ],
+                    "idBarcode": [
+                      "33433018654362"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001996"
+                  },
+                  "sort": [
+                    "          -1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 65
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858882",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1996 - Jan. 1997"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1996 - Jan. 1997",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654248"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1996 - Jan. 1997"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654248"
+                    ],
+                    "idBarcode": [
+                      "33433018654248"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1996 - Jan. 001997"
+                  },
+                  "sort": [
+                    "          -1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 73
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858879",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654602"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1995"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654602"
+                    ],
+                    "idBarcode": [
+                      "33433018654602"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001995"
+                  },
+                  "sort": [
+                    "          -1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 64
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858880",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1995 - Jan. 1996"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1995 - Jan. 1996",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654487"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1995 - Jan. 1996"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654487"
+                    ],
+                    "idBarcode": [
+                      "33433018654487"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1996"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1995 - Jan. 001996"
+                  },
+                  "sort": [
+                    "          -1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 72
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858877",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1994"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1994",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654230"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1994"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654230"
+                    ],
+                    "idBarcode": [
+                      "33433018654230"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001994"
+                  },
+                  "sort": [
+                    "          -1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 63
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858878",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1994 - Jan. 1995"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1994 - Jan. 1995",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654115"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1994 - Jan. 1995"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654115"
+                    ],
+                    "idBarcode": [
+                      "33433018654115"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1994 - Jan. 001995"
+                  },
+                  "sort": [
+                    "          -1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 71
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858875",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1993"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1993",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654479"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1993"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654479"
+                    ],
+                    "idBarcode": [
+                      "33433018654479"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1993",
+                        "lte": "1993"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1993"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001993"
+                  },
+                  "sort": [
+                    "          -1993"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 62
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858876",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1993 - Jan. 1994"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1993 - Jan. 1994",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654354"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1993 - Jan. 1994"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654354"
+                    ],
+                    "idBarcode": [
+                      "33433018654354"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1993",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1993"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1993 - Jan. 001994"
+                  },
+                  "sort": [
+                    "          -1993"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 70
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858873",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1992"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1992",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654107"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1992"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654107"
+                    ],
+                    "idBarcode": [
+                      "33433018654107"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1992",
+                        "lte": "1992"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1992"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001992"
+                  },
+                  "sort": [
+                    "          -1992"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 61
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858874",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1992 - Jan. 1993"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1992 - Jan. 1993",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654594"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1992 - Jan. 1993"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654594"
+                    ],
+                    "idBarcode": [
+                      "33433018654594"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1992",
+                        "lte": "1993"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1992"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1992 - Jan. 001993"
+                  },
+                  "sort": [
+                    "          -1992"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 69
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858871",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1991"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1991",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654347"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1991"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654347"
+                    ],
+                    "idBarcode": [
+                      "33433018654347"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1991",
+                        "lte": "1991"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1991"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001991"
+                  },
+                  "sort": [
+                    "          -1991"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 60
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858872",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1991 - Jan. 1992"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1991 - Jan. 1992",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654222"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1991 - Jan. 1992"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654222"
+                    ],
+                    "idBarcode": [
+                      "33433018654222"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1991",
+                        "lte": "1992"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1991"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1991 - Jan. 001992"
+                  },
+                  "sort": [
+                    "          -1991"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 68
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858869",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1990"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1990",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654586"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1990"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654586"
+                    ],
+                    "idBarcode": [
+                      "33433018654586"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1990",
+                        "lte": "1990"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1990"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001990"
+                  },
+                  "sort": [
+                    "          -1990"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 59
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858870",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1990 - Jan. 1991"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1990 - Jan. 1991",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654461"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1990 - Jan. 1991"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654461"
+                    ],
+                    "idBarcode": [
+                      "33433018654461"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1990",
+                        "lte": "1991"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1990"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1990 - Jan. 001991"
+                  },
+                  "sort": [
+                    "          -1990"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 57
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858868",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Apr. 1989 - Jan. 1990"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Apr. 1989 - Jan. 1990",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654099"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Apr. 1989 - Jan. 1990"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654099"
+                    ],
+                    "idBarcode": [
+                      "33433018654099"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1989",
+                        "lte": "1990"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1989"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Apr. 1989 - Jan. 001990"
+                  },
+                  "sort": [
+                    "          -1989"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 67
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858866",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Feb.-July 1988"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Feb.-July 1988",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654339"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Feb.-July 1988"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654339"
+                    ],
+                    "idBarcode": [
+                      "33433018654339"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1988",
+                        "lte": "1988"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1988"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Feb.-July 001988"
+                  },
+                  "sort": [
+                    "          -1988"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 58
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858867",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Aug. 1988 - Jan. 1989"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Aug. 1988 - Jan. 1989",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654214"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Aug. 1988 - Jan. 1989"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654214"
+                    ],
+                    "idBarcode": [
+                      "33433018654214"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1988",
+                        "lte": "1989"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1988"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Aug. 1988 - Jan. 001989"
+                  },
+                  "sort": [
+                    "          -1988"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 79
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858865",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Mar.-Dec. 1987"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Mar.-Dec. 1987",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654453"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Mar.-Dec. 1987"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654453"
+                    ],
+                    "idBarcode": [
+                      "33433018654453"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1987",
+                        "lte": "1987"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1987"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Mar.-Dec. 001987"
+                  },
+                  "sort": [
+                    "          -1987"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 78
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858864",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Mar.-Dec. 1986"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Mar.-Dec. 1986",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654578"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Mar.-Dec. 1986"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654578"
+                    ],
+                    "idBarcode": [
+                      "33433018654578"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1986",
+                        "lte": "1986"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1986"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Mar.-Dec. 001986"
+                  },
+                  "sort": [
+                    "          -1986"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 77
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858863",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Mar.-Dec. 1985"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Mar.-Dec. 1985",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654081"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Mar.-Dec. 1985"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654081"
+                    ],
+                    "idBarcode": [
+                      "33433018654081"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1985",
+                        "lte": "1985"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1985"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Mar.-Dec. 001985"
+                  },
+                  "sort": [
+                    "          -1985"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 76
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858862",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Mar.-Dec. 1984"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Mar.-Dec. 1984",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654206"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Mar.-Dec. 1984"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654206"
+                    ],
+                    "idBarcode": [
+                      "33433018654206"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1984",
+                        "lte": "1984"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1984"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Mar.-Dec. 001984"
+                  },
+                  "sort": [
+                    "          -1984"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 54
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858860",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 1983"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 1983",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654446"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1983"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654446"
+                    ],
+                    "idBarcode": [
+                      "33433018654446"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1983",
+                        "lte": "1983"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1983"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 001983"
+                  },
+                  "sort": [
+                    "          -1983"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 53
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858859",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 1982"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 1982",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654560"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1982"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654560"
+                    ],
+                    "idBarcode": [
+                      "33433018654560"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1982",
+                        "lte": "1982"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1982"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 001982"
+                  },
+                  "sort": [
+                    "          -1982"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 52
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858858",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 1981"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 1981",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654073"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1981"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654073"
+                    ],
+                    "idBarcode": [
+                      "33433018654073"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1981",
+                        "lte": "1981"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1981"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 001981"
+                  },
+                  "sort": [
+                    "          -1981"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 51
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858857",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 1980"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 1980",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654198"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1980"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654198"
+                    ],
+                    "idBarcode": [
+                      "33433018654198"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1980",
+                        "lte": "1980"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1980"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 001980"
+                  },
+                  "sort": [
+                    "          -1980"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 75
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858861",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 Index (1977-1983)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 Index (1977-1983)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654321"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "Index (1977-1983)"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654321"
+                    ],
+                    "idBarcode": [
+                      "33433018654321"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1977",
+                        "lte": "1983"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1977"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 Index (1977-1983)"
+                  },
+                  "sort": [
+                    "          -1977"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 56
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12858856",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1002",
+                        "label": "New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1002||New York Public Library for the Performing Arts, Dorothy and Lewis B. Cullman Center"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:myh32",
+                        "label": "Performing Arts Research Collections - Recorded Sound"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:myh32||Performing Arts Research Collections - Recorded Sound"
+                    ],
+                    "shelfMark": [
+                      "*LA 81-296 1977-1979"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "*LA 81-296 1977-1979",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433018654313"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "1977-1979"
+                    ],
+                    "physicalLocation": [
+                      "*LA 81-296"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433018654313"
+                    ],
+                    "idBarcode": [
+                      "33433018654313"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1977",
+                        "lte": "1979"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1977"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "a*LA 81-296 1977-001979"
+                  },
+                  "sort": [
+                    "          -1977"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010676",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title from cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Note",
+              "label": "At head of title: No 704. Sénat. Année 1919. Session ordinaire ...",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "World War, 1914-1918"
+          ],
+          "publisherLiteral": [
+            "Impr. du Sénat,"
+          ],
+          "language": [
+            {
+              "id": "lang:fre",
+              "label": "French"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1919
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Rapport de la Commission d'enquête sur les faits de la guerre [microform]."
+          ],
+          "shelfMark": [
+            "*Z-3990 no. 9"
+          ],
+          "creatorLiteral": [
+            "France. Commission d'enquête sur les faits de la guerre."
+          ],
+          "createdString": [
+            "1919"
+          ],
+          "dateStartYear": [
+            1919
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-3990 no. 9"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010676"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "WWIa"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01112568"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210652"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636125262067,
+          "publicationStatement": [
+            "Paris : Impr. du Sénat, 1919-"
+          ],
+          "identifier": [
+            "urn:bnum:10010676",
+            "urn:undefined:WWIa",
+            "urn:undefined:NNSZ01112568",
+            "urn:undefined:(WaOLN)nyp0210652"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1919"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "World War, 1914-1918."
+          ],
+          "titleDisplay": [
+            "Rapport de la Commission d'enquête sur les faits de la guerre [microform]."
+          ],
+          "uri": "b10010676",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Paris :"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "tableOfContents": [
+            "v.1. Mémoire sur les responsabilités de la guerre/établi ... par Émile Bourgeois et Georges Pagès."
+          ],
+          "dimensions": [
+            "26 cm."
+          ]
+        },
+        "sort": [
+          "b10010676"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433106577558"
+                    ],
+                    "physicalLocation": [
+                      "*Z-3990"
+                    ],
+                    "shelfMark_sort": "a*Z-3990 no. 000001-9",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i24076474",
+                    "shelfMark": [
+                      "*Z-3990 no. 1-9"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*Z-3990 no. 1-9"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433106577558"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-9"
+                    ],
+                    "idBarcode": [
+                      "33433106577558"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b10010704",
+        "_score": null,
+        "_source": {
+          "extent": [
+            "v."
+          ],
+          "note": [
+            {
+              "noteType": "Reproduction",
+              "label": "Microfilm.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "World War, 1914-1918",
+            "World War, 1914-1918 -- Schools",
+            "World War, 1914-1918 -- Women"
+          ],
+          "publisherLiteral": [
+            "Govt. Print. Off.,"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "createdYear": [
+            1918
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "War work of women in colleges [microform]"
+          ],
+          "shelfMark": [
+            "*Z-4016 no. 7"
+          ],
+          "creatorLiteral": [
+            "United States. Committee on Public Information."
+          ],
+          "createdString": [
+            "1918"
+          ],
+          "idLccn": [
+            "18026236"
+          ],
+          "dateStartYear": [
+            1918
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "*Z-4016 no. 7"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10010704"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "18026236"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "WWIa"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NNSZ01112597"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0210680"
+            }
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1636143142429,
+          "publicationStatement": [
+            "Washington, Govt. Print. Off., 1918-"
+          ],
+          "identifier": [
+            "urn:bnum:10010704",
+            "urn:lccn:18026236",
+            "urn:undefined:WWIa",
+            "urn:undefined:NNSZ01112597",
+            "urn:undefined:(WaOLN)nyp0210680"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1918"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "World War, 1914-1918 -- Schools.",
+            "World War, 1914-1918 -- Women."
+          ],
+          "titleDisplay": [
+            "War work of women in colleges [microform] issued by the Committee on Public Information ..."
+          ],
+          "uri": "b10010704",
+          "lccClassification": [
+            "D639.W7 U5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "Washington,"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "sort": [
+          "b10010704"
+        ],
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433106577871"
+                    ],
+                    "physicalLocation": [
+                      "*Z-4016"
+                    ],
+                    "shelfMark_sort": "a*Z-4016 no. 000001-14",
+                    "catalogItemType_packed": [
+                      "catalogItemType:6||microfilm service copy"
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "uri": "i30102337",
+                    "shelfMark": [
+                      "*Z-4016 no. 1-14"
+                    ],
+                    "identifierV2": [
+                      {
+                        "type": "bf:ShelfMark",
+                        "value": "*Z-4016 no. 1-14"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433106577871"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmi2||Offsite"
+                    ],
+                    "enumerationChronology": [
+                      "no. 1-14"
+                    ],
+                    "idBarcode": [
+                      "33433106577871"
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:6",
+                        "label": "microfilm service copy"
+                      }
+                    ],
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmi2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ]
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-f0b861cf37660e9b788d79bad4efea6e.json
+++ b/test/fixtures/query-f0b861cf37660e9b788d79bad4efea6e.json
@@ -1,0 +1,16925 @@
+{
+  "took": 1103,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 5,
+    "max_score": 55.690517,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b11826883",
+        "_score": 55.690517,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Indexed In",
+              "label": "Applied science & technology index",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Art index",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "R]pertoire international de la littérature de l'art",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Art and archaeology technical abstracts",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Artbibliographies modern",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Avery index to architectural periodicals",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexes/Finding Aids",
+              "label": "Vols. 1 (1965)-10 (1974). 1 v.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Vol. 1 (1965)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Furniture",
+            "Furniture -- England",
+            "Furniture -- England -- History",
+            "Furniture -- England -- History -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            69
+          ],
+          "publisherLiteral": [
+            "The Society"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            69
+          ],
+          "createdYear": [
+            1965
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Furniture history : the journal of the Furniture History Society."
+          ],
+          "shelfMark": [
+            "JQL 08-18"
+          ],
+          "numItemVolumesParsed": [
+            69
+          ],
+          "createdString": [
+            "1965"
+          ],
+          "idLccn": [
+            "66053650 //r89"
+          ],
+          "idIssn": [
+            "0016-3058"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Furniture History Society (London, England)"
+          ],
+          "dateStartYear": [
+            1965
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 08-18"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11826883"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0016-3058"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "66053650 //r89"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "1570335"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "0280126"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1832956"
+            }
+          ],
+          "idOclc": [
+            "1570335"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1(1965)-44(2008)-",
+                "v. 3636 (2000) - v. 45 (2000); v. 44 (2008); v. 45 (2009); v. 46 (2010); v. 47 (2011); v. 48 (2012); v. 49 (2013); v. 50 (2014); v. 55 (2019)"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "No. 30 (1994)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 31 (1995)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 32 (1996)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 33 (1997)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 34 (1998)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 35 (1999)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 26-35 (1990 - 1999)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 36 (2000)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 37 (2001)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 38 (2002)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 39 (2003)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 40 (2004)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 41 (2005)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 42 (2006)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 43 (2007)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 44 (2008)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 45 (2009)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 46 (2010)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 47 (2011)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 48 (2012)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 36-45 (2000 - 2009)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 49 (2013)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 50 (2014)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 51 (2015)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 52 (2016)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 53 (2017)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 54 (2018)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 55 (2019)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 56 (2020)",
+                  "position": "29",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 57 (2021)",
+                  "position": "30",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 58 (2022)",
+                  "position": "31",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-18"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "JQL 08-18"
+                }
+              ],
+              "physicalLocation": [
+                "JQL 08-18"
+              ],
+              "location": [
+                {
+                  "code": "loc:mab",
+                  "label": "Schwarzman Building - Art & Architecture Room 300"
+                }
+              ],
+              "uri": "h1066822",
+              "shelfMark": [
+                "JQL 08-18"
+              ]
+            }
+          ],
+          "updatedAt": 1678048106848,
+          "publicationStatement": [
+            "[London] : The Society"
+          ],
+          "identifier": [
+            "urn:bnum:11826883",
+            "urn:issn:0016-3058",
+            "urn:lccn:66053650 //r89",
+            "urn:oclc:1570335",
+            "urn:undefined:0280126",
+            "urn:undefined:(WaOLN)nyp1832956"
+          ],
+          "numCheckinCardItems": [
+            31
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1965"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Furniture -- England -- History -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Furniture history : the journal of the Furniture History Society."
+          ],
+          "uri": "b11826883",
+          "lccClassification": [
+            "NK2528 .F8"
+          ],
+          "numItems": [
+            38
+          ],
+          "numAvailable": [
+            63
+          ],
+          "placeOfPublication": [
+            "[London]"
+          ],
+          "titleAlt": [
+            "Furnit. hist.",
+            "Furniture history"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 38,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 68
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i39962833",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab",
+                        "label": "Schwarzman Building - Art & Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab||Schwarzman Building - Art & Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 58 (2022)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 58 (2022)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076543143"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 58 (2022)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076543143"
+                    ],
+                    "idBarcode": [
+                      "33433076543143"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 58,
+                        "lte": 58
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022",
+                        "lte": "2022"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        58-2022"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000058 (2022)"
+                  },
+                  "sort": [
+                    "        58-2022"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 67
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i39175596",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab",
+                        "label": "Schwarzman Building - Art & Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab||Schwarzman Building - Art & Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 57 (2021)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 57 (2021)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433072299997"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 57 (2021)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433072299997"
+                    ],
+                    "idBarcode": [
+                      "33433072299997"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 57,
+                        "lte": 57
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021",
+                        "lte": "2021"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        57-2021"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000057 (2021)"
+                  },
+                  "sort": [
+                    "        57-2021"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 66
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i38877467",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab",
+                        "label": "Schwarzman Building - Art & Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab||Schwarzman Building - Art & Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 56 (2020)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 56 (2020)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076529019"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 56 (2020)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076529019"
+                    ],
+                    "idBarcode": [
+                      "33433076529019"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 56,
+                        "lte": 56
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2020",
+                        "lte": "2020"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        56-2020"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000056 (2020)"
+                  },
+                  "sort": [
+                    "        56-2020"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 65
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i38877461",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab",
+                        "label": "Schwarzman Building - Art & Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab||Schwarzman Building - Art & Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 55 (2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 55 (2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433076528763"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 55 (2019)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433076528763"
+                    ],
+                    "idBarcode": [
+                      "33433076528763"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 55,
+                        "lte": 55
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2019",
+                        "lte": "2019"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        55-2019"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000055 (2019)"
+                  },
+                  "sort": [
+                    "        55-2019"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 64
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753906",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 54 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 54 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433083531677"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 54 (2018)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433083531677"
+                    ],
+                    "idBarcode": [
+                      "33433083531677"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 54,
+                        "lte": 54
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        54-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000054 (2018)"
+                  },
+                  "sort": [
+                    "        54-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 63
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36041027",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 53 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 53 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433086720046"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 53 (2017)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433086720046"
+                    ],
+                    "idBarcode": [
+                      "33433086720046"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 53,
+                        "lte": 53
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2017",
+                        "lte": "2017"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        53-2017"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000053 (2017)"
+                  },
+                  "sort": [
+                    "        53-2017"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 62
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33587281",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 51 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 51 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433069825366"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 51 (2015)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433069825366"
+                    ],
+                    "idBarcode": [
+                      "33433069825366"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 51,
+                        "lte": 51
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2015",
+                        "lte": "2015"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        51-2015"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000051 (2015)"
+                  },
+                  "sort": [
+                    "        51-2015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 61
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32204255",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 50 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 50 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433112607373"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 50 (2014)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433112607373"
+                    ],
+                    "idBarcode": [
+                      "33433112607373"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 50,
+                        "lte": 50
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        50-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000050 (2014)"
+                  },
+                  "sort": [
+                    "        50-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 60
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i31146937",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 49 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 49 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101062549"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 49 (2013)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101062549"
+                    ],
+                    "idBarcode": [
+                      "33433101062549"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 49,
+                        "lte": 49
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        49-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000049 (2013)"
+                  },
+                  "sort": [
+                    "        49-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 59
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30011841",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 48 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 48 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101084204"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 48 (2012)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101084204"
+                    ],
+                    "idBarcode": [
+                      "33433101084204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 48,
+                        "lte": 48
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        48-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000048 (2012)"
+                  },
+                  "sort": [
+                    "        48-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 58
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28878768",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 47 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 47 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101072555"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 47 (2011)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101072555"
+                    ],
+                    "idBarcode": [
+                      "33433101072555"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 47,
+                        "lte": 47
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        47-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000047 (2011)"
+                  },
+                  "sort": [
+                    "        47-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 57
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i26216680",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 46 (2010)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 46 (2010)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433088832484"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 46 (2010)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433088832484"
+                    ],
+                    "idBarcode": [
+                      "33433088832484"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 46,
+                        "lte": 46
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        46-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000046 (2010)"
+                  },
+                  "sort": [
+                    "        46-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 56
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29627803",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 44-45 (2008-2009)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 44-45 (2008-2009)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433084525736"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 44-45 (2008-2009)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433084525736"
+                    ],
+                    "idBarcode": [
+                      "33433084525736"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 44,
+                        "lte": 45
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        44-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000044-45 (2008-2009)"
+                  },
+                  "sort": [
+                    "        44-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 55
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29627528",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 42-43 (2006-2007)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 42-43 (2006-2007)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433102440397"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 42-43 (2006-2007)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433102440397"
+                    ],
+                    "idBarcode": [
+                      "33433102440397"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 42,
+                        "lte": 43
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        42-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000042-43 (2006-2007)"
+                  },
+                  "sort": [
+                    "        42-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 54
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29627525",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 40-41 (2004-2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 40-41 (2004-2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433102440389"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 40-41 (2004-2005)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433102440389"
+                    ],
+                    "idBarcode": [
+                      "33433102440389"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 40,
+                        "lte": 41
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        40-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000040-41 (2004-2005)"
+                  },
+                  "sort": [
+                    "        40-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 53
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753905",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 38-39 (2002-2003)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 38-39 (2002-2003)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272329"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 38-39 (2002-2003)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272329"
+                    ],
+                    "idBarcode": [
+                      "33433078272329"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 38,
+                        "lte": 39
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        38-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000038-39 (2002-2003)"
+                  },
+                  "sort": [
+                    "        38-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 52
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30011859",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 36-45 (2000-2009) + index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 36-45 (2000-2009) + index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101083917"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 36-45 (2000-2009) + index"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101083917"
+                    ],
+                    "idBarcode": [
+                      "33433101083917"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 36,
+                        "lte": 45
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        36-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000036-45 (2000-2009) + index"
+                  },
+                  "sort": [
+                    "        36-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 51
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753904",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 35-37 (1999-2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 35-37 (1999-2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272311"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 35-37 (1999-2001)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272311"
+                    ],
+                    "idBarcode": [
+                      "33433078272311"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 35,
+                        "lte": 37
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1999",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        35-1999"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000035-37 (1999-2001)"
+                  },
+                  "sort": [
+                    "        35-1999"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 50
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753903",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 32-34 (1996-1998)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 32-34 (1996-1998)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272303"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 32-34 (1996-1998)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272303"
+                    ],
+                    "idBarcode": [
+                      "33433078272303"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 32,
+                        "lte": 34
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1996",
+                        "lte": "1998"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        32-1996"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000032-34 (1996-1998)"
+                  },
+                  "sort": [
+                    "        32-1996"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 49
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753902",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 31 (1995)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 31 (1995)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272295"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 31 (1995)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272295"
+                    ],
+                    "idBarcode": [
+                      "33433078272295"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 31,
+                        "lte": 31
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1995"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        31-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000031 (1995)"
+                  },
+                  "sort": [
+                    "        31-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 48
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753901",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 30 (1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 30 (1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272287"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 30 (1994)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272287"
+                    ],
+                    "idBarcode": [
+                      "33433078272287"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 30,
+                        "lte": 30
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        30-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000030 (1994)"
+                  },
+                  "sort": [
+                    "        30-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 47
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753900",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 29 (1993)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 29 (1993)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272279"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 29 (1993)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272279"
+                    ],
+                    "idBarcode": [
+                      "33433078272279"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 29,
+                        "lte": 29
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1993",
+                        "lte": "1993"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        29-1993"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000029 (1993)"
+                  },
+                  "sort": [
+                    "        29-1993"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 46
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753899",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 28 (1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 28 (1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272261"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 28 (1992)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272261"
+                    ],
+                    "idBarcode": [
+                      "33433078272261"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 28,
+                        "lte": 28
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1992",
+                        "lte": "1992"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        28-1992"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000028 (1992)"
+                  },
+                  "sort": [
+                    "        28-1992"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 45
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753898",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 27 (1991)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 27 (1991)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272253"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 27 (1991)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272253"
+                    ],
+                    "idBarcode": [
+                      "33433078272253"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 27,
+                        "lte": 27
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1991",
+                        "lte": "1991"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        27-1991"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000027 (1991)"
+                  },
+                  "sort": [
+                    "        27-1991"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 43
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753896",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 23-24 (1987-1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 23-24 (1987-1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272238"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 23-24 (1987-1988)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272238"
+                    ],
+                    "idBarcode": [
+                      "33433078272238"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 23,
+                        "lte": 24
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1987",
+                        "lte": "1988"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        23-1987"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000023-24 (1987-1988)"
+                  },
+                  "sort": [
+                    "        23-1987"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 42
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753895",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 21-22 (1985-1986)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 21-22 (1985-1986)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272220"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 21-22 (1985-1986)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272220"
+                    ],
+                    "idBarcode": [
+                      "33433078272220"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 21,
+                        "lte": 22
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1985",
+                        "lte": "1986"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        21-1985"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000021-22 (1985-1986)"
+                  },
+                  "sort": [
+                    "        21-1985"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 41
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753894",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 19-20 (1983-1984)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 19-20 (1983-1984)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272212"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 19-20 (1983-1984)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272212"
+                    ],
+                    "idBarcode": [
+                      "33433078272212"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 19,
+                        "lte": 20
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1983",
+                        "lte": "1984"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        19-1983"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000019-20 (1983-1984)"
+                  },
+                  "sort": [
+                    "        19-1983"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 40
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753893",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 18 (1982)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 18 (1982)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272204"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 18 (1982)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272204"
+                    ],
+                    "idBarcode": [
+                      "33433078272204"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 18,
+                        "lte": 18
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1982",
+                        "lte": "1982"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        18-1982"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000018 (1982)"
+                  },
+                  "sort": [
+                    "        18-1982"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 44
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753897",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 25-26 (1989-90) + Index v. 16-25 (1980-90)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 25-26 (1989-90) + Index v. 16-25 (1980-90)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272246"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 25-26 (1989-90) + Index v. 16-25 (1980-90)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272246"
+                    ],
+                    "idBarcode": [
+                      "33433078272246"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 25,
+                        "lte": 26
+                      },
+                      {
+                        "gte": 16,
+                        "lte": 25
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1989",
+                        "lte": "1990"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        16-1989"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000025-26 (1989-90) + Index v. 16-25 (1980-90)"
+                  },
+                  "sort": [
+                    "        16-1989"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 39
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753892",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 16-17 (1980-1981)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 16-17 (1980-1981)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272196"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 16-17 (1980-1981)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272196"
+                    ],
+                    "idBarcode": [
+                      "33433078272196"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 16,
+                        "lte": 17
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1980",
+                        "lte": "1981"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        16-1980"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000016-17 (1980-1981)"
+                  },
+                  "sort": [
+                    "        16-1980"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 38
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753891",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 14-15 (1978-1979)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 14-15 (1978-1979)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272188"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 14-15 (1978-1979)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272188"
+                    ],
+                    "idBarcode": [
+                      "33433078272188"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 14,
+                        "lte": 15
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1978",
+                        "lte": "1979"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        14-1978"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000014-15 (1978-1979)"
+                  },
+                  "sort": [
+                    "        14-1978"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 37
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753890",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 13 (1977)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 13 (1977)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272170"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 13 (1977)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272170"
+                    ],
+                    "idBarcode": [
+                      "33433078272170"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 13,
+                        "lte": 13
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1977",
+                        "lte": "1977"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        13-1977"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000013 (1977)"
+                  },
+                  "sort": [
+                    "        13-1977"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 36
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753889",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 11-12 (1975-1976)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 11-12 (1975-1976)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272162"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 11-12 (1975-1976)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272162"
+                    ],
+                    "idBarcode": [
+                      "33433078272162"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 11,
+                        "lte": 12
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1975",
+                        "lte": "1976"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        11-1975"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000011-12 (1975-1976)"
+                  },
+                  "sort": [
+                    "        11-1975"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 34
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753887",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 8-9 (1972-1973)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 8-9 (1972-1973)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272147"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 8-9 (1972-1973)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272147"
+                    ],
+                    "idBarcode": [
+                      "33433078272147"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 8,
+                        "lte": 9
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1972",
+                        "lte": "1973"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         8-1972"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000008-9 (1972-1973)"
+                  },
+                  "sort": [
+                    "         8-1972"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 33
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753886",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 7 (1971)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 7 (1971)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272139"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 7 (1971)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272139"
+                    ],
+                    "idBarcode": [
+                      "33433078272139"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 7,
+                        "lte": 7
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1971",
+                        "lte": "1971"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         7-1971"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000007 (1971)"
+                  },
+                  "sort": [
+                    "         7-1971"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 32
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753885",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 5-6 (1969-1970)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 5-6 (1969-1970)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272121"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 5-6 (1969-1970)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272121"
+                    ],
+                    "idBarcode": [
+                      "33433078272121"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 6
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1969",
+                        "lte": "1970"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-1969"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000005-6 (1969-1970)"
+                  },
+                  "sort": [
+                    "         5-1969"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 35
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753888",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 10 (1974) + Index v. 1-10"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 10 (1974) + Index v. 1-10",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272154"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 10 (1974) + Index v. 1-10"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272154"
+                    ],
+                    "idBarcode": [
+                      "33433078272154"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 10,
+                        "lte": 10
+                      },
+                      {
+                        "gte": 1,
+                        "lte": 10
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1974",
+                        "lte": "1974"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-1974"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000010 (1974) + Index v. 1-10"
+                  },
+                  "sort": [
+                    "         1-1974"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 31
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i16753884",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-18 v. 1-4 (1965-1968)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-18 v. 1-4 (1965-1968)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433078272113"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-4 (1965-1968)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-18"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433078272113"
+                    ],
+                    "idBarcode": [
+                      "33433078272113"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 4
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1965",
+                        "lte": "1968"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-1965"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-18 v. 000001-4 (1965-1968)"
+                  },
+                  "sort": [
+                    "         1-1965"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b21506221",
+        "_score": 16.541245,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"A magazine of art, design and architecture.\"",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Description based on: Issue 01 (2007/08); title from cover.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Source of Description",
+              "label": "Latest issue consulted: Issue 01 (2007/08)",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Issue 01 (2007-08)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Art",
+            "Art -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Faculty of Art, Design and Architecture, Kingston University"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            2007
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Kiosk."
+          ],
+          "shelfMark": [
+            "JQL 18-4"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "2007"
+          ],
+          "idIssn": [
+            "1755-9626"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Kingston University (London, England). Faculty of Art, Design and Architecture."
+          ],
+          "dateStartYear": [
+            2007
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 18-4"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "21506221"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "1755-9626"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "190792176"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "190792176"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)190792176"
+            }
+          ],
+          "idOclc": [
+            "190792176"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "updatedAt": 1671766334241,
+          "publicationStatement": [
+            "London : Faculty of Art, Design and Architecture, Kingston University, 2007-"
+          ],
+          "identifier": [
+            "urn:bnum:21506221",
+            "urn:issn:1755-9626",
+            "urn:oclc:190792176",
+            "urn:undefined:(OCoLC)190792176"
+          ],
+          "genreForm": [
+            "Periodicals."
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "2007"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Art -- Periodicals.",
+            "Art."
+          ],
+          "titleDisplay": [
+            "Kiosk."
+          ],
+          "uri": "b21506221",
+          "lccClassification": [
+            "N1 .K56"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "23 cm"
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i35913145",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 18-4 issue 1 (2007/08)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 18-4 issue 1 (2007/08)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433116522354"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "issue 1 (2007/08)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 18-4"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433116522354"
+                    ],
+                    "idBarcode": [
+                      "33433116522354"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 18-4 issue 1 (2007/08)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b16775643",
+        "_score": 16.413342,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Title from cover.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "No. 16 (fall 1982)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Art",
+            "Art -- Research",
+            "Art -- Research -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            10
+          ],
+          "publisherLiteral": [
+            "University of Illinois Press"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            10
+          ],
+          "createdYear": [
+            1982
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Visual arts research."
+          ],
+          "shelfMark": [
+            "JQL 08-3"
+          ],
+          "numItemVolumesParsed": [
+            2
+          ],
+          "createdString": [
+            "1982"
+          ],
+          "idLccn": [
+            "83644328 "
+          ],
+          "idIssn": [
+            "0736-0770"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1982
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 08-3"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "16775643"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0736-0770"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "83644328 "
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "9069635"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "9069635"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)9069635"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)S240000007"
+            },
+            {
+              "type": "bf:Issn",
+              "identifierStatus": "incorrect",
+              "value": "0160-3221"
+            }
+          ],
+          "idOclc": [
+            "9069635"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "9(1983)-27(2001)-"
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "JQL 08-3"
+                }
+              ],
+              "physicalLocation": [
+                "JQL 08-3"
+              ],
+              "location": [
+                {
+                  "code": "loc:mab82",
+                  "label": "Schwarzman Building M1 - Art & Architecture Room 300"
+                }
+              ],
+              "uri": "h1090282",
+              "shelfMark": [
+                "JQL 08-3"
+              ]
+            }
+          ],
+          "updatedAt": 1675273126903,
+          "publicationStatement": [
+            "[Champaign, Ill.] : University of Illinois Press, c1982-"
+          ],
+          "identifier": [
+            "urn:bnum:16775643",
+            "urn:issn:0736-0770",
+            "urn:lccn:83644328 ",
+            "urn:oclc:9069635",
+            "urn:undefined:(OCoLC)9069635",
+            "urn:undefined:(WaOLN)S240000007",
+            "b16775643#1.0001",
+            "urn:issn:0160-3221"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1982"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Art -- Research -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Visual arts research."
+          ],
+          "uri": "b16775643",
+          "lccClassification": [
+            "N81 .R49"
+          ],
+          "numItems": [
+            10
+          ],
+          "numAvailable": [
+            10
+          ],
+          "placeOfPublication": [
+            "[Champaign, Ill.]"
+          ],
+          "titleAlt": [
+            "Vis. arts res.",
+            "Visual arts research"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "23 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 10,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 9
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29405160",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 v. 38, no. 1, Issue 74 (Sum. 2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 v. 38, no. 1, Issue 74 (Sum. 2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433115147914"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 38, no. 1, Issue 74 (Sum. 2012)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433115147914"
+                    ],
+                    "idBarcode": [
+                      "33433115147914"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 38,
+                        "lte": 38
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        38-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 v. 000038, no. 1, Issue 74 (Sum. 2012)"
+                  },
+                  "sort": [
+                    "        38-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 8
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i29627807",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 v. 15-16 (1989-90)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 v. 15-16 (1989-90)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105255586"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 15-16 (1989-90)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105255586"
+                    ],
+                    "idBarcode": [
+                      "33433105255586"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 15,
+                        "lte": 16
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1989",
+                        "lte": "1990"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        15-1989"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 v. 000015-16 (1989-90)"
+                  },
+                  "sort": [
+                    "        15-1989"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 6
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662016",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 26-27 (2000-2001)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 26-27 (2000-2001)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083142"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "26-27 (2000-2001)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083142"
+                    ],
+                    "idBarcode": [
+                      "33433074083142"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 26-27 (2000-2001)"
+                  },
+                  "sort": [
+                    "          -2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 5
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662015",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 24-25 (1998-1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 24-25 (1998-1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083191"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "24-25 (1998-1999)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083191"
+                    ],
+                    "idBarcode": [
+                      "33433074083191"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1998",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1998"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 24-25 (1998-1999)"
+                  },
+                  "sort": [
+                    "          -1998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 4
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662014",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 21-23 (1995-1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 21-23 (1995-1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083217"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "21-23 (1995-1997)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083217"
+                    ],
+                    "idBarcode": [
+                      "33433074083217"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 21-23 (1995-1997)"
+                  },
+                  "sort": [
+                    "          -1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 3
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662013",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 19-20 (1993-1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 19-20 (1993-1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083209"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "19-20 (1993-1994)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083209"
+                    ],
+                    "idBarcode": [
+                      "33433074083209"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1993",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1993"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 19-20 (1993-1994)"
+                  },
+                  "sort": [
+                    "          -1993"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 2
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662012",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 17-18 (1991-1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 17-18 (1991-1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083225"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "17-18 (1991-1992)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083225"
+                    ],
+                    "idBarcode": [
+                      "33433074083225"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1991",
+                        "lte": "1992"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1991"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 17-18 (1991-1992)"
+                  },
+                  "sort": [
+                    "          -1991"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 1
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662011",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 13-14 (1987-1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 13-14 (1987-1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083175"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "13-14 (1987-1988)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083175"
+                    ],
+                    "idBarcode": [
+                      "33433074083175"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1987",
+                        "lte": "1988"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1987"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 13-14 (1987-1988)"
+                  },
+                  "sort": [
+                    "          -1987"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662010",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 11-12 (1985-1986)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 11-12 (1985-1986)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083159"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "11-12 (1985-1986)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083159"
+                    ],
+                    "idBarcode": [
+                      "33433074083159"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1985",
+                        "lte": "1986"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1985"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 11-12 (1985-1986)"
+                  },
+                  "sort": [
+                    "          -1985"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 7
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17662009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-3 9-10 (1983-1984)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-3 9-10 (1983-1984)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433074083183"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "9-10 (1983-1984)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-3"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433074083183"
+                    ],
+                    "idBarcode": [
+                      "33433074083183"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1983",
+                        "lte": "1984"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "          -1983"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-3 9-10 (1983-1984)"
+                  },
+                  "sort": [
+                    "          -1983"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b11560439",
+        "_score": 13.703643,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Indexed In",
+              "label": "Art index",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "RILA. Répertoire international de la littérature de l'art",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "Avery index to architectural periodicals. Second edition. Revised and enlarged. Supplement",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Language",
+              "label": "Summaries in English.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "1. jaarg., nr. 1/2 (1953)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Rijksmuseum (Netherlands)",
+            "Rijksmuseum (Netherlands) -- Periodicals",
+            "Art",
+            "Art -- Periodicals",
+            "Art -- Amsterdam",
+            "Art -- Amsterdam -- Periodicals"
+          ],
+          "numItemDatesParsed": [
+            90
+          ],
+          "publisherLiteral": [
+            "Rijks-Museum"
+          ],
+          "language": [
+            {
+              "id": "lang:dut",
+              "label": "Dutch"
+            }
+          ],
+          "numItemsTotal": [
+            90
+          ],
+          "createdYear": [
+            1953
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bulletin."
+          ],
+          "shelfMark": [
+            "JQL 08-19"
+          ],
+          "numItemVolumesParsed": [
+            90
+          ],
+          "createdString": [
+            "1953"
+          ],
+          "idLccn": [
+            "sn 86000271"
+          ],
+          "idIssn": [
+            "0165-9510"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1953
+          ],
+          "donor": [
+            "Gift of the DeWitt Wallace Endowment Fund, named in honor of the founder of Reader's Digest"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 08-19"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "11560439"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0165-9510"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "sn 86000271"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "4272788"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "4272788"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG92-S1332"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp1568914"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(OCoLC)4272788"
+            }
+          ],
+          "idOclc": [
+            "4272788",
+            "NYPG92-S1332"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1(1953)-65(2017), 66:2(2018)-67:3(2019),68:1(2020)-68:2(2020)-",
+                "v. 66, no. 1 (2018); v. 66, no. 4 (2018) - v. 67, no. 3 (2019); v. 68, no. 1 (2020) - no. 3 (2020); v. 69, no. 3 (2021); v. 70, no. 2 (2022) - no. 3 (2022)"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "Vol. 66 No. 1 (2018)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 66 No. 2 (2018)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 66 No. 3 (2018)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 66 No. 4 (2018)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 67 No. 1 (2019)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 67 No. 2 (2019)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 67 No. 3 (2019)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 67 No. 4 (2019)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 68 No. 1 (2020)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 68 No. 2 (2020)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 68 No. 3 (2020)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 68 No. 4 (2020)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 69 No. 1 (2021)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 69 No. 2 (2021)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 69 No. 3 (2021)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 69 No. 4 (2021)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 70 No. 1 (2022)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "Vol. 70 No. 2 (2022)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "Vol. 70 No. 3 (2022)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-19"
+                  ],
+                  "status": "Arrived"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "JQL 08-19"
+                }
+              ],
+              "physicalLocation": [
+                "JQL 08-19"
+              ],
+              "format": [
+                "PRINT"
+              ],
+              "location": [
+                {
+                  "code": "loc:rcmb2",
+                  "label": "Offsite"
+                }
+              ],
+              "uri": "h1059577",
+              "shelfMark": [
+                "JQL 08-19"
+              ]
+            }
+          ],
+          "updatedAt": 1677204627427,
+          "publicationStatement": [
+            "Amsterdam : Rijks-Museum, 1953-"
+          ],
+          "identifier": [
+            "urn:bnum:11560439",
+            "urn:issn:0165-9510",
+            "urn:lccn:sn 86000271",
+            "urn:oclc:4272788",
+            "urn:oclc:NYPG92-S1332",
+            "urn:undefined:(WaOLN)nyp1568914",
+            "urn:undefined:(OCoLC)4272788"
+          ],
+          "numCheckinCardItems": [
+            19
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1953"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rijksmuseum (Netherlands) -- Periodicals.",
+            "Art -- Periodicals.",
+            "Art -- Amsterdam -- Periodicals."
+          ],
+          "titleDisplay": [
+            "Bulletin."
+          ],
+          "uri": "b11560439",
+          "lccClassification": [
+            "N2460 .A3"
+          ],
+          "numItems": [
+            71
+          ],
+          "numAvailable": [
+            83
+          ],
+          "placeOfPublication": [
+            "Amsterdam"
+          ],
+          "titleAlt": [
+            "Bull. Rÿksmus.",
+            "Bulletin Mauritshuis",
+            "Bulletin van het Rijksmuseum"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "24 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 71,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 89
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i39951329",
+                    "status": [
+                      {
+                        "id": "status:b",
+                        "label": "New-in process"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:b||New-in process"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 70 no. 3 (2022)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 70 no. 3 (2022)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433133816284"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 no. 3 (2022)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433133816284"
+                    ],
+                    "idBarcode": [
+                      "33433133816284"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022",
+                        "lte": "2022"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-2022"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000070 no. 3 (2022)"
+                  },
+                  "sort": [
+                    "        70-2022"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 88
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i39914205",
+                    "status": [
+                      {
+                        "id": "status:b",
+                        "label": "New-in process"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:b||New-in process"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 70 no. 2 (2022)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 70 no. 2 (2022)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433133814750"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 70 no. 2 (2022)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433133814750"
+                    ],
+                    "idBarcode": [
+                      "33433133814750"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 70,
+                        "lte": 70
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2022",
+                        "lte": "2022"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        70-2022"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000070 no. 2 (2022)"
+                  },
+                  "sort": [
+                    "        70-2022"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 87
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i39094674",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 69 no. 3 (2021)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 69 no. 3 (2021)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433132312749"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 69 no. 3 (2021)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433132312749"
+                    ],
+                    "idBarcode": [
+                      "33433132312749"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 69,
+                        "lte": 69
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2021",
+                        "lte": "2021"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        69-2021"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000069 no. 3 (2021)"
+                  },
+                  "sort": [
+                    "        69-2021"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 86
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i38109693",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 68, no. 2 (2020)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 68, no. 2 (2020)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128589565"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 68, no. 2 (2020)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128589565"
+                    ],
+                    "idBarcode": [
+                      "33433128589565"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 68,
+                        "lte": 68
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2020",
+                        "lte": "2020"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        68-2020"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000068, no. 2 (2020)"
+                  },
+                  "sort": [
+                    "        68-2020"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 85
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i39094662",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 68 no. 3 (2020)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 68 no. 3 (2020)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433132313184"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 68 no. 3 (2020)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433132313184"
+                    ],
+                    "idBarcode": [
+                      "33433132313184"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 68,
+                        "lte": 68
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2020",
+                        "lte": "2020"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        68-2020"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000068 no. 3 (2020)"
+                  },
+                  "sort": [
+                    "        68-2020"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 84
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37528681",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 67, no. 3 (2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 67, no. 3 (2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433128509571"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 67, no. 3 (2019)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433128509571"
+                    ],
+                    "idBarcode": [
+                      "33433128509571"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 67,
+                        "lte": 67
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2019",
+                        "lte": "2019"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        67-2019"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000067, no. 3 (2019)"
+                  },
+                  "sort": [
+                    "        67-2019"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 83
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37379200",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 67, no. 2 (2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 67, no. 2 (2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121962835"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 67, no. 2 (2019)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121962835"
+                    ],
+                    "idBarcode": [
+                      "33433121962835"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 67,
+                        "lte": 67
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2019",
+                        "lte": "2019"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        67-2019"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000067, no. 2 (2019)"
+                  },
+                  "sort": [
+                    "        67-2019"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 82
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37012009",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 67 no. 1 (2019)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 67 no. 1 (2019)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121711620"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 67 no. 1 (2019)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121711620"
+                    ],
+                    "idBarcode": [
+                      "33433121711620"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 67,
+                        "lte": 67
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2019",
+                        "lte": "2019"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        67-2019"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000067 no. 1 (2019)"
+                  },
+                  "sort": [
+                    "        67-2019"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 81
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587547",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 66, no. 3 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 66, no. 3 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433122611373"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 66, no. 3 (2018)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NH"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433122611373"
+                    ],
+                    "idBarcode": [
+                      "33433122611373"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 66,
+                        "lte": 66
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        66-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000066, no. 3 (2018)"
+                  },
+                  "sort": [
+                    "        66-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 80
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587546",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 66, no. 2  (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 66, no. 2  (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433122611381"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 66, no. 2  (2018)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NH"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433122611381"
+                    ],
+                    "idBarcode": [
+                      "33433122611381"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 66,
+                        "lte": 66
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        66-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000066, no. 2 (2018)"
+                  },
+                  "sort": [
+                    "        66-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 79
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36785774",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 66 no. 4 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 66 no. 4 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121696201"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 66 no. 4 (2018)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121696201"
+                    ],
+                    "idBarcode": [
+                      "33433121696201"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 66,
+                        "lte": 66
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        66-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000066 no. 4 (2018)"
+                  },
+                  "sort": [
+                    "        66-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 78
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36842152",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 66 no. 1 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 66 no. 1 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121700144"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 66 no. 1 (2018)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121700144"
+                    ],
+                    "idBarcode": [
+                      "33433121700144"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 66,
+                        "lte": 66
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        66-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000066 no. 1 (2018)"
+                  },
+                  "sort": [
+                    "        66-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 77
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809132",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 65, no. 4 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 65, no. 4 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938576"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 65, no. 4 (2017)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938576"
+                    ],
+                    "idBarcode": [
+                      "33433124938576"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 65,
+                        "lte": 65
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2017",
+                        "lte": "2017"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        65-2017"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000065, no. 4 (2017)"
+                  },
+                  "sort": [
+                    "        65-2017"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 76
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809128",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 65, no. 3 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 65, no. 3 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938584"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 65, no. 3 (2017)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938584"
+                    ],
+                    "idBarcode": [
+                      "33433124938584"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 65,
+                        "lte": 65
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2017",
+                        "lte": "2017"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        65-2017"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000065, no. 3 (2017)"
+                  },
+                  "sort": [
+                    "        65-2017"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 75
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809126",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 65, no. 2 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 65, no. 2 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938592"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 65, no. 2 (2017)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938592"
+                    ],
+                    "idBarcode": [
+                      "33433124938592"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 65,
+                        "lte": 65
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2017",
+                        "lte": "2017"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        65-2017"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000065, no. 2 (2017)"
+                  },
+                  "sort": [
+                    "        65-2017"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 74
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587336",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 65, no. 1 (2017)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 65, no. 1 (2017)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124930862"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 65, no. 1 (2017)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124930862"
+                    ],
+                    "idBarcode": [
+                      "33433124930862"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 65,
+                        "lte": 65
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2017",
+                        "lte": "2017"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        65-2017"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000065, no. 1 (2017)"
+                  },
+                  "sort": [
+                    "        65-2017"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 73
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809123",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 64, no. 4 (2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 64, no. 4 (2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938527"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 64, no. 4 (2016)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938527"
+                    ],
+                    "idBarcode": [
+                      "33433124938527"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 64,
+                        "lte": 64
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        64-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000064, no. 4 (2016)"
+                  },
+                  "sort": [
+                    "        64-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 72
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809121",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 64, no. 3 (2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 64, no. 3 (2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938519"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 64, no. 3 (2016)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938519"
+                    ],
+                    "idBarcode": [
+                      "33433124938519"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 64,
+                        "lte": 64
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        64-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000064, no. 3 (2016)"
+                  },
+                  "sort": [
+                    "        64-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 71
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809120",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 64, no. 2 (2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 64, no. 2 (2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938501"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 64, no. 2 (2016)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938501"
+                    ],
+                    "idBarcode": [
+                      "33433124938501"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 64,
+                        "lte": 64
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        64-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000064, no. 2 (2016)"
+                  },
+                  "sort": [
+                    "        64-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 70
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809118",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 64, no. 1 (2016)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 64, no. 1 (2016)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938493"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 64, no. 1 (2016)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938493"
+                    ],
+                    "idBarcode": [
+                      "33433124938493"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 64,
+                        "lte": 64
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2016",
+                        "lte": "2016"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        64-2016"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000064, no. 1 (2016)"
+                  },
+                  "sort": [
+                    "        64-2016"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 69
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809115",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 63, no. 4 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 63, no. 4 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938535"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 63, no. 4 (2015)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938535"
+                    ],
+                    "idBarcode": [
+                      "33433124938535"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 63,
+                        "lte": 63
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2015",
+                        "lte": "2015"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        63-2015"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000063, no. 4 (2015)"
+                  },
+                  "sort": [
+                    "        63-2015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 68
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809112",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 63, no. 3 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 63, no. 3 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938543"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 63, no. 3 (2015)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938543"
+                    ],
+                    "idBarcode": [
+                      "33433124938543"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 63,
+                        "lte": 63
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2015",
+                        "lte": "2015"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        63-2015"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000063, no. 3 (2015)"
+                  },
+                  "sort": [
+                    "        63-2015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 67
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809110",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 63, no. 2 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 63, no. 2 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938550"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 63, no. 2 (2015)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938550"
+                    ],
+                    "idBarcode": [
+                      "33433124938550"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 63,
+                        "lte": 63
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2015",
+                        "lte": "2015"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        63-2015"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000063, no. 2 (2015)"
+                  },
+                  "sort": [
+                    "        63-2015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 66
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809109",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 63, no. 1 (2015)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 63, no. 1 (2015)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938568"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 63, no. 1 (2015)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938568"
+                    ],
+                    "idBarcode": [
+                      "33433124938568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 63,
+                        "lte": 63
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2015",
+                        "lte": "2015"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        63-2015"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000063, no. 1 (2015)"
+                  },
+                  "sort": [
+                    "        63-2015"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 65
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809106",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 62, no. 4 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 62, no. 4 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938485"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 62, no. 4 (2014)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938485"
+                    ],
+                    "idBarcode": [
+                      "33433124938485"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 62,
+                        "lte": 62
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        62-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000062, no. 4 (2014)"
+                  },
+                  "sort": [
+                    "        62-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 64
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809104",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 62, no. 3 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 62, no. 3 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938477"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 62, no. 3 (2014)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938477"
+                    ],
+                    "idBarcode": [
+                      "33433124938477"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 62,
+                        "lte": 62
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        62-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000062, no. 3 (2014)"
+                  },
+                  "sort": [
+                    "        62-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 63
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809103",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 62, no. 2 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 62, no. 2 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938469"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 62, no. 2 (2014)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938469"
+                    ],
+                    "idBarcode": [
+                      "33433124938469"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 62,
+                        "lte": 62
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        62-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000062, no. 2 (2014)"
+                  },
+                  "sort": [
+                    "        62-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 62
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587273",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 62, no. 1 (2014) "
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 62, no. 1 (2014) ",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124930854"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 62, no. 1 (2014) "
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124930854"
+                    ],
+                    "idBarcode": [
+                      "33433124930854"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 62,
+                        "lte": 62
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        62-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000062, no. 1 (2014) "
+                  },
+                  "sort": [
+                    "        62-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 61
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809100",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 61, no. 4 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 61, no. 4 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938451"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 61, no. 4 (2013)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938451"
+                    ],
+                    "idBarcode": [
+                      "33433124938451"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 61,
+                        "lte": 61
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        61-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000061, no. 4 (2013)"
+                  },
+                  "sort": [
+                    "        61-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 60
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809097",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 61, no. 3 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 61, no. 3 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938444"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 61, no. 3 (2013)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938444"
+                    ],
+                    "idBarcode": [
+                      "33433124938444"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 61,
+                        "lte": 61
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        61-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000061, no. 3 (2013)"
+                  },
+                  "sort": [
+                    "        61-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 59
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809096",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 61, no. 2 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 61, no. 2 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938436"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 61, no. 2 (2013)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938436"
+                    ],
+                    "idBarcode": [
+                      "33433124938436"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 61,
+                        "lte": 61
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        61-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000061, no. 2 (2013)"
+                  },
+                  "sort": [
+                    "        61-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 58
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809095",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 61, no. 1 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 61, no. 1 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938428"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 61, no. 1 (2013)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938428"
+                    ],
+                    "idBarcode": [
+                      "33433124938428"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 61,
+                        "lte": 61
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        61-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000061, no. 1 (2013)"
+                  },
+                  "sort": [
+                    "        61-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 57
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809092",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 60, no. 4 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 60, no. 4 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938410"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 60, no. 4 (2012)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938410"
+                    ],
+                    "idBarcode": [
+                      "33433124938410"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 60,
+                        "lte": 60
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        60-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000060, no. 4 (2012)"
+                  },
+                  "sort": [
+                    "        60-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 56
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809091",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 60, no. 3 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 60, no. 3 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938402"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 60, no. 3 (2012)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938402"
+                    ],
+                    "idBarcode": [
+                      "33433124938402"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 60,
+                        "lte": 60
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        60-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000060, no. 3 (2012)"
+                  },
+                  "sort": [
+                    "        60-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 55
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809089",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 60, no. 2 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 60, no. 2 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938394"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 60, no. 2 (2012)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938394"
+                    ],
+                    "idBarcode": [
+                      "33433124938394"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 60,
+                        "lte": 60
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        60-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000060, no. 2 (2012)"
+                  },
+                  "sort": [
+                    "        60-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 54
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809088",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 60, no. 1 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 60, no. 1 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938386"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 60, no. 1 (2012)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938386"
+                    ],
+                    "idBarcode": [
+                      "33433124938386"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 60,
+                        "lte": 60
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        60-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000060, no. 1 (2012)"
+                  },
+                  "sort": [
+                    "        60-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 53
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809087",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59, no. 4 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59, no. 4 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938378"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 59, no. 4 (2011)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938378"
+                    ],
+                    "idBarcode": [
+                      "33433124938378"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 59,
+                        "lte": 59
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        59-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059, no. 4 (2011)"
+                  },
+                  "sort": [
+                    "        59-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 52
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809085",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59, no. 3 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59, no. 3 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938360"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 59, no. 3 (2011)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938360"
+                    ],
+                    "idBarcode": [
+                      "33433124938360"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 59,
+                        "lte": 59
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        59-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059, no. 3 (2011)"
+                  },
+                  "sort": [
+                    "        59-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 51
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36809083",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59, no. 2 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59, no. 2 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124938352"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 59, no. 2 (2011)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124938352"
+                    ],
+                    "idBarcode": [
+                      "33433124938352"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 59,
+                        "lte": 59
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        59-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059, no. 2 (2011)"
+                  },
+                  "sort": [
+                    "        59-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 50
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36587267",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:4",
+                        "label": "serial, loose"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:4||serial, loose"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59, no. 1 (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59, no. 1 (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124930839"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 59, no. 1 (2011)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124930839"
+                    ],
+                    "idBarcode": [
+                      "33433124930839"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 59,
+                        "lte": 59
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        59-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059, no. 1 (2011)"
+                  },
+                  "sort": [
+                    "        59-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 49
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i36975113",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:29",
+                        "label": "bundled materials (vols.)"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:29||bundled materials (vols.)"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 59 (2011); v. 62 (2014) & v. 65 (2017):indexes"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 59 (2011); v. 62 (2014) & v. 65 (2017):indexes",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433124984265"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 59 (2011); v. 62 (2014) & v. 65 (2017):indexes"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433124984265"
+                    ],
+                    "idBarcode": [
+                      "33433124984265"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:u",
+                        "label": "Supervised use"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:u||Supervised use"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 59,
+                        "lte": 59
+                      },
+                      {
+                        "gte": 62,
+                        "lte": 62
+                      },
+                      {
+                        "gte": 65,
+                        "lte": 65
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2017"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        59-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000059 (2011); v. 62 (2014) & v. 65 (2017):indexes"
+                  },
+                  "sort": [
+                    "        59-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 48
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28757665",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 58 (2010) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 58 (2010) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099608048"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 58 (2010) & Index"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099608048"
+                    ],
+                    "idBarcode": [
+                      "33433099608048"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 58,
+                        "lte": 58
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2010",
+                        "lte": "2010"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        58-2010"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000058 (2010) & Index"
+                  },
+                  "sort": [
+                    "        58-2010"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 47
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28757661",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 57 (2009) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 57 (2009) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099608055"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 57 (2009) & Index"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099608055"
+                    ],
+                    "idBarcode": [
+                      "33433099608055"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 57,
+                        "lte": 57
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2009",
+                        "lte": "2009"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        57-2009"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000057 (2009) & Index"
+                  },
+                  "sort": [
+                    "        57-2009"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 46
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28757051",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 56 (2008) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 56 (2008) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099607917"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 56 (2008) & Index"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099607917"
+                    ],
+                    "idBarcode": [
+                      "33433099607917"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 56,
+                        "lte": 56
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2008",
+                        "lte": "2008"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        56-2008"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000056 (2008) & Index"
+                  },
+                  "sort": [
+                    "        56-2008"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 45
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28756751",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 55 (2007) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 55 (2007) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099608063"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 55 (2007) & Index"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099608063"
+                    ],
+                    "idBarcode": [
+                      "33433099608063"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 55,
+                        "lte": 55
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2007",
+                        "lte": "2007"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        55-2007"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000055 (2007) & Index"
+                  },
+                  "sort": [
+                    "        55-2007"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 44
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i28756731",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 54 (2006) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 54 (2006) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433099608188"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 54 (2006) & Index"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433099608188"
+                    ],
+                    "idBarcode": [
+                      "33433099608188"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 54,
+                        "lte": 54
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2006",
+                        "lte": "2006"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        54-2006"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000054 (2006) & Index"
+                  },
+                  "sort": [
+                    "        54-2006"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 43
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508061",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 53 (2005)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 53 (2005)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526242"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 53 (2005)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526242"
+                    ],
+                    "idBarcode": [
+                      "33433071526242"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 53,
+                        "lte": 53
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2005",
+                        "lte": "2005"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        53-2005"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000053 (2005)"
+                  },
+                  "sort": [
+                    "        53-2005"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 42
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508060",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 52 (2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 52 (2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526234"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 52 (2004)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526234"
+                    ],
+                    "idBarcode": [
+                      "33433071526234"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 52,
+                        "lte": 52
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2004",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        52-2004"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000052 (2004)"
+                  },
+                  "sort": [
+                    "        52-2004"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 41
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508059",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 51 (2003) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 51 (2003) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526226"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 51 (2003) & Index"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526226"
+                    ],
+                    "idBarcode": [
+                      "33433071526226"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 51,
+                        "lte": 51
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2003"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        51-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000051 (2003) & Index"
+                  },
+                  "sort": [
+                    "        51-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 40
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508058",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 50 (2002) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 50 (2002) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526218"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 50 (2002) & Index"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526218"
+                    ],
+                    "idBarcode": [
+                      "33433071526218"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 50,
+                        "lte": 50
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2002",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        50-2002"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000050 (2002) & Index"
+                  },
+                  "sort": [
+                    "        50-2002"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 39
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508057",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 49 (2001) & Index"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 49 (2001) & Index",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433071526143"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 49 (2001) & Index"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433071526143"
+                    ],
+                    "idBarcode": [
+                      "33433071526143"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 49,
+                        "lte": 49
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2001",
+                        "lte": "2001"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        49-2001"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000049 (2001) & Index"
+                  },
+                  "sort": [
+                    "        49-2001"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 38
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i17508056",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 48 (2000)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 48 (2000)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433105255578"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 48 (2000)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433105255578"
+                    ],
+                    "idBarcode": [
+                      "33433105255578"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 48,
+                        "lte": 48
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2000"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        48-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000048 (2000)"
+                  },
+                  "sort": [
+                    "        48-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 37
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693382",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 46-47 (1998-1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 46-47 (1998-1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846223"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 46-47 (1998-1999)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846223"
+                    ],
+                    "idBarcode": [
+                      "33433019846223"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 46,
+                        "lte": 47
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1998",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        46-1998"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000046-47 (1998-1999)"
+                  },
+                  "sort": [
+                    "        46-1998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 36
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693381",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 43-45 (1995-1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 43-45 (1995-1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846215"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 43-45 (1995-1997)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846215"
+                    ],
+                    "idBarcode": [
+                      "33433019846215"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 43,
+                        "lte": 45
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        43-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000043-45 (1995-1997)"
+                  },
+                  "sort": [
+                    "        43-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 35
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693380",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 42 (1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 42 (1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846207"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 42 (1994)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846207"
+                    ],
+                    "idBarcode": [
+                      "33433019846207"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 42,
+                        "lte": 42
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1994",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        42-1994"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000042 (1994)"
+                  },
+                  "sort": [
+                    "        42-1994"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 34
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693379",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 41 (1993)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 41 (1993)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846199"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 41 (1993)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846199"
+                    ],
+                    "idBarcode": [
+                      "33433019846199"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 41,
+                        "lte": 41
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1993",
+                        "lte": "1993"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        41-1993"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000041 (1993)"
+                  },
+                  "sort": [
+                    "        41-1993"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 33
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693378",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 40 (1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 40 (1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846181"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 40 (1992)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846181"
+                    ],
+                    "idBarcode": [
+                      "33433019846181"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 40,
+                        "lte": 40
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1992",
+                        "lte": "1992"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        40-1992"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000040 (1992)"
+                  },
+                  "sort": [
+                    "        40-1992"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 32
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693377",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 39 (1991)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 39 (1991)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846173"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 39 (1991)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846173"
+                    ],
+                    "idBarcode": [
+                      "33433019846173"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 39,
+                        "lte": 39
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1991",
+                        "lte": "1991"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        39-1991"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000039 (1991)"
+                  },
+                  "sort": [
+                    "        39-1991"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 31
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693376",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 38 (1990)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 38 (1990)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846165"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 38 (1990)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846165"
+                    ],
+                    "idBarcode": [
+                      "33433019846165"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 38,
+                        "lte": 38
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1990",
+                        "lte": "1990"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        38-1990"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000038 (1990)"
+                  },
+                  "sort": [
+                    "        38-1990"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 30
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693375",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 37 (1989)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 37 (1989)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846157"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 37 (1989)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846157"
+                    ],
+                    "idBarcode": [
+                      "33433019846157"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 37,
+                        "lte": 37
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1989",
+                        "lte": "1989"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        37-1989"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000037 (1989)"
+                  },
+                  "sort": [
+                    "        37-1989"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 29
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693374",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 35-36 (1987-1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 35-36 (1987-1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846140"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 35-36 (1987-1988)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846140"
+                    ],
+                    "idBarcode": [
+                      "33433019846140"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 35,
+                        "lte": 36
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1987",
+                        "lte": "1988"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        35-1987"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000035-36 (1987-1988)"
+                  },
+                  "sort": [
+                    "        35-1987"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 28
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693373",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 33-34 (1985-1986)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 33-34 (1985-1986)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846132"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 33-34 (1985-1986)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846132"
+                    ],
+                    "idBarcode": [
+                      "33433019846132"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 33,
+                        "lte": 34
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1985",
+                        "lte": "1986"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        33-1985"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000033-34 (1985-1986)"
+                  },
+                  "sort": [
+                    "        33-1985"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 27
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693372",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 30-32 (1982-1984)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 30-32 (1982-1984)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846124"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 30-32 (1982-1984)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846124"
+                    ],
+                    "idBarcode": [
+                      "33433019846124"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 30,
+                        "lte": 32
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1982",
+                        "lte": "1984"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        30-1982"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000030-32 (1982-1984)"
+                  },
+                  "sort": [
+                    "        30-1982"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 26
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693371",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 27-29 (1979-1981)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 27-29 (1979-1981)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846116"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 27-29 (1979-1981)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846116"
+                    ],
+                    "idBarcode": [
+                      "33433019846116"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 27,
+                        "lte": 29
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1979",
+                        "lte": "1981"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        27-1979"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000027-29 (1979-1981)"
+                  },
+                  "sort": [
+                    "        27-1979"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 25
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693370",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 23-26 (1975-1978)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 23-26 (1975-1978)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846108"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 23-26 (1975-1978)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846108"
+                    ],
+                    "idBarcode": [
+                      "33433019846108"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 23,
+                        "lte": 26
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1975",
+                        "lte": "1978"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        23-1975"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000023-26 (1975-1978)"
+                  },
+                  "sort": [
+                    "        23-1975"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 24
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693369",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 19-22 (1971-1974)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 19-22 (1971-1974)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846090"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 19-22 (1971-1974)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846090"
+                    ],
+                    "idBarcode": [
+                      "33433019846090"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 19,
+                        "lte": 22
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1971",
+                        "lte": "1974"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        19-1971"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000019-22 (1971-1974)"
+                  },
+                  "sort": [
+                    "        19-1971"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 23
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693368",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 16-18 (1968-1970)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 16-18 (1968-1970)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846082"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 16-18 (1968-1970)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846082"
+                    ],
+                    "idBarcode": [
+                      "33433019846082"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 16,
+                        "lte": 18
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1968",
+                        "lte": "1970"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        16-1968"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000016-18 (1968-1970)"
+                  },
+                  "sort": [
+                    "        16-1968"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 22
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693367",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 13-15 (1965-1967)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 13-15 (1965-1967)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846074"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 13-15 (1965-1967)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846074"
+                    ],
+                    "idBarcode": [
+                      "33433019846074"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 13,
+                        "lte": 15
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1965",
+                        "lte": "1967"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        13-1965"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000013-15 (1965-1967)"
+                  },
+                  "sort": [
+                    "        13-1965"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 21
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693366",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 9-12 (1961-1964)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 9-12 (1961-1964)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846066"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 9-12 (1961-1964)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846066"
+                    ],
+                    "idBarcode": [
+                      "33433019846066"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 9,
+                        "lte": 12
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1961",
+                        "lte": "1964"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         9-1961"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000009-12 (1961-1964)"
+                  },
+                  "sort": [
+                    "         9-1961"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 20
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693365",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 5-8 (1957-1960)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 5-8 (1957-1960)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846058"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 5-8 (1957-1960)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846058"
+                    ],
+                    "idBarcode": [
+                      "33433019846058"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 8
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1957",
+                        "lte": "1960"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-1957"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000005-8 (1957-1960)"
+                  },
+                  "sort": [
+                    "         5-1957"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 19
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12693364",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-19 v. 1-4 (1953-1956)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-19 v. 1-4 (1953-1956)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019846041"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-4 (1953-1956)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-19"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019846041"
+                    ],
+                    "idBarcode": [
+                      "33433019846041"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 4
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1953",
+                        "lte": "1956"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-1953"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-19 v. 000001-4 (1953-1956)"
+                  },
+                  "sort": [
+                    "         1-1953"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b12525718",
+        "_score": 13.617916,
+        "_source": {
+          "extent": [
+            "v. : ill. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Published: Fratelli Palombi Editori, 1954-1984; L'Erma di Bretschneider, 1985- .",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Indexed In",
+              "label": "RILA. Répertoire international de la littérature de l'art",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Numbering",
+              "label": "Anno 25 (1978)-27 (1980) combined.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "serialPublicationDates": [
+            "Anno 1, n. 1-2 (1954)-anno 32 (1985) ; nuova serie, 1 (1987)-"
+          ],
+          "subjectLiteral_exploded": [
+            "Rome (Italy)",
+            "Rome (Italy) -- Galleries and museums"
+          ],
+          "numItemDatesParsed": [
+            45
+          ],
+          "publisherLiteral": [
+            "Gli Amici"
+          ],
+          "language": [
+            {
+              "id": "lang:ita",
+              "label": "Italian"
+            }
+          ],
+          "numItemsTotal": [
+            45
+          ],
+          "createdYear": [
+            1954
+          ],
+          "dateEndString": [
+            "9999"
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Bollettino dei Musei comunali di Roma"
+          ],
+          "shelfMark": [
+            "JQL 08-17"
+          ],
+          "numItemVolumesParsed": [
+            45
+          ],
+          "createdString": [
+            "1954"
+          ],
+          "idLccn": [
+            "64036787 //r882"
+          ],
+          "idIssn": [
+            "0523-9346"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Amici dei musei di Roma (Italy)"
+          ],
+          "dateStartYear": [
+            1954
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "JQL 08-17"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "12525718"
+            },
+            {
+              "type": "bf:Issn",
+              "value": "0523-9346"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "64036787 //r882"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "2785323"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)S010000043"
+            }
+          ],
+          "idOclc": [
+            "2785323"
+          ],
+          "dateEndYear": [
+            9999
+          ],
+          "holdings": [
+            {
+              "holdingStatement": [
+                "1(1954)-6(1959),8(1961)-32(1985) [N.S] 1(1987)-18(2004),25(2011)28(2014),32(2018)-",
+                "v. 25 (2011) - v. 28 (2014); v. 32 (2020)"
+              ],
+              "checkInBoxes": [
+                {
+                  "coverage": "No. 7 (1993)",
+                  "position": "1",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 8 (1994)",
+                  "position": "2",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 9 (1995)",
+                  "position": "3",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 10 (1996)",
+                  "position": "4",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 11 (1997)",
+                  "position": "5",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 12 (1998)",
+                  "position": "6",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 13 (1999)",
+                  "position": "7",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 14 (2000)",
+                  "position": "8",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 15 (2001)",
+                  "position": "9",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 16 (2002)",
+                  "position": "10",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 17 (2003)",
+                  "position": "11",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 18 (2004)",
+                  "position": "12",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 19 (2005)",
+                  "position": "13",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 20 (2006)",
+                  "position": "14",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 21 (2007)",
+                  "position": "15",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 22 (2008)",
+                  "position": "16",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 23 (2009)",
+                  "position": "17",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 24 (2010)",
+                  "position": "18",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 25 (2011)",
+                  "position": "19",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 26 (2012)",
+                  "position": "20",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 27 (2013)",
+                  "position": "21",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 28 (2014)",
+                  "position": "22",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 29 (2015)",
+                  "position": "23",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 30 (2018)",
+                  "position": "24",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 31 (2019)",
+                  "position": "25",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 32 (2018)",
+                  "position": "26",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Arrived"
+                },
+                {
+                  "coverage": "No. 33 (2021)",
+                  "position": "27",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                },
+                {
+                  "coverage": "No. 34 (2022)",
+                  "position": "28",
+                  "type": "nypl:CheckInBox",
+                  "shelfMark": [
+                    "JQL 08-17"
+                  ],
+                  "status": "Expected"
+                }
+              ],
+              "identifier": [
+                {
+                  "type": "bf:shelfMark",
+                  "value": "JQL 08-17"
+                }
+              ],
+              "notes": [
+                "Order transferred from GRD to ART per CCK/ART 7/29/04 ?EP"
+              ],
+              "physicalLocation": [
+                "JQL 08-17"
+              ],
+              "location": [
+                {
+                  "code": "loc:mab",
+                  "label": "Schwarzman Building - Art & Architecture Room 300"
+                }
+              ],
+              "uri": "h1069076",
+              "shelfMark": [
+                "JQL 08-17"
+              ]
+            }
+          ],
+          "updatedAt": 1675270544507,
+          "publicationStatement": [
+            "[Roma] : Gli Amici, [1954]-"
+          ],
+          "identifier": [
+            "urn:bnum:12525718",
+            "urn:issn:0523-9346",
+            "urn:lccn:64036787 //r882",
+            "urn:oclc:2785323",
+            "urn:undefined:(WaOLN)S010000043"
+          ],
+          "numCheckinCardItems": [
+            28
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1954"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Rome (Italy) -- Galleries and museums."
+          ],
+          "titleDisplay": [
+            "Bollettino dei Musei comunali di Roma / a cura degli Amici dei musei di Roma."
+          ],
+          "uri": "b12525718",
+          "lccClassification": [
+            "AM55.R6 B6"
+          ],
+          "numItems": [
+            17
+          ],
+          "numAvailable": [
+            34
+          ],
+          "placeOfPublication": [
+            "[Roma]"
+          ],
+          "titleAlt": [
+            "Boll. Mus. comunali Roma",
+            "Bollettino dei Musei comunali di Roma"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:s",
+              "label": "serial"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 17,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 40
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i37359040",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 32 (2018)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 32 (2018)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433121729853"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 32 (2018)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433121729853"
+                    ],
+                    "idBarcode": [
+                      "33433121729853"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 32,
+                        "lte": 32
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2018",
+                        "lte": "2018"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        32-2018"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000032 (2018)"
+                  },
+                  "sort": [
+                    "        32-2018"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 39
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33860628",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 28 (2014)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 28 (2014)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433117119341"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 28 (2014)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433117119341"
+                    ],
+                    "idBarcode": [
+                      "33433117119341"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 28,
+                        "lte": 28
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2014",
+                        "lte": "2014"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        28-2014"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000028 (2014)"
+                  },
+                  "sort": [
+                    "        28-2014"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 38
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i33682199",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 27 (2013)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 27 (2013)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433117979173"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 27 (2013)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433117979173"
+                    ],
+                    "idBarcode": [
+                      "33433117979173"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 27,
+                        "lte": 27
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2013",
+                        "lte": "2013"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        27-2013"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000027 (2013)"
+                  },
+                  "sort": [
+                    "        27-2013"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 37
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i32391069",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 26 (2012)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 26 (2012)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433112611961"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 26 (2012)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433112611961"
+                    ],
+                    "idBarcode": [
+                      "33433112611961"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 26,
+                        "lte": 26
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2012",
+                        "lte": "2012"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        26-2012"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000026 (2012)"
+                  },
+                  "sort": [
+                    "        26-2012"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 36
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i30890910",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 25  (2011)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 25  (2011)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433101055220"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 25  (2011)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433101055220"
+                    ],
+                    "idBarcode": [
+                      "33433101055220"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 25,
+                        "lte": 25
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2011",
+                        "lte": "2011"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        25-2011"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000025 (2011)"
+                  },
+                  "sort": [
+                    "        25-2011"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 44
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757465",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 v. 25-32 (1978-1985)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 v. 25-32 (1978-1985)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857568"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 25-32 (1978-1985)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857568"
+                    ],
+                    "idBarcode": [
+                      "33433019857568"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 25,
+                        "lte": 32
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1978",
+                        "lte": "1985"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        25-1978"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 v. 000025-32 (1978-1985)"
+                  },
+                  "sort": [
+                    "        25-1978"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 35
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i14288461",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 17-18 (2003-2004)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 17-18 (2003-2004)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433060930082"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 17-18 (2003-2004)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433060930082"
+                    ],
+                    "idBarcode": [
+                      "33433060930082"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 17,
+                        "lte": 18
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2003",
+                        "lte": "2004"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        17-2003"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000017-18 (2003-2004)"
+                  },
+                  "sort": [
+                    "        17-2003"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 43
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757464",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 v. 16-24 (1969-1977)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 v. 16-24 (1969-1977)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857550"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 16-24 (1969-1977)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857550"
+                    ],
+                    "idBarcode": [
+                      "33433019857550"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 16,
+                        "lte": 24
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1969",
+                        "lte": "1977"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        16-1969"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 v. 000016-24 (1969-1977)"
+                  },
+                  "sort": [
+                    "        16-1969"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 34
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757472",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 14-16 (2000-2002)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 14-16 (2000-2002)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857634"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 14-16 (2000-2002)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857634"
+                    ],
+                    "idBarcode": [
+                      "33433019857634"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 14,
+                        "lte": 16
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "2000",
+                        "lte": "2002"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        14-2000"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000014-16 (2000-2002)"
+                  },
+                  "sort": [
+                    "        14-2000"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 33
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757471",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 12-13 (1998-1999)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 12-13 (1998-1999)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857626"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 12-13 (1998-1999)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857626"
+                    ],
+                    "idBarcode": [
+                      "33433019857626"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 12,
+                        "lte": 13
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1998",
+                        "lte": "1999"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "        12-1998"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000012-13 (1998-1999)"
+                  },
+                  "sort": [
+                    "        12-1998"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 32
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757470",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 9-11 (1995-1997)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 9-11 (1995-1997)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857618"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 9-11 (1995-1997)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857618"
+                    ],
+                    "idBarcode": [
+                      "33433019857618"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 9,
+                        "lte": 11
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1995",
+                        "lte": "1997"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         9-1995"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000009-11 (1995-1997)"
+                  },
+                  "sort": [
+                    "         9-1995"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 42
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757463",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 v. 8-15 (1961-1968)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 v. 8-15 (1961-1968)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857543"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 8-15 (1961-1968)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857543"
+                    ],
+                    "idBarcode": [
+                      "33433019857543"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 8,
+                        "lte": 15
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1961",
+                        "lte": "1968"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         8-1961"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 v. 000008-15 (1961-1968)"
+                  },
+                  "sort": [
+                    "         8-1961"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 31
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757469",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 7-8 (1993-1994)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 7-8 (1993-1994)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857600"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 7-8 (1993-1994)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857600"
+                    ],
+                    "idBarcode": [
+                      "33433019857600"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 7,
+                        "lte": 8
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1993",
+                        "lte": "1994"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         7-1993"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000007-8 (1993-1994)"
+                  },
+                  "sort": [
+                    "         7-1993"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 30
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757468",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 5-6 (1991-1992)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 5-6 (1991-1992)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857592"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 5-6 (1991-1992)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857592"
+                    ],
+                    "idBarcode": [
+                      "33433019857592"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 5,
+                        "lte": 6
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1991",
+                        "lte": "1992"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         5-1991"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000005-6 (1991-1992)"
+                  },
+                  "sort": [
+                    "         5-1991"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 29
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757467",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:mab92",
+                        "label": "Schwarzman Building M2 - Art and Architecture Room 300"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:mab92||Schwarzman Building M2 - Art and Architecture Room 300"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 3-4 (1989-1990)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 3-4 (1989-1990)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857584"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 3-4 (1989-1990)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857584"
+                    ],
+                    "idBarcode": [
+                      "33433019857584"
+                    ],
+                    "requestable": [
+                      false
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 3,
+                        "lte": 4
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1989",
+                        "lte": "1990"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         3-1989"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000003-4 (1989-1990)"
+                  },
+                  "sort": [
+                    "         3-1989"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 28
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757466",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 N.S. v. 1-2 (1987-1988)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 N.S. v. 1-2 (1987-1988)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857576"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "N.S. v. 1-2 (1987-1988)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857576"
+                    ],
+                    "idBarcode": [
+                      "33433019857576"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 2
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1987",
+                        "lte": "1988"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-1987"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 N.S. v. 000001-2 (1987-1988)"
+                  },
+                  "sort": [
+                    "         1-1987"
+                  ]
+                },
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 41
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i12757462",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1110",
+                        "label": "The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1110||The Miriam and Ira D. Wallach Division of Art, Prints and Photographs: Art & Architecture Collection"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:3",
+                        "label": "serial"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:3||serial"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rcmb2",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rcmb2||Offsite"
+                    ],
+                    "shelfMark": [
+                      "JQL 08-17 v. 1-6 (1954-1959)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "JQL 08-17 v. 1-6 (1954-1959)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433019857535"
+                      }
+                    ],
+                    "enumerationChronology": [
+                      "v. 1-6 (1954-1959)"
+                    ],
+                    "physicalLocation": [
+                      "JQL 08-17"
+                    ],
+                    "recapCustomerCode": [
+                      "NQ"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433019857535"
+                    ],
+                    "idBarcode": [
+                      "33433019857535"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "volumeRange": [
+                      {
+                        "gte": 1,
+                        "lte": 6
+                      }
+                    ],
+                    "dateRange": [
+                      {
+                        "gte": "1954",
+                        "lte": "1959"
+                      }
+                    ],
+                    "enumerationChronology_sort": [
+                      "         1-1954"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aJQL 08-17 v. 000001-6 (1954-1959)"
+                  },
+                  "sort": [
+                    "         1-1954"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/query-f940083c64e724272143f8437b1868d5.json
+++ b/test/fixtures/query-f940083c64e724272143f8437b1868d5.json
@@ -1,0 +1,14 @@
+{
+  "took": 6,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 0,
+    "max_score": null,
+    "hits": []
+  }
+}

--- a/test/fixtures/query-fa09178fbbf4213e2088a264c2c254b6.json
+++ b/test/fixtures/query-fa09178fbbf4213e2088a264c2c254b6.json
@@ -1,0 +1,253 @@
+{
+  "took": 160,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 121.470184,
+    "hits": [
+      {
+        "_index": "resources-2018-04-09",
+        "_type": "resource",
+        "_id": "b13627363",
+        "_score": 121.470184,
+        "_source": {
+          "extent": [
+            "128 p. illus."
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Cats",
+            "Cats -- Pictorial works"
+          ],
+          "publisherLiteral": [
+            "Creative age press, inc."
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "createdYear": [
+            1947
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Cats, cats, & cats"
+          ],
+          "shelfMark": [
+            "VPS (Rice, E. Cats, cats, & cats)"
+          ],
+          "creatorLiteral": [
+            "Rice, Edward, 1917-"
+          ],
+          "createdString": [
+            "1947"
+          ],
+          "idLccn": [
+            "agr47000211"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "contributorLiteral": [
+            "Gleason, Jean, 1917-"
+          ],
+          "dateStartYear": [
+            1947
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "VPS (Rice, E. Cats, cats, & cats)"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "13627363"
+            },
+            {
+              "type": "bf:Lccn",
+              "value": "agr47000211"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp3600714"
+            }
+          ],
+          "updatedAt": 1659488510917,
+          "publicationStatement": [
+            "New York, Creative age press, inc. [c1947]"
+          ],
+          "identifier": [
+            "urn:bnum:13627363",
+            "urn:lccn:agr47000211",
+            "urn:undefined:(WaOLN)nyp3600714"
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1947"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Cats.",
+            "Cats -- Pictorial works."
+          ],
+          "titleDisplay": [
+            "Cats, cats, & cats, by Edward Rice and Jean Gleason."
+          ],
+          "uri": "b13627363",
+          "lccClassification": [
+            "SF447 .R5"
+          ],
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "New York"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "i10754478",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:1000",
+                        "label": "Stephen A. Schwarzman Building"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:1000||Stephen A. Schwarzman Building"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:55",
+                        "label": "book, limited circ, MaRLI"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:55||book, limited circ, MaRLI"
+                    ],
+                    "holdingLocation": [
+                      {
+                        "id": "loc:rc2ma",
+                        "label": "Offsite"
+                      }
+                    ],
+                    "holdingLocation_packed": [
+                      "loc:rc2ma||Offsite"
+                    ],
+                    "shelfMark": [
+                      "VPS (Rice, E. Cats, cats, & cats)"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "VPS (Rice, E. Cats, cats, & cats)",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "33433006598316"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "VPS (Rice, E. Cats, cats, & cats)"
+                    ],
+                    "recapCustomerCode": [
+                      "NL"
+                    ],
+                    "identifier": [
+                      "urn:barcode:33433006598316"
+                    ],
+                    "idBarcode": [
+                      "33433006598316"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:2",
+                        "label": "Request in advance"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:2||Request in advance"
+                    ],
+                    "shelfMark_sort": "aVPS (Rice, E. Cats, cats, & cats)"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/scsb-by-barcode-459f6f37fcdb71a9c34013aa059821ef.json
+++ b/test/fixtures/scsb-by-barcode-459f6f37fcdb71a9c34013aa059821ef.json
@@ -1,0 +1,277 @@
+[
+  {
+    "itemBarcode": "33433046113795",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433050409147",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417551",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060370396",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419649",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419680",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418526",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417486",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419979",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417452",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417478",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058031224",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058030721",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059840763",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058030051",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060420118",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060420126",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060420076",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060420100",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060420092",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058597968",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058648977",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058648969",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060359332",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014525079",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433096515220",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433115326104",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058548284",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417874",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060359365",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417890",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418666",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058574710",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417288",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057993358",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417726",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419664",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433059862981",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060359589",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017339361",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433017339353",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433057993127",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433032678454",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433098691227",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011952243",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419870",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417494",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618418",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418260",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418252",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419987",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417882",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418278",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058602826",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418286",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-6c993f47bd26ff18e9686daa48c071e7.json
+++ b/test/fixtures/scsb-by-barcode-6c993f47bd26ff18e9686daa48c071e7.json
@@ -1,0 +1,502 @@
+[
+  {
+    "itemBarcode": "33433119872095",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433119872087",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099610952",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611083",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611109",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099610945",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611075",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611091",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099612925",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611125",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611141",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611117",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611133",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611166",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611182",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611190",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433099611174",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063992",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064008",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063950",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063976",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064172",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064214",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063984",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063943",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064180",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064206",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085063968",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433085064198",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240575",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240559",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240567",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240542",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240583",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240526",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240518",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240492",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240534",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240500",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240476",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240468",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078508037",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433080028222",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240484",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240443",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240427",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240401",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240450",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240435",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240419",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240385",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240369",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240344",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240393",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240377",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240351",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240328",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433079991612",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240302",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240336",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240310",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240286",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240294",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078639105",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240278",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433080426707",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240211",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240245",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240252",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240229",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240237",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240260",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240203",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078660671",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240195",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433080030616",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078530031",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433081121117",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658105",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658113",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658089",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658071",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078626128",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658097",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658063",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658048",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658022",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240179",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658055",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433078658030",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240187",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240161",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240138",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240146",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240104",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240112",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240096",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240153",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240120",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084240088",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-90631da55eeeb66c5b375de62298d27a.json
+++ b/test/fixtures/scsb-by-barcode-90631da55eeeb66c5b375de62298d27a.json
@@ -1,0 +1,267 @@
+[
+  {
+    "itemBarcode": "33433061301556",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022691665",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301689",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301598",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014514719",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022691780",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301580",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002031718",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301572",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301564",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005548676",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002031700",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011094210",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012968222",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013173012",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011528696",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058548433",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058153572",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061301622",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058618392",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080645",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080413",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080439",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080421",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080447",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080454",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080462",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012357756",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015080363",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433030669448",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000481",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058152988",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004672303",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004314914",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013172402",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000465",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000457",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000440",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000432",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004672238",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011745118",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004672246",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058153028",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011108135",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011745134",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011167040",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013106327",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838980",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005548338",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000689",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014514545",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001937568",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000671",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/fixtures/scsb-by-barcode-c611e4c0e4880bfee11c1a4cd80d95bb.json
+++ b/test/fixtures/scsb-by-barcode-c611e4c0e4880bfee11c1a4cd80d95bb.json
@@ -1,0 +1,512 @@
+[
+  {
+    "itemBarcode": "33433002000671",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838949",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838964",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838956",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838972",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012457234",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433084847221",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061318089",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001837818",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001944218",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005586205",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838923",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014543452",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014543445",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001839004",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014514537",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001937576",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011242736",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001838998",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011167834",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004673145",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011167826",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011167818",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014514172",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060417551",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001542319",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014514271",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002038218",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014519783",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014463446",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005586346",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001937469",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433014504074",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001965965",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001965734",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001999683",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001999675",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005562628",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058007638",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004668285",
+    "itemAvailabilityStatus": "Not Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022688901",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061320515",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001718117",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001965767",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061328062",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004552323",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013118892",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004673160",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004673152",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002000598",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058069497",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013125202",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013145382",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012996868",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001925001",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060370396",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433005577659",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004689307",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012996876",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299065",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299073",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433012996892",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299099",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299107",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419649",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013145390",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433022691053",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011098963",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299735",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299719",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001889223",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433013020924",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011098971",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011098989",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058552856",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058153408",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060419680",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011093949",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433093040370",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299701",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011098955",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011093956",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011098930",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011049917",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061299693",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010762189",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433001718323",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433015458726",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010762171",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058630249",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011093998",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011094004",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433058153416",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004689018",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433060418526",
+    "itemAvailabilityStatus": "Item Barcode doesn't exist in SCSB database.",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061296400",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433061296392",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433004689042",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011439092",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433011486549",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433010171373",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  },
+  {
+    "itemBarcode": "33433002039166",
+    "itemAvailabilityStatus": "Available",
+    "errorMessage": null
+  }
+]

--- a/test/resources-responses.test.js
+++ b/test/resources-responses.test.js
@@ -34,7 +34,7 @@ describe('Test Resources responses', function () {
       request.get(url, (err, res, body) => {
         if (err) throw err
         const doc = JSON.parse(body)
-        expect(doc.numItemsMatched).to.equal(562)
+        expect(doc.numItemsMatched).to.equal(563)
         done()
       })
     })
@@ -52,7 +52,7 @@ describe('Test Resources responses', function () {
       request.get(url, (err, res, body) => {
         if (err) throw err
         const doc = JSON.parse(body)
-        expect(doc.numItemsMatched).to.equal(12) // this changed when I rebuild the fixtures with no code changes
+        expect(doc.numItemsMatched).to.equal(9) // this changed when I rebuild the fixtures with no code changes
         done()
       })
     })


### PR DESCRIPTION
Refactor code around when/how we run inner_hits queries:
 - always run inner_hits queries because we use inner_hits to constrain the number of items returned and we depend on those queries to derive numItemsTotal
 - always include an electronicResources inner_hits query to ensure that, if there are any e-resoures in the items array, we separate them at query time
 - centralize where we process the inner_hits respones in the "massager" code so items and electronicResources obtained through inner_hits are moved into appropriate spots in the record. This is also where we can handle pulling the .total properties
 - treat the item-id endpoint just like any other item filter query so that we can apply the above changes there as well
 - fix stale publisher filter (was using deprecated field)