### PR TITLE
Fix bug calculating hasItemDatesParsed

### DIFF
--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -254,9 +254,13 @@ class ResourceSerializer extends JsonLdItemSerializer {
       stmts.itemAggregations = ResourceSerializer.formatItemFilterAggregations(this.body.itemAggregations)
     }
 
-    // Add hasVol and hasDate properties
+    // Add hasItemVolumes and hasItemDates bool properties to indicate whether
+    // or not one can do meaningful date/volume filters on this bib
     stmts.hasItemVolumes = false
     stmts.hasItemDates = false
+    // Check both numItemsTotal (the property written by RCI) and numItems
+    // (written by legacy indexing process). Note that very old bibs may have
+    // neither
     const numItems = this.body.numItemsTotal && this.body.numItemsTotal[0] || this.body.numItems && this.body.numItems[0]
     if (numItems) {
       if (Array.isArray(this.body.numItemVolumesParsed)) {

--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -257,14 +257,13 @@ class ResourceSerializer extends JsonLdItemSerializer {
     // Add hasVol and hasDate properties
     stmts.hasItemVolumes = false
     stmts.hasItemDates = false
-    // once we switch to RCI, we can remove numItems check.
-    const numItems = this.body.numItems && this.body.numItems[0] || this.body.numItemsTotal[0]
+    const numItems = this.body.numItemsTotal && this.body.numItemsTotal[0] || this.body.numItems && this.body.numItems[0]
     if (numItems) {
       if (Array.isArray(this.body.numItemVolumesParsed)) {
-        stmts.hasItemVolumes = this.body.numItemVolumesParsed[0] / numItems > parseFloat(process.env.BIB_HAS_VOLUMES_THRESHOLD)
+        stmts.hasItemVolumes = this.body.numItemVolumesParsed[0] / numItems >= parseFloat(process.env.BIB_HAS_VOLUMES_THRESHOLD)
       }
       if (Array.isArray(this.body.numItemDatesParsed)) {
-        stmts.hasItemDates = this.body.numItemDatesParsed[0] / numItems > parseFloat(process.env.BIB_HAS_DATES_THRESHOLD)
+        stmts.hasItemDates = this.body.numItemDatesParsed[0] / numItems >= parseFloat(process.env.BIB_HAS_DATES_THRESHOLD)
       }
     }
 

--- a/test/jsonld-serializers.test.js
+++ b/test/jsonld-serializers.test.js
@@ -33,7 +33,7 @@ describe('JSONLD Serializers', () => {
         numItems: [10]
       }
       const serialized = ResourceSerializer.serialize(esDoc)
-      // When 8 of 10 items have parsed dates, we fail the min 80% thresshold:
+      // When 8 of 10 items have parsed dates, we meet the min 80% thresshold:
       expect(serialized.hasItemDates).to.equal(true)
     })
 

--- a/test/jsonld-serializers.test.js
+++ b/test/jsonld-serializers.test.js
@@ -1,0 +1,69 @@
+const { expect } = require('chai')
+
+const { ResourceSerializer } = require('../lib/jsonld_serializers')
+
+describe('JSONLD Serializers', () => {
+  describe('ResourceSerializer', () => {
+    it('enables hasItemDates when numItemsTotal is above thresshold', () => {
+      const esDoc = {
+        uri: 'b123',
+        numItemDatesParsed: [8],
+        numItemsTotal: [10]
+      }
+      const serialized = ResourceSerializer.serialize(esDoc)
+      // When 8 of 10 items have parsed dates, we meet the min 80% thresshold:
+      expect(serialized.hasItemDates).to.equal(true)
+    })
+
+    it('disables hasItemDates when numItemsTotal is below thresshold', () => {
+      const esDoc = {
+        uri: 'b123',
+        numItemDatesParsed: [7],
+        numItemsTotal: [10]
+      }
+      const serialized = ResourceSerializer.serialize(esDoc)
+      // When 7 of 10 items have parsed dates, we fail the min 80% thresshold:
+      expect(serialized.hasItemDates).to.equal(false)
+    })
+
+    it('enables hasItemDates when numItemsTotal is missing but numItems is above thresshold', () => {
+      const esDoc = {
+        uri: 'b123',
+        numItemDatesParsed: [8],
+        numItems: [10]
+      }
+      const serialized = ResourceSerializer.serialize(esDoc)
+      // When 8 of 10 items have parsed dates, we fail the min 80% thresshold:
+      expect(serialized.hasItemDates).to.equal(true)
+    })
+
+    it('disables hasItemDates when numItemsTotal is missing and numItems is below thresshold', () => {
+      const esDoc = {
+        uri: 'b123',
+        numItemDatesParsed: [7],
+        numItems: [10]
+      }
+      const serialized = ResourceSerializer.serialize(esDoc)
+      // When 7 of 10 items have parsed dates, we fail the min 80% thresshold:
+      expect(serialized.hasItemDates).to.equal(false)
+    })
+
+    it('disables hasItemDates when any counts are missing', () => {
+      ; [
+        // No numItems or numItemsTotal set (unlikely):
+        {
+          uri: 'b123',
+          numItemDatesParsed: [7]
+        },
+        // No numItemDatesParsed set:
+        {
+          uri: 'b123',
+          numItems: [10]
+        }
+      ].forEach((esDoc) => {
+        const serialized = ResourceSerializer.serialize(esDoc)
+        expect(serialized.hasItemDates).to.equal(false)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fix bug calculating `hasItemDates` (the property that controls whether or not the Date Filter is shown in RC):
 - Favor `numItemsTotal` over `numItems` (which is not written by RCI)
 - Don't assume that if `numItems` is not set, then `numItemsTotal` is set. There may be very old bibs that have neither
 - Make the check greater-than-**OR-EQUAL** so that a bib that exactly meets the threshold gets a date filter
 - Adds serializer tests