### PR TITLE
Fix bug where partner bib item status aggs are wrong

### DIFF
--- a/lib/availability_resolver.js
+++ b/lib/availability_resolver.js
@@ -2,6 +2,7 @@ const config = require('config')
 const scsbClient = require('./scsb-client')
 const logger = require('./logger')
 const ResourceSerializer = require('./jsonld_serializers').ResourceSerializer
+const NyplSourceMapper = require('discovery-store-models/lib/nypl-source-mapper')
 const { nonRecapItemStatusAggregation } = require('./es-client')
 const { deepValue, isInRecap } = require('./util')
 
@@ -58,19 +59,26 @@ class AvailabilityResolver {
       logger.debug('_fixItemStatusAggregation: Skipping because no SCSB statuses provided')
       return Promise.resolve()
     }
+    const bnum = this.elasticSearchResponse.hits.hits[0]._id
+    const { nyplSource } = NyplSourceMapper.instance().splitIdentifier(bnum)
 
-    // Count number of ReCAP items by summing the counts for rc* locations:
-    const numRecapItems = resp.aggregations.item_location._nested.buckets
-      .filter((bucket) => /^loc:rc/.test(bucket.key))
-      .reduce((sum, entry) => entry.doc_count + sum, 0)
+    // Get total number of items:
+    const numItems = (resp.hits.hits[0]._source.numItemsTotal || resp.hits.hits[0]._source.numItems)[0]
+
+    // For partner bibs, all items are ReCAP items:
+    const numRecapItems = nyplSource !== 'sierra-nypl'
+      ? numItems
+      // For NYPL bibs, count number of ReCAP items by summing the counts for
+      // rc* locations:
+      : resp.aggregations.item_location._nested.buckets
+        .filter((bucket) => /^loc:rc/.test(bucket.key))
+        .reduce((sum, entry) => entry.doc_count + sum, 0)
 
     // If no ReCAP items, then response has correct item status aggregation
     if (numRecapItems === 0) return Promise.resolve()
 
     const recapStatusesAsEsAggregation = this._recapStatusesAsEsAggregations(options.recapBarcodesByStatus)
 
-    // Get total number of items:
-    const numItems = (resp.hits.hits[0]._source.numItemsTotal || resp.hits.hits[0]._source.numItems)[0]
     logger.debug(`_fixItemStatusAggregation: Total items: ${numItems}. ReCAP items: ${numRecapItems}`)
     logger.debug(`_fixItemStatusAggregation: Original status agg: ${JSON.stringify(resp.aggregations.item_status._nested.buckets)}`)
     logger.debug(`_fixItemStatusAggregation: Incorporating ReCAP statuses: ${JSON.stringify(recapStatusesAsEsAggregation)}}`)

--- a/lib/requestability_resolver.js
+++ b/lib/requestability_resolver.js
@@ -17,13 +17,11 @@ class RequestabilityResolver {
             // requestable.
             physRequestableCriteria = 'Missing customer code'
             deliveryInfo = { eddRequestable: true, deliveryLocation: [''] }
-          }
-          else if (itemIsInRecap && hasRecapCustomerCode) {
+          } else if (itemIsInRecap && hasRecapCustomerCode) {
             deliveryInfo = DeliveryLocationsResolver.getRecapDeliveryInfo(item)
             physRequestableCriteria = `${deliveryInfo.deliveryLocation &&
               deliveryInfo.deliveryLocation.length || 0} delivery locations.`
-          }
-          else if (!itemIsInRecap) {
+          } else if (!itemIsInRecap) {
             deliveryInfo = DeliveryLocationsResolver.getOnsiteDeliveryInfo(item)
             physRequestableCriteria = `${deliveryInfo.deliveryLocation &&
               deliveryInfo.deliveryLocation.length || 0} delivery locations.`

--- a/lib/scsb-client.js
+++ b/lib/scsb-client.js
@@ -1,5 +1,6 @@
 const ScsbRestClient = require('@nypl/scsb-rest-client')
 const request = require('request')
+const NyplSourceMapper = require('discovery-store-models/lib/nypl-source-mapper')
 const logger = require('./logger')
 const { bNumberWithCheckDigit } = require('./util')
 
@@ -65,11 +66,16 @@ clientWrapper.getItemsAvailabilityForBarcodes = (barcodes) => scsbClient().getIt
 
 // bnum is a plain bnum without padding such as we use in the DiscoveryAPI
 clientWrapper.getItemsAvailabilityForBnum = (bnum) => {
-  const bibId = bnum.replace(/^b/, '')
-  const body = {
-    institutionId: 'NYPL',
-    bibliographicId: `.b${bNumberWithCheckDigit(bibId)}`
-  }
+  // Identify nypl-source and unprefixed id:
+  const { nyplSource, id } = NyplSourceMapper.instance().splitIdentifier(bnum)
+  // Determine SCSB "institutionId" (e.g. NYPL, HL, CUL, PUL):
+  const institutionId = nyplSource.split('-').pop().toUpperCase()
+  // The "bibliographicId" in SCSB for our items is padded and prefixed;
+  // not so for partner items:
+  const bibliographicId = institutionId === 'NYPL'
+    ? `.b${bNumberWithCheckDigit(id)}`
+    : id
+  const body = { institutionId, bibliographicId }
   return scsbClient()
     .scsbQuery('/sharedCollection/bibAvailabilityStatus', body)
     // Remove entries sans barcodes as they are just error responses

--- a/test/availability_resolver.test.js
+++ b/test/availability_resolver.test.js
@@ -356,5 +356,22 @@ describe('Response with updated availability', function () {
           ])
         })
     })
+
+    it('incorporates Not Available statuses for partner items that are not available in ReCAP', () => {
+      const availabilityResolver = new AvailabilityResolver(
+        require('./fixtures/es-response-pb2847934.json')
+      )
+
+      const recapBarcodesByStatus = {
+        'Not Available': ['32101095377683']
+      }
+      return availabilityResolver.responseWithUpdatedAvailability({ recapBarcodesByStatus })
+        .then((modifiedResponse) => {
+          const buckets = modifiedResponse.aggregations.item_status._nested.buckets
+          expect(buckets).to.deep.equal([
+            { key: 'status:na||Not available', doc_count: 1 }
+          ])
+        })
+    })
   })
 })

--- a/test/fixtures/es-response-pb2847934.json
+++ b/test/fixtures/es-response-pb2847934.json
@@ -1,0 +1,300 @@
+{
+  "took": 5,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 14.900511,
+    "hits": [
+      {
+        "_index": "resources-2020-05-08",
+        "_type": "resource",
+        "_id": "pb2847934",
+        "_score": 14.900511,
+        "_source": {
+          "extent": [
+            "103 p. ;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "\"First performed at the Royal Court Theatre Upstairs ... on 12th February 1999.\"",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "recap-pul"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "Oberon"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            1
+          ],
+          "createdYear": [
+            1999
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "title": [
+            "Toast"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "creatorLiteral": [
+            "Bean, Richard, 1956-"
+          ],
+          "createdString": [
+            "1999"
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1999
+          ],
+          "identifierV2": [
+            {
+              "type": "nypl:Bnumber",
+              "value": "2847934"
+            },
+            {
+              "type": "bf:Isbn",
+              "value": "1840021047"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "SCSB-964143"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(CStRLIN)GAEGO42263032-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(GEU)(Sirsi)o42263032"
+            }
+          ],
+          "idOclc": [
+            "SCSB-964143"
+          ],
+          "updatedAt": 1691435028691,
+          "publicationStatement": [
+            "London : Oberon, 1999."
+          ],
+          "identifier": [
+            "urn:bnum:2847934",
+            "urn:isbn:1840021047",
+            "urn:oclc:SCSB-964143",
+            "urn:undefined:(CStRLIN)GAEGO42263032-B",
+            "urn:undefined:(GEU)(Sirsi)o42263032"
+          ],
+          "idIsbn": [
+            "1840021047"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1999"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "titleDisplay": [
+            "Toast / by Richard Bean."
+          ],
+          "uri": "pb2847934",
+          "numItems": [
+            1
+          ],
+          "numAvailable": [
+            1
+          ],
+          "placeOfPublication": [
+            "London"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "idIsbn_clean": [
+            "1840021047"
+          ],
+          "dimensions": [
+            "21 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 1,
+              "max_score": null,
+              "hits": [
+                {
+                  "_nested": {
+                    "field": "items",
+                    "offset": 0
+                  },
+                  "_score": null,
+                  "_source": {
+                    "uri": "pi2440892",
+                    "status": [
+                      {
+                        "id": "status:a",
+                        "label": "Available"
+                      }
+                    ],
+                    "status_packed": [
+                      "status:a||Available"
+                    ],
+                    "owner": [
+                      {
+                        "id": "orgs:0003",
+                        "label": "Princeton University Library"
+                      }
+                    ],
+                    "owner_packed": [
+                      "orgs:0003||Princeton University Library"
+                    ],
+                    "catalogItemType": [
+                      {
+                        "id": "catalogItemType:1",
+                        "label": "non-circ"
+                      }
+                    ],
+                    "catalogItemType_packed": [
+                      "catalogItemType:1||non-circ"
+                    ],
+                    "shelfMark": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "identifierV2": [
+                      {
+                        "value": "PR6052.E176 T627 1999",
+                        "type": "bf:ShelfMark"
+                      },
+                      {
+                        "type": "bf:Barcode",
+                        "value": "32101095377683"
+                      }
+                    ],
+                    "physicalLocation": [
+                      "PR6052.E176 T627 1999"
+                    ],
+                    "recapCustomerCode": [
+                      "PA"
+                    ],
+                    "identifier": [
+                      "urn:barcode:32101095377683"
+                    ],
+                    "idBarcode": [
+                      "32101095377683"
+                    ],
+                    "requestable": [
+                      true
+                    ],
+                    "accessMessage": [
+                      {
+                        "id": "accessMessage:1",
+                        "label": "Use in library"
+                      }
+                    ],
+                    "accessMessage_packed": [
+                      "accessMessage:1||Use in library"
+                    ],
+                    "type": [
+                      "bf:Item"
+                    ],
+                    "formatLiteral": [
+                      "Text"
+                    ],
+                    "shelfMark_sort": "aPR6052.E176 T627 001999"
+                  },
+                  "sort": [
+                    null
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 1,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": []
+      }
+    },
+    "item_format": {
+      "doc_count": 1,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "Text",
+            "doc_count": 1
+          }
+        ]
+      }
+    },
+    "item_status": {
+      "doc_count": 1,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": [
+          {
+            "key": "status:a||Available",
+            "doc_count": 1
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/scsb-client.test.js
+++ b/test/scsb-client.test.js
@@ -1,0 +1,65 @@
+const sinon = require('sinon')
+const ScsbRestClient = require('@nypl/scsb-rest-client')
+const scsbClient = require('../lib/scsb-client')
+
+describe('scsb-client', () => {
+  describe('getItemsAvailabilityForBnum', () => {
+    beforeEach(() => {
+      sinon.stub(ScsbRestClient.prototype, 'scsbQuery')
+        .callsFake((path, body) => {
+          return Promise.resolve([
+            {
+              itemBarcode: 'some-barcode',
+              itemAvailabilityStatus: 'Available'
+            }
+          ])
+        })
+    })
+
+    afterEach(() => {
+      ScsbRestClient.prototype.scsbQuery.restore()
+    })
+
+    it('returns barcode-status map for NYPL bnum', () => {
+      return scsbClient.getItemsAvailabilityForBnum('b123')
+        .then((resp) => {
+          // Verify SCSB API hit once:
+          expect(ScsbRestClient.prototype.scsbQuery.callCount).to.equal(1)
+          // Verify SCSB bibAvailabilityStatus query performed
+          expect(ScsbRestClient.prototype.scsbQuery.firstCall.args[0])
+            .to.equal('/sharedCollection/bibAvailabilityStatus')
+          expect(ScsbRestClient.prototype.scsbQuery.firstCall.args[1])
+            .to.deep.equal({
+              institutionId: 'NYPL',
+              // Verify payload has NYPL padded bnum:
+              bibliographicId: '.b1235'
+            })
+
+          // Verify stubbed response is intact
+          expect(resp).to.deep.equal([
+            {
+              itemBarcode: 'some-barcode',
+              itemAvailabilityStatus: 'Available'
+            }
+          ])
+        })
+    })
+
+    it('returns barcode-status map for partner bnum', () => {
+      return scsbClient.getItemsAvailabilityForBnum('hb123')
+        .then((resp) => {
+          // Verify SCSB API hit once:
+          expect(ScsbRestClient.prototype.scsbQuery.callCount).to.equal(1)
+          // Verify SCSB bibAvailabilityStatus query performed
+          expect(ScsbRestClient.prototype.scsbQuery.firstCall.args[0])
+            .to.equal('/sharedCollection/bibAvailabilityStatus')
+          expect(ScsbRestClient.prototype.scsbQuery.firstCall.args[1])
+            .to.deep.equal({
+              institutionId: 'HL',
+              // Verify payload has original HL bnum:
+              bibliographicId: '123'
+            })
+        })
+    })
+  })
+})


### PR DESCRIPTION
We don't appear to be properly folding in partner item statuses when building item aggregations. This fixes that.