### PR TITLE
Scc 3541/add fulfillment

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -8,7 +8,7 @@ const DeliveryLocationsResolver = require('./delivery-locations-resolver')
 const recapCustomerCodes = require('@nypl/nypl-core-objects')('by-recap-customer-code')
 const Feature = require('../lib/feature')
 const { nonRecapItemStatusAggregation } = require('./es-client')
-const { deepValue, itemHasRecapHoldingLocation } = require('./util')
+const { deepValue, isInRecap } = require('./util')
 
 class AvailabilityResolver {
   constructor (responseReceived) {
@@ -212,7 +212,7 @@ class AvailabilityResolver {
   _checkScsbForRecapCustomerCode () {
     const item = this.elasticSearchResponse.hits.hits[0]._source.items[0]
     // If it's an electronic item or a non-recap item, skip it
-    if (item.electronicLocator || !this._isInRecap(item)) return Promise.resolve()
+    if (item.electronicLocator || !isInRecap(item)) return Promise.resolve()
     const barcode = this._getItemBarcode(item)
     if (!barcode) return Promise.resolve()
 
@@ -242,9 +242,9 @@ class AvailabilityResolver {
         item.physRequestable = false
         item.specRequestable = false
         item.requestable = [false]
-        const isInRecap = this._isInRecap(item)
-        item.eddRequestable = this._fixEddRequestability(item, isInRecap, request)
-        item.physRequestable = this._fixPhysRequestability(item, isInRecap, bibUri)
+        const _isInRecap = isInRecap(item)
+        item.eddRequestable = this._fixEddRequestability(item, _isInRecap, request)
+        item.physRequestable = this._fixPhysRequestability(item, _isInRecap, bibUri)
         item.specRequestable = !!item.aeonUrl
         item.requestable = [item.eddRequestable || item.physRequestable || item.specRequestable]
       })
@@ -313,11 +313,11 @@ class AvailabilityResolver {
   _fixItemAvailability (barcodesAndAvailability) {
     for (let hit of this.elasticSearchResponse.hits.hits) {
       (hit._source.items || []).map((item) => {
-        const isInRecap = this._isInRecap(item)
+        const _isInRecap = isInRecap(item)
         if (item.electronicLocator) return item
         // Only need to calculate recap item availability because nypl-owned records
         // status is updated elsewhere.
-        if (isInRecap) {
+        if (_isInRecap) {
           const barcode = this._getItemBarcode(item)
           let recapAvailabilityStatus = barcodesAndAvailability[barcode]
           if (recapAvailabilityStatus === 'Available') {
@@ -335,12 +335,6 @@ class AvailabilityResolver {
         return item
       })
     }
-  }
-
-  _isInRecap (item) {
-    return !!item.recapCustomerCode ||
-      itemHasRecapHoldingLocation(item) ||
-      !isItemNyplOwned(item)
   }
 
   _getItemBarcode (item) {

--- a/lib/fulfillment_resolver.js
+++ b/lib/fulfillment_resolver.js
@@ -9,8 +9,10 @@ class FulfillmentResolver {
       (hit._source.items || []).map((item) => {
         if (item.electronicLocator) return item
         const _isInRecap = isInRecap(item)
-        item.physFulfillment = {'@id': this._determinePhysFulfillment(item, _isInRecap, false)}
-        item.eddFulfillment = {'@id': this._determineEddFulfillment(item, _isInRecap, true)}
+        const physFulfillment = this._determinePhysFulfillment(item, _isInRecap)
+        const eddFulfillment = this._determineEddFulfillment(item, _isInRecap)
+        item.physFulfillment = physFulfillment && {'@id': physFulfillment}
+        item.eddFulfillment = eddFulfillment && {'@id': eddFulfillment}
         return item
       })
     }

--- a/lib/fulfillment_resolver.js
+++ b/lib/fulfillment_resolver.js
@@ -9,18 +9,19 @@ class FulfillmentResolver {
       (hit._source.items || []).map((item) => {
         if (item.electronicLocator) return item
         const _isInRecap = isInRecap(item)
-        item.physFulfillment = this._determinePhysFulfillment(item, _isInRecap, false)
-        item.eddFulfillment = this._determineEddFulfillment(item, _isInRecap, true)
+        item.physFulfillment = {'@id': this._determinePhysFulfillment(item, _isInRecap, false)}
+        item.eddFulfillment = {'@id': this._determineEddFulfillment(item, _isInRecap, true)}
         return item
       })
     }
     return this.elasticSearchResponse
   }
 
-  _onsiteLocation (onsiteLocationId) {
-    if (onsiteLocationId === 'sc') return 'sc'
-    else if (onsiteLocationId === 'ma') return 'sasb'
-    else if (onsiteLocationId === 'my') return 'lpa'
+  _onsiteLocation (locationCode) {
+    if (!locationCode) return
+    if (locationCode.startsWith('sc')) return 'sc'
+    else if (locationCode.startsWith('ma')) return 'sasb'
+    else if (locationCode.startsWith('my')) return 'lpa'
   }
 
   _recapLocation (recapDepository) {
@@ -29,9 +30,10 @@ class FulfillmentResolver {
   }
 
   _fulfillmentPrefix (item, _isInRecap) {
+    const locationCode = item.holdingLocation && item.holdingLocation[0] && item.holdingLocation[0].id.split(':')[1]
     return _isInRecap
       ? this._recapLocation(item.recapDepository)
-      : this._onsiteLocation(item.holdingLocation && item.holdingLocation.id)
+      : this._onsiteLocation(locationCode)
   }
 
   _determinePhysFulfillment (item, _isInRecap) {

--- a/lib/fulfillment_resolver.js
+++ b/lib/fulfillment_resolver.js
@@ -4,7 +4,7 @@ class FulfillmentResolver {
   constructor (responseReceived) {
     this.elasticSearchResponse = responseReceived
   }
-  responseWithFulfillmentEntities () {
+  responseWithFulfillment () {
     for (let hit of this.elasticSearchResponse.hits.hits) {
       (hit._source.items || []).map((item) => {
         if (item.electronicLocator) return item
@@ -14,6 +14,7 @@ class FulfillmentResolver {
         return item
       })
     }
+    return this.elasticSearchResponse
   }
 
   _onsiteLocation (onsiteLocationId) {

--- a/lib/fulfillment_resolver.js
+++ b/lib/fulfillment_resolver.js
@@ -9,8 +9,8 @@ class FulfillmentResolver {
       (hit._source.items || []).map((item) => {
         if (item.electronicLocator) return item
         const _isInRecap = isInRecap(item)
-        item.physFulfillment = this._determinePhysFulfillment(item, _isInRecap)
-        item.eddFulfillment = this._determineEddFulfillment(item, _isInRecap)
+        item.physFulfillment = this._determinePhysFulfillment(item, _isInRecap, false)
+        item.eddFulfillment = this._determineEddFulfillment(item, _isInRecap, true)
         return item
       })
     }
@@ -28,32 +28,29 @@ class FulfillmentResolver {
     else return 'hd'
   }
 
+  _fulfillmentPrefix (item, _isInRecap) {
+    return _isInRecap
+      ? this._recapLocation(item.recapDepository)
+      : this._onsiteLocation(item.holdingLocation && item.holdingLocation.id)
+  }
+
   _determinePhysFulfillment (item, _isInRecap) {
-    let fulfillmentInfo
-    if (item.physRequestable) {
-      if (_isInRecap) {
-        fulfillmentInfo = this._recapLocation(item.recapDepository) + '-offsite'
-      } else {
-        const onsiteLocation = this._onsiteLocation(item.holdingLocation.id)
-        if (onsiteLocation) fulfillmentInfo = onsiteLocation + '-onsite'
-      }
+    let fulfillmentPrefix = this._fulfillmentPrefix(item, _isInRecap)
+    let fulfillmentSuffix
+    if (item.physRequestable && _isInRecap) {
+      fulfillmentSuffix = '-offsite'
+    } else if (item.physRequestable && !_isInRecap) {
+      fulfillmentSuffix = '-onsite'
     }
-    if (fulfillmentInfo) return 'fulfillment:' + fulfillmentInfo
+    if (fulfillmentSuffix && fulfillmentPrefix) return 'fulfillment:' + fulfillmentPrefix + fulfillmentSuffix
   }
 
   _determineEddFulfillment (item, _isInRecap) {
-    let fulfillmentInfo
-    if (item.eddRequestable) {
-      if (_isInRecap) {
-        fulfillmentInfo = this._recapLocation(item.recapDepository)
-      } else {
-        const onsiteLocation = this._onsiteLocation(item.holdingLocation.id)
-        if (onsiteLocation) fulfillmentInfo = onsiteLocation
-      }
+    let fulfillmentPrefix = this._fulfillmentPrefix(item, _isInRecap)
+    if (item.eddRequestable && fulfillmentPrefix) {
+      return 'fulfillment:' + fulfillmentPrefix + '-edd'
     }
-    if (fulfillmentInfo) return 'fulfillment:' + fulfillmentInfo + '-edd'
   }
-
 }
 
 module.exports = FulfillmentResolver

--- a/lib/fulfillment_resolver.js
+++ b/lib/fulfillment_resolver.js
@@ -1,15 +1,12 @@
 const { isInRecap } = require('./util')
 
-const sierraLocations = require('@nypl/nypl-core-objects')('by-sierra-location')
-
-class Fulfillment {
+class FulfillmentResolver {
   constructor (responseReceived) {
     this.elasticSearchResponse = responseReceived
   }
-  responseWithFulfillmentEntities() {
+  responseWithFulfillmentEntities () {
     for (let hit of this.elasticSearchResponse.hits.hits) {
       (hit._source.items || []).map((item) => {
-
         if (item.electronicLocator) return item
         const _isInRecap = isInRecap(item)
         item.physFulfillment = this._determinePhysFulfillment(item, _isInRecap)
@@ -19,18 +16,18 @@ class Fulfillment {
     }
   }
 
-  _onsiteLocation(onsiteLocationId) {
+  _onsiteLocation (onsiteLocationId) {
     if (onsiteLocationId === 'sc') return 'sc'
     else if (onsiteLocationId === 'ma') return 'sasb'
     else if (onsiteLocationId === 'my') return 'lpa'
   }
 
-  _recapLocation(recapDepository) {
-    if (recapDepository != 'hd') return 'recap'
+  _recapLocation (recapDepository) {
+    if (recapDepository !== 'hd') return 'recap'
     else return 'hd'
   }
 
-  _determinePhysFulfillment(item, _isInRecap) {
+  _determinePhysFulfillment (item, _isInRecap) {
     let fulfillmentInfo
     if (item.physRequestable) {
       if (_isInRecap) {
@@ -43,7 +40,7 @@ class Fulfillment {
     if (fulfillmentInfo) return 'fulfillment:' + fulfillmentInfo
   }
 
-  _determineEddFulfillment(item, _isInRecap) {
+  _determineEddFulfillment (item, _isInRecap) {
     let fulfillmentInfo
     if (item.eddRequestable) {
       if (_isInRecap) {
@@ -58,4 +55,4 @@ class Fulfillment {
 
 }
 
-module.exports = Fulfillment
+module.exports = FulfillmentResolver

--- a/lib/fulfillment_updater.js
+++ b/lib/fulfillment_updater.js
@@ -1,0 +1,61 @@
+const { isInRecap } = require('./util')
+
+const sierraLocations = require('@nypl/nypl-core-objects')('by-sierra-location')
+
+class Fulfillment {
+  constructor (responseReceived) {
+    this.elasticSearchResponse = responseReceived
+  }
+  responseWithFulfillmentEntities() {
+    for (let hit of this.elasticSearchResponse.hits.hits) {
+      (hit._source.items || []).map((item) => {
+
+        if (item.electronicLocator) return item
+        const _isInRecap = isInRecap(item)
+        item.physFulfillment = this._determinePhysFulfillment(item, _isInRecap)
+        item.eddFulfillment = this._determineEddFulfillment(item, _isInRecap)
+        return item
+      })
+    }
+  }
+
+  _onsiteLocation(onsiteLocationId) {
+    if (onsiteLocationId === 'sc') return 'sc'
+    else if (onsiteLocationId === 'ma') return 'sasb'
+    else if (onsiteLocationId === 'my') return 'lpa'
+  }
+
+  _recapLocation(recapDepository) {
+    if (recapDepository != 'hd') return 'recap'
+    else return 'hd'
+  }
+
+  _determinePhysFulfillment(item, _isInRecap) {
+    let fulfillmentInfo
+    if (item.physRequestable) {
+      if (_isInRecap) {
+        fulfillmentInfo = this._recapLocation(item.recapDepository) + '-offsite'
+      } else {
+        const onsiteLocation = this._onsiteLocation(item.holdingLocation.id)
+        if (onsiteLocation) fulfillmentInfo = onsiteLocation + '-onsite'
+      }
+    }
+    if (fulfillmentInfo) return 'fulfillment:' + fulfillmentInfo
+  }
+
+  _determineEddFulfillment(item, _isInRecap) {
+    let fulfillmentInfo
+    if (item.eddRequestable) {
+      if (_isInRecap) {
+        fulfillmentInfo = this._recapLocation(item.recapDepository)
+      } else {
+        const onsiteLocation = this._onsiteLocation(item.holdingLocation.id)
+        if (onsiteLocation) fulfillmentInfo = onsiteLocation
+      }
+    }
+    if (fulfillmentInfo) return 'fulfillment:' + fulfillmentInfo + '-edd'
+  }
+
+}
+
+module.exports = Fulfillment

--- a/lib/response_massager.js
+++ b/lib/response_massager.js
@@ -2,6 +2,7 @@ const LocationLabelUpdater = require('./location_label_updater')
 const AvailabilityResolver = require('./availability_resolver.js')
 const parallelFieldsExtractor = require('./parallel-fields-extractor')
 const {isAeonUrl} = require('../lib/util')
+const FulfillmentResolver = require('./fulfillment_resolver')
 // const addNumItemsMatched = require('./item-match-numerator')
 
 class ResponseMassager {
@@ -74,6 +75,7 @@ class ResponseMassager {
         return (new LocationLabelUpdater(response))
           .responseWithUpdatedLabels()
       })
+      .then((response) => new FulfillmentResolver(response).responseWithFulfillment())
   }
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,7 @@ const jsonld = require('jsonld')
 const fs = require('fs')
 const csv = require('fast-csv')
 const logger = require('./logger')
+const isItemNyplOwned = require('./ownership_determination').isItemNyplOwned
 
 var exports = module.exports = {}
 
@@ -481,3 +482,8 @@ exports.isAeonUrl = (url) => {
   return Boolean(aeonLinks.some((path) => link.startsWith(path)))
 }
 
+exports.isInRecap = (item) => {
+  return !!item.recapCustomerCode ||
+    exports.itemHasRecapHoldingLocation(item) ||
+    !isItemNyplOwned(item)
+}

--- a/test/fulfillment_resolver.test.js
+++ b/test/fulfillment_resolver.test.js
@@ -40,7 +40,7 @@ describe('FulfillmentResolver', () => {
       expect(FulfillmentResolver.prototype._determinePhysFulfillment(item, false))
         .to.equal('fulfillment:lpa-onsite')
     })
-    it('returns undefined when fulfillmentInfo is undefined', () => {
+    it('returns undefined when fulfillmentPrefix is undefined', () => {
       const item = {physRequestable: true, holdingLocation: {id: 'xyz'}}
       expect(FulfillmentResolver.prototype._determinePhysFulfillment(item, false))
         .to.equal(undefined)
@@ -61,7 +61,7 @@ describe('FulfillmentResolver', () => {
       expect(FulfillmentResolver.prototype._determineEddFulfillment(item, false))
         .to.equal('fulfillment:sc-edd')
     })
-    it('returns undefined when fulfillmentInfo is undefined', () => {
+    it('returns undefined when fulfillmentPrefix is undefined', () => {
       const item = {eddRequestable: true, holdingLocation: {id: 'xyz'}}
       expect(FulfillmentResolver.prototype._determineEddFulfillment(item, false))
         .to.equal(undefined)

--- a/test/fulfillment_resolver.test.js
+++ b/test/fulfillment_resolver.test.js
@@ -36,12 +36,12 @@ describe('FulfillmentResolver', () => {
         .to.equal('fulfillment:hd-offsite')
     })
     it('returns correctly for onsite item', () => {
-      const item = {physRequestable: true, holdingLocation: {id: 'my'}}
+      const item = {physRequestable: true, holdingLocation: [{id: 'loc:my'}]}
       expect(FulfillmentResolver.prototype._determinePhysFulfillment(item, false))
         .to.equal('fulfillment:lpa-onsite')
     })
     it('returns undefined when fulfillmentPrefix is undefined', () => {
-      const item = {physRequestable: true, holdingLocation: {id: 'xyz'}}
+      const item = {physRequestable: true, holdingLocation: [{id: 'loc:xyz'}]}
       expect(FulfillmentResolver.prototype._determinePhysFulfillment(item, false))
         .to.equal(undefined)
     })
@@ -57,12 +57,12 @@ describe('FulfillmentResolver', () => {
         .to.equal('fulfillment:recap-edd')
     })
     it('returns correctly for onsite item', () => {
-      const item = {eddRequestable: true, holdingLocation: {id: 'sc'}}
+      const item = {eddRequestable: true, holdingLocation: [{id: 'loc:sc'}]}
       expect(FulfillmentResolver.prototype._determineEddFulfillment(item, false))
         .to.equal('fulfillment:sc-edd')
     })
     it('returns undefined when fulfillmentPrefix is undefined', () => {
-      const item = {eddRequestable: true, holdingLocation: {id: 'xyz'}}
+      const item = {eddRequestable: true, holdingLocation: [{id: 'loc:xyz'}]}
       expect(FulfillmentResolver.prototype._determineEddFulfillment(item, false))
         .to.equal(undefined)
     })

--- a/test/fulfillment_resolver.test.js
+++ b/test/fulfillment_resolver.test.js
@@ -1,0 +1,70 @@
+const expect = require('chai').expect
+
+const FulfillmentResolver = require('../lib/fulfillment_resolver')
+
+describe.only('FulfillmentResolver', () => {
+  describe('_onsiteLocation', () => {
+    it('returns sc', () => {
+      expect(FulfillmentResolver.prototype._onsiteLocation('sc')).to.equal('sc')
+    })
+    it('returns sasb', () => {
+      expect(FulfillmentResolver.prototype._onsiteLocation('ma')).to.equal('sasb')
+    })
+    it('returns lpa', () => {
+      expect(FulfillmentResolver.prototype._onsiteLocation('my')).to.equal('lpa')
+    })
+    it('returns undefined', () => {
+      expect(FulfillmentResolver.prototype._onsiteLocation('llol')).to.equal(undefined)
+    })
+  })
+  describe('_recapLocation', () => {
+    it('returns hd', () => {
+      expect(FulfillmentResolver.prototype._recapLocation('hd')).to.equal('hd')
+    })
+    it('returns recap', () => {
+      expect(FulfillmentResolver.prototype._recapLocation('not hd')).to.equal('recap')
+    })
+  })
+  describe('_determinePhysFulfillment', () => {
+    it('returns undefined when item is not physRequestable', () => {
+      expect(FulfillmentResolver.prototype._determinePhysFulfillment({}))
+        .to.equal(undefined)
+    })
+    it('returns correctly for hd item', () => {
+      const item = {physRequestable: true, recapDepository: 'hd'}
+      expect(FulfillmentResolver.prototype._determinePhysFulfillment(item, true))
+        .to.equal('fulfillment:hd-offsite')
+    })
+    it('returns correctly for onsite item', () => {
+      const item = {physRequestable: true, holdingLocation: {id: 'my'}}
+      expect(FulfillmentResolver.prototype._determinePhysFulfillment(item, false))
+        .to.equal('fulfillment:lpa-onsite')
+    })
+    it('returns undefined when fulfillmentInfo is undefined', () => {
+      const item = {physRequestable: true, holdingLocation: {id: 'xyz'}}
+      expect(FulfillmentResolver.prototype._determinePhysFulfillment(item, false))
+        .to.equal(undefined)
+    })
+  })
+  describe('_determineEddFulfillment', () => {
+    it('returns undefined when item is not eddRequestable', () => {
+      expect(FulfillmentResolver.prototype._determineEddFulfillment({}))
+        .to.equal(undefined)
+    })
+    it('returns correctly for recap item', () => {
+      const item = {eddRequestable: true, recapDepository: 'recap'}
+      expect(FulfillmentResolver.prototype._determineEddFulfillment(item, true))
+        .to.equal('fulfillment:recap-edd')
+    })
+    it('returns correctly for onsite item', () => {
+      const item = {eddRequestable: true, holdingLocation: {id: 'sc'}}
+      expect(FulfillmentResolver.prototype._determineEddFulfillment(item, false))
+        .to.equal('fulfillment:sc-edd')
+    })
+    it('returns undefined when fulfillmentInfo is undefined', () => {
+      const item = {eddRequestable: true, holdingLocation: {id: 'xyz'}}
+      expect(FulfillmentResolver.prototype._determineEddFulfillment(item, false))
+        .to.equal(undefined)
+    })
+  })
+})

--- a/test/fulfillment_resolver.test.js
+++ b/test/fulfillment_resolver.test.js
@@ -2,7 +2,7 @@ const expect = require('chai').expect
 
 const FulfillmentResolver = require('../lib/fulfillment_resolver')
 
-describe.only('FulfillmentResolver', () => {
+describe('FulfillmentResolver', () => {
   describe('_onsiteLocation', () => {
     it('returns sc', () => {
       expect(FulfillmentResolver.prototype._onsiteLocation('sc')).to.equal('sc')


### PR DESCRIPTION
- Creates FulfillmentResolver. The class's only public function returns an elastic search response with fulfillment links attached to items with `phys` and or `eddrequestable = true`. 
- Extracts isInRecap to `utils.js`

For meaningful deployment, this is dependent on forthcoming and unassigned [add recapDepository to Es Index](https://jira.nypl.org/browse/SCC-3448). Until then, no recap items will get `physFulfillment` or `eddFulfillment`, as those strings are dependent on item.recapDepository, which does not yet exist.