### PR TITLE
Scc 3522

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -231,8 +231,8 @@ class AvailabilityResolver {
 
   _fixItemRequestability (request) {
     for (let hit of this.elasticSearchResponse.hits.hits) {
-      const bibUri = hit._source.uri
       (hit._source.items || []).map((item) => {
+        let bibUri = hit._source.uri
         if (item.electronicLocator) return item
         item.eddRequestable = false
         item.physRequestable = false
@@ -293,15 +293,16 @@ class AvailabilityResolver {
       }
     } else {
       let deliveryLocations
+      let overriddenByXaCriteria
       if (item.m2CustomerCode && item.m2CustomerCode[0]) {
-        overriddenByXaCriteria = item.m2CustomerCode[0] === 'XA'
-          && process.env.ROMCOM_MAX_XA_BNUM
-          && bibUri
-          && bibUri > process.env.ROMCOM_MAX_XA_BNUM
+        overriddenByXaCriteria = item.m2CustomerCode[0] === 'XA' &&
+          process.env.ROMCOM_MAX_XA_BNUM &&
+          bibUri &&
+          bibUri > process.env.ROMCOM_MAX_XA_BNUM
         deliveryLocations = DeliveryLocationsResolver.deliveryLocationsByM2CustomerCode(item.m2CustomerCode)
       }
       const requestableByHoldingLocation = requestability.requestableBasedOnHoldingLocation(item)
-      return requestableByHoldingLocation && deliveryLocations && deliveryLocations.length > 0 && ! overriddenByXaCriteria
+      return requestableByHoldingLocation && deliveryLocations && deliveryLocations.length > 0 && !overriddenByXaCriteria
     }
   }
 

--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -231,6 +231,7 @@ class AvailabilityResolver {
 
   _fixItemRequestability (request) {
     for (let hit of this.elasticSearchResponse.hits.hits) {
+      const bibUri = hit._source.uri
       (hit._source.items || []).map((item) => {
         if (item.electronicLocator) return item
         item.eddRequestable = false
@@ -239,7 +240,7 @@ class AvailabilityResolver {
         item.requestable = [false]
         const isInRecap = this._isInRecap(item)
         item.eddRequestable = this._fixEddRequestability(item, isInRecap, request)
-        item.physRequestable = this._fixPhysRequestability(item, isInRecap)
+        item.physRequestable = this._fixPhysRequestability(item, isInRecap, bibUri)
         item.specRequestable = !!item.aeonUrl
         item.requestable = [item.eddRequestable || item.physRequestable || item.specRequestable]
       })
@@ -270,7 +271,7 @@ class AvailabilityResolver {
     }
   }
 
-  _fixPhysRequestability (item, isInRecap) {
+  _fixPhysRequestability (item, isInRecap, bibUri) {
     // this is not the final physRequestable value. True physRequestable is
     // only determined on the front end via the vars closed_locations and
     // open_locations.
@@ -293,10 +294,14 @@ class AvailabilityResolver {
     } else {
       let deliveryLocations
       if (item.m2CustomerCode && item.m2CustomerCode[0]) {
+        overriddenByXaCriteria = item.m2CustomerCode[0] === 'XA'
+          && process.env.ROMCOM_MAX_XA_BNUM
+          && bibUri
+          && bibUri > process.env.ROMCOM_MAX_XA_BNUM
         deliveryLocations = DeliveryLocationsResolver.deliveryLocationsByM2CustomerCode(item.m2CustomerCode)
       }
       const requestableByHoldingLocation = requestability.requestableBasedOnHoldingLocation(item)
-      return requestableByHoldingLocation && deliveryLocations && deliveryLocations.length > 0
+      return requestableByHoldingLocation && deliveryLocations && deliveryLocations.length > 0 && ! overriddenByXaCriteria
     }
   }
 

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -537,6 +537,7 @@ describe('Response with updated availability', function () {
     afterEach(() => {
       holdingLocationStub.restore()
       deliveryResolverStub.restore()
+      process.env.ROMCOM_MAX_XA_BNUM = null
     })
 
     it('returns true for item with requestable m2 customer code', () => {
@@ -557,6 +558,18 @@ describe('Response with updated availability', function () {
       holdingLocationStub.returns(true)
       expect(AvailabilityResolver.prototype._fixPhysRequestability(item, false)).to.equal(false)
     })
+    it('overrides physRequestability for XA bnumbers when env variable is set', () => {
+      process.env.ROMCOM_MAX_XA_BNUM = 'b000000'
+      const item = { m2CustomerCode: ['XA'] }
+      deliveryResolverStub.returns(['loc:ma82, loc:456'])
+      holdingLocationStub.returns(true)
+      expect(AvailabilityResolver.prototype._fixPhysRequestability(item, false, 'b000001')).to.equal(false)
+    })
+    it('does not override physRequestability for XA bnumbers when env variable is not set', () => {
+      const item = { m2CustomerCode: ['XA'] }
+      deliveryResolverStub.returns(['loc:ma82, loc:456'])
+      holdingLocationStub.returns(true)
+      expect(AvailabilityResolver.prototype._fixPhysRequestability(item, false, 'b000001')).to.equal(true)
+    })
   })
 })
-


### PR DESCRIPTION
- Adds option to set `ROMCOM_MAX_XA_BNUM`. This will override physRequestability for items with `m2CustomerCode` `XA` and a high enough bnumber
- adds tests