### PR TITLE
Fix delivery locations endpoint for M2 items

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -8,7 +8,7 @@ const DeliveryLocationsResolver = require('./delivery-locations-resolver')
 const recapCustomerCodes = require('@nypl/nypl-core-objects')('by-recap-customer-code')
 const Feature = require('../lib/feature')
 const { nonRecapItemStatusAggregation } = require('./es-client')
-const { deepValue } = require('./util')
+const { deepValue, itemHasRecapHoldingLocation } = require('./util')
 
 class AvailabilityResolver {
   constructor (responseReceived) {
@@ -322,9 +322,9 @@ class AvailabilityResolver {
   }
 
   _isInRecap (item) {
-    const holdingLocation = (item.holdingLocation || [{}])[0].id
-    const isRecapHoldingLocation = (holdingLocation && /^loc:rc/.test(holdingLocation))
-    return !!item.recapCustomerCode || isRecapHoldingLocation || !isItemNyplOwned(item)
+    return !!item.recapCustomerCode
+      || itemHasRecapHoldingLocation(item)
+      || !isItemNyplOwned(item)
   }
 
   _getItemBarcode (item) {

--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -322,9 +322,9 @@ class AvailabilityResolver {
   }
 
   _isInRecap (item) {
-    return !!item.recapCustomerCode
-      || itemHasRecapHoldingLocation(item)
-      || !isItemNyplOwned(item)
+    return !!item.recapCustomerCode ||
+      itemHasRecapHoldingLocation(item) ||
+      !isItemNyplOwned(item)
   }
 
   _getItemBarcode (item) {

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -1,4 +1,4 @@
-const arrayIntersection = require('./util').arrayIntersection
+const { arrayIntersection, itemHasRecapHoldingLocation, barcodeFromItem } = require('./util')
 const SCSBRestClient = require('@nypl/scsb-rest-client')
 const recapCustomerCodes = require('@nypl/nypl-core-objects')('by-recap-customer-code')
 const sierraLocations = require('@nypl/nypl-core-objects')('by-sierra-location')
@@ -111,6 +111,8 @@ class DeliveryLocationsResolver {
    *  Given an array of item barcodes, returns a hash mapping barcodes to customer codes
    */
   static __recapCustomerCodesByBarcodes (barcodes) {
+    if (!barcodes || barcodes.length === 0) return Promise.resolve({})
+
     let scsbClient = new SCSBRestClient({ url: process.env.SCSB_URL, apiKey: process.env.SCSB_API_KEY })
 
     // Record time to process all:
@@ -167,36 +169,38 @@ class DeliveryLocationsResolver {
     // Assert sensible default for location types:
     if (!Array.isArray(deliveryLocationTypes) || deliveryLocationTypes.length === 0) deliveryLocationTypes = ['Research']
 
-    // Extract barcodes from items:
-    var barcodes = items.map((i) => i.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2])
-
-    // TODO: Remove barcodes associated with items that are not in ReCAP (by holdingLocation)
+    // Extract ReCAP barcodes from items:
+    const recapBarcodes = items
+      .filter(itemHasRecapHoldingLocation)
+      .map(barcodeFromItem)
 
     // Get a map from barcodes to ReCAP customercodes:
-    return this.__recapCustomerCodesByBarcodes(barcodes)
-      .then((barcodeToCustomerCode) => {
+    return this.__recapCustomerCodesByBarcodes(recapBarcodes)
+      .then((barcodeToRecapCustomerCode) => {
         // Now map over items to affix deliveryLocations:
         return items.map((item) => {
           // Get this item's barcode:
-          var barcode = item.identifier.filter((i) => /^urn:barcode:/.test(i))[0].split(':')[2]
+          const barcode = barcodeFromItem(item)
 
           // Establish default for Electronic Document Delivery flag:
           item.eddRequestable = false
 
           let sierraLocations = []
           // If recap has a customer code for this barcode, map it by recap cust code:
-          if (barcodeToCustomerCode[barcode]) {
+          if (barcodeToRecapCustomerCode[barcode]) {
             // Delivery locations are not valid if [NYPL] item's holding
             // location is not requestable:
             if (requestableBasedOnHoldingLocation(item) || !isItemNyplOwned(item)) {
-              sierraLocations = this.deliveryLocationsByRecapCustomerCode(barcodeToCustomerCode[barcode])
+              sierraLocations = this.deliveryLocationsByRecapCustomerCode(barcodeToRecapCustomerCode[barcode])
             }
-            item.eddRequestable = this.__eddRequestableByCustomerCode(barcodeToCustomerCode[barcode])
+            item.eddRequestable = this.__eddRequestableByCustomerCode(barcodeToRecapCustomerCode[barcode])
 
-          // Otherwise, it's not in recap
-          // Currently, there is no physical delivery request for onsite items
+          // Otherwise, it's not in recap..
           } else {
-            item.sierraDeliveryLocations = []
+            // But perhaps it's in M2?
+            if (Array.isArray(item.m2CustomerCode) && item.m2CustomerCode[0]) {
+              sierraLocations = this.deliveryLocationsByM2CustomerCode(item.m2CustomerCode[0])
+            }
             item.eddRequestable = this.eddRequestableByOnSiteCriteria(item)
           }
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -375,7 +375,7 @@ module.exports = function (app, _private = null) {
     // Create promise to resolve items:
     let fetchItems = itemsByFilter(
       { terms: { 'items.identifier': identifierValues } },
-      { _source: ['uri', 'type', 'items.uri', 'items.type', 'items.identifier', 'items.holdingLocation', 'items.status', 'items.catalogItemType', 'items.accessMessage'] }
+      { _source: ['uri', 'type', 'items.uri', 'items.type', 'items.identifier', 'items.holdingLocation', 'items.status', 'items.catalogItemType', 'items.accessMessage', 'items.m2CustomerCode'] }
 
       // Filter out any items (multi item bib) that don't match one of the queriered barcodes:
     ).then((items) => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -442,3 +442,22 @@ exports.checkForNestedHitsAndSource = (resp, type) => {
     && resp.hits.hits[0].inner_hits.items.hits.hits
   */
 }
+
+/**
+ *  Given an ES item, returns true if the item has a ReCAP holding location
+ */
+exports.itemHasRecapHoldingLocation = (item) => {
+  if (!exports.deepValue(item, 'holdingLocation[0].id')) return false
+  return /^loc:rc/.test(item.holdingLocation[0].id)
+}
+
+/**
+ *  Given an ES item, returns the item's barcode from the identifer array
+ */
+exports.barcodeFromItem = (item) => {
+  if (!item.identifier || !Array.isArray(item.identifier)) return null
+  const barcodeIdentifier = item.identifier.find((identifier) => /^urn:barcode:/.test(identifier))
+  if (!barcodeIdentifier) return null
+  return barcodeIdentifier.split(':').pop()
+}
+

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -200,4 +200,32 @@ describe('Util', function () {
       expect(util.deepValue({ a: { b: { c: 'foo' } } }, 'x.y', 'fladeedle')).to.deep.equal('fladeedle')
     })
   })
+
+  describe('itemHasRecapHoldingLocation', () => {
+    it('identifies an item with a rc location', () => {
+      expect(util.itemHasRecapHoldingLocation({ holdingLocation: [ { id: 'loc:rc' } ] })).to.equal(true)
+      expect(util.itemHasRecapHoldingLocation({ holdingLocation: [ { id: 'loc:rc2ma' } ] })).to.equal(true)
+    })
+
+    it('rejects an item with a non-rc location', () => {
+      expect(util.itemHasRecapHoldingLocation({ holdingLocation: [ { id: 'loc:xx' } ] })).to.equal(false)
+      expect(util.itemHasRecapHoldingLocation({ holdingLocation: [] })).to.equal(false)
+      expect(util.itemHasRecapHoldingLocation({ })).to.equal(false)
+    })
+  })
+
+  describe('barcodeFromItem', () => {
+    it('extracts barcode from item', () => {
+      expect(util.barcodeFromItem({ identifier: [ 'urn:barcode:1234' ] })).to.equal('1234')
+      expect(util.barcodeFromItem({ identifier: [ 'urn:another:foo', 'urn:barcode:1234' ] })).to.equal('1234')
+      expect(util.barcodeFromItem({ identifier: [ '', null, 'fladeedle', 'urn:barcode:1234' ] })).to.equal('1234')
+    })
+
+    it('gracefully handles missing identifier prop', () => {
+      expect(util.barcodeFromItem({ })).to.equal(null)
+      expect(util.barcodeFromItem({ identifier: null })).to.equal(null)
+      expect(util.barcodeFromItem({ identifier: [] })).to.equal(null)
+      expect(util.barcodeFromItem({ identifier: [ null ] })).to.equal(null)
+    })
+  })
 })


### PR DESCRIPTION
Fixes delivery locations endpoint for M2 items. The function existed to retrieve delivery locations by M2 customer code, but the route wasn't calling it.

Also:
 - Improves a long-standing issue where we query SCSB for all barcodes regardless of their holding location (which should be used to restrict the queried barcodes to just those items that have ReCAP holding locations). Now we only query SCSB for ReCAP customer codes for those items that have ReCAP holding locations.
 - Centralize item barcode extraction and ReCAP holding location check.