### PR TITLE
Fix bug where physRequestable sometimes missing

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -302,7 +302,7 @@ class AvailabilityResolver {
         deliveryLocations = DeliveryLocationsResolver.deliveryLocationsByM2CustomerCode(item.m2CustomerCode)
       }
       const requestableByHoldingLocation = requestability.requestableBasedOnHoldingLocation(item)
-      return requestableByHoldingLocation && deliveryLocations && deliveryLocations.length > 0 && !overriddenByXaCriteria
+      return requestableByHoldingLocation && !!deliveryLocations && deliveryLocations.length > 0 && !overriddenByXaCriteria
     }
   }
 


### PR DESCRIPTION
Fix issue where items that have an `undefined` `deliveryLocations` end up calculating `physRequestable=undefined`, causing the property to not be added to the API response. The fix is to cast `deliveryLocations` as a boolean, to ensure that when `deliveryLocations` is falsey, the result of the expression does not default to the actual value of `deliveryLocations` which is `undefined`.