### PR TITLE
Fix bug where partner delivery locations broken

### DIFF
--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -171,7 +171,12 @@ class DeliveryLocationsResolver {
 
     // Extract ReCAP barcodes from items:
     const recapBarcodes = items
-      .filter(itemHasRecapHoldingLocation)
+      .filter((item) => {
+        // It's in ReCAP if 1) it has a RC location
+        return itemHasRecapHoldingLocation(item) ||
+          // .. or 2) it's a partner item:
+          !isItemNyplOwned(item)
+      })
       .map(barcodeFromItem)
 
     // Get a map from barcodes to ReCAP customercodes:

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -296,7 +296,7 @@ describe('Delivery-locations-resolver', function () {
   describe('resolveDeliveryLocations', () => {
     if (process.env.NYPL_CORE_VERSION && process.env.NYPL_CORE_VERSION.includes('rom-com')) {
       it('returns delivery locations for requestable M2 items', () => {
-        const items = [{ m2CustomerCode: [ 'XA' ] }]
+        const items = [{ uri: 'b123', m2CustomerCode: [ 'XA' ] }]
         return DeliveryLocationsResolver
           .resolveDeliveryLocations(items, ['Research'])
           .then((deliveryLocations) => {
@@ -310,14 +310,15 @@ describe('Delivery-locations-resolver', function () {
                   {id: 'loc:mal', label: 'Schwarzman Building - Main Reading Room 315'},
                   {id: 'loc:map', label: 'Schwarzman Building - Map Division Room 117'},
                   {id: 'loc:mag', label: 'Schwarzman Building - Milstein Division Room 121'}
-                ]
+                ],
+                uri: 'b123'
               }
             ])
           })
       })
 
       it('returns scholar delivery locations for requestable M2 items when Scholar rooms requested', () => {
-        const items = [{ m2CustomerCode: [ 'XA' ] }]
+        const items = [{ uri: 'b123', m2CustomerCode: [ 'XA' ] }]
         return DeliveryLocationsResolver
           .resolveDeliveryLocations(items, ['Research', 'Scholar'])
           .then((deliveryLocations) => {
@@ -336,7 +337,7 @@ describe('Delivery-locations-resolver', function () {
       })
 
       it('returns no delivery locations for non-requestable M2 customer codes', () => {
-        const items = [{ m2CustomerCode: [ 'XS' ] }]
+        const items = [{ uri: 'b123', m2CustomerCode: [ 'XS' ] }]
         return DeliveryLocationsResolver
           .resolveDeliveryLocations(items, ['Research', 'Scholar'])
           .then((deliveryLocations) => {

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -90,8 +90,8 @@ const scholarRooms = [
 
 function takeThisPartyPartiallyOffline () {
   // Reroute HTC API requests mapping specific barcodes tested above to recap customer codes:
-  DeliveryLocationsResolver.__recapCustomerCodesByBarcodes = () => {
-    return Promise.resolve({
+  DeliveryLocationsResolver.__recapCustomerCodesByBarcodes = (barcodes) => {
+    const stubbedLookups = {
       '33433047331719': 'NP',
       '32101062243553': 'PA',
       'CU56521537': 'CU',
@@ -99,7 +99,15 @@ function takeThisPartyPartiallyOffline () {
       // Let's pretend this is a valid NYPL Map Division item barcode
       // and let's further pretend that HTC API tells us it's recap customer code is ND
       'made-up-barcode-that-recap-says-belongs-to-ND': 'ND'
-    })
+    }
+
+    // Return hash containing only requested barcodes:
+    return Promise.resolve(
+      barcodes.reduce((h, barcode) => {
+        h[barcode] = stubbedLookups[barcode]
+        return h
+      }, {})
+    )
   }
 }
 


### PR DESCRIPTION
Partner delivery locations failed to load due to restricting SCSB customer code lookup to only items with /^rc/ holding locations, which only match NYPL items. Added check for partner items as well (which may have all sorts of other holding locations). Fixed the bad test stub that failed to alert us to the issue.