### PR TITLE
Fix broken annotated-marc test

### DIFF
--- a/test/annotated-marc-rules.test.js
+++ b/test/annotated-marc-rules.test.js
@@ -534,18 +534,32 @@ describe('Annotated Marc Rules', function () {
     })
   })
 
-  describe('Added Title 246 Fields', function () {
-    it('should have added title field for MARC tags 24630/1/blank', function () {
-      const sampleBib = { varFields: [{ fieldTag: 'u', marcTag: '246', ind1: '3', ind2: '0', subfields: [{ tag: 'a', content: 'how' }, { tag: '6', content: '880-01' }] },
-        { fieldTag: 'u', marcTag: '246', ind1: '3', ind2: ' ', subfields: [{ tag: 'a', content: 'town' }] }
-      ] }
+  describe('Added Title Page Title 246 Fields', function () {
+    it('should have added title field for MARC tags 24615/1/blank', function () {
+      const sampleBib = {
+        varFields: [
+          {
+            fieldTag: 'u',
+            marcTag: '246', ind1: '1', ind2: '5',
+            subfields: [{ tag: 'a', content: 'how' }, { tag: '6', content: '880-01' }]
+          },
+          // This one is a 246, but won't match the current pattern of ^24615:
+          {
+            fieldTag: 'u',
+            marcTag: '246', ind1: '3', ind2: ' ',
+            subfields: [{ tag: 'a', content: 'town' }]
+          }
+        ]
+      }
       const serialized = AnnotatedMarcSerializer.serialize(sampleBib)
       expect(serialized.bib).to.be.an('object')
       expect(serialized.bib.fields).to.be.an('array')
       expect(serialized.bib.fields).to.have.lengthOf(1)
-      expect(serialized.bib.fields[0].label).to.equal('Added Title')
+      expect(serialized.bib.fields[0].label).to.equal('Added Title Page Title')
       expect(serialized.bib.fields[0].values).to.be.an('array')
-      expect(serialized.bib.fields[0].values).to.have.lengthOf(2)
+      // Only the first 246 in the sampleBib matches:
+      expect(serialized.bib.fields[0].values).to.have.lengthOf(1)
+      expect(serialized.bib.fields[0].values[0].content).to.equal('how')
     })
   })
 


### PR DESCRIPTION
This was broken because one of the annotated-marc-tests randomly chose to assert that varFields with marc 246 and fieldTag u are mapped to "Added Title". In actuality, the rule didn't actually dictate a marc tag of 246. The rule the test was using was actually a fall-through rule applied to all varFields with fieldTag u.

(The logic of webpub.def is it's a series of patterns applied to varField and first- and second-indicator values. When nothing matches there, there is often a catch-all rule for the fieldTag.)

That rule is [here](https://github.com/NYPL/discovery-api/blob/775e85f9080cb4020d8f2b0298a7f025bc752219/data/annotated-marc-rules.json#L2150-L2162)

Since that rule has been removed in the latest webpub.def, our annotated-marc rules correctly no longer consider just any varField with fieldTag u as "Added Title". So I changed the test to be some other arbitrary assertion, this time for something more specific: It's asserting that a rule over varFields with marc 246 and 1st indicator '1' and second indicator '5' (hence the pattern `^24615`) tags such a varField as "Added Title Page Title".