### PR TITLE
Limit customer-code lookup to 5s

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -218,6 +218,10 @@ class AvailabilityResolver {
 
     return scsbClient.recapCustomerCodeByBarcode(barcode)
       .then((mostRecentCustomerCode) => {
+        if (!mostRecentCustomerCode) {
+          logger.debug('Not updating item with most recent customer code because none returned')
+          return
+        }
         if (!item.recapCustomerCode) item.recapCustomerCode = [mostRecentCustomerCode]
         else if (mostRecentCustomerCode !== item.recapCustomerCode[0]) {
           logger.error('Mismatched customer code', { 'barcode': barcode })

--- a/lib/scsb-client.js
+++ b/lib/scsb-client.js
@@ -12,9 +12,20 @@ const scsbClient = () => {
 
 const clientWrapper = {}
 
+/**
+ *  Utility for building a function that returns a Promise that rejects the
+ *  given error payload in the specified ms. Useful for racing unbound
+ *  requests.
+ */
+const rejectIn = (timeoutMs, errorPayload) => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => reject(errorPayload), timeoutMs)
+  })
+}
+
 clientWrapper.recapCustomerCodeByBarcode = (barcode) => {
   const __start = new Date()
-  return scsbClient().search({ fieldValue: barcode, fieldName: 'Barcode' })
+  const search = scsbClient().search({ fieldValue: barcode, fieldName: 'Barcode' })
     .then((response) => {
       let ellapsed = ((new Date()) - __start)
       logger.debug({ message: `HTC searchByParam API took ${ellapsed}ms`, metric: 'searchByParam-barcode', timeMs: ellapsed })
@@ -40,6 +51,14 @@ clientWrapper.recapCustomerCodeByBarcode = (barcode) => {
       logger.error(`Error retrieving customer code by barcode ${barcode}`, { scsbError: error.message })
       return null
     })
+  // Artificially limit effective search time by settling in 5s:
+  const timeoutMs = 5000
+  return Promise.race([
+    search,
+    rejectIn(timeoutMs, new Error(`Exhausted ${timeoutMs}ms timeout waiting for SCSB`))
+  ]).catch((e) => {
+    logger.error('Error fetching customer code: ', e)
+  })
 }
 
 clientWrapper.getItemsAvailabilityForBarcodes = (barcodes) => scsbClient().getItemsAvailabilityForBarcodes(barcodes)


### PR DESCRIPTION
Adds a quick fix to the customer code lookup that is triggered when specific items are indicated in the findById route (i.e. when retrieving item information for a hold-request). We look up an item's customer code in SCSB to be sure we have the most recent, accurate value (as it governs delivery options). If the SCSB API doesn't respond in 5s, we should assume there is a production SCSB issue and we should fall back on using whatever customer code we have indexed, which will be correct most of the time.