### PR TITLE
Scc 3581/rom schom

### DIFF
--- a/lib/requestability_resolver.js
+++ b/lib/requestability_resolver.js
@@ -1,6 +1,6 @@
 const DeliveryLocationsResolver = require('./delivery-locations-resolver')
 const { isItemNyplOwned } = require('./ownership_determination')
-const { isInRecap } = require('./util')
+const { isInRecap, isInSchomburg, getSchomburgDeliveryInfo } = require('./util')
 const logger = require('./logger')
 class RequestabilityResolver {
   static fixItemRequestability (elasticSearchResponse) {
@@ -25,6 +25,9 @@ class RequestabilityResolver {
             deliveryInfo = DeliveryLocationsResolver.getOnsiteDeliveryInfo(item)
             physRequestableCriteria = `${deliveryInfo.deliveryLocation &&
               deliveryInfo.deliveryLocation.length || 0} delivery locations.`
+          }
+          if (isInSchomburg(item)) {
+            deliveryInfo = getSchomburgDeliveryInfo(item, deliveryInfo)
           }
           item.eddRequestable = !!deliveryInfo.eddRequestable
           item.physRequestable = !!(deliveryInfo.deliveryLocation &&

--- a/lib/util.js
+++ b/lib/util.js
@@ -489,13 +489,25 @@ exports.isInRecap = (item) => {
 
 exports.isInSchomburg = (item) => {
   const holdingLocation = exports.deepValue(item, 'holdingLocation[0].id')
-  if (holdingLocation) return holdingLocation.startsWith('loc:sc')
+  if (holdingLocation) {
+    return holdingLocation.startsWith('loc:sc')
+  }
 }
 
-exports.isSchomburgRequestableItemType = (item) => {
+exports.getSchomburgDeliveryInfo = (item, deliveryInfo) => {
   const itemType = exports.deepValue(item, 'catalogItemType[0].id')
   if (itemType) {
     const itemNumber = itemType.split(':')[1]
-    return itemNumber === '26'
+    const holdingLocation = exports.deepValue(item, 'holdingLocation[0].id')
+    const case1 = holdingLocation === 'loc:scff3' && itemNumber === '26'
+    const case2 = holdingLocation === 'loc:scff2' && itemNumber === '6'
+    let criteria
+    if (case1) criteria = 'scff3 microfiche'
+    else if (case2) criteria = 'scff2 microfilm'
+    else {
+      deliveryInfo.deliveryLocation = []
+      criteria = 'Non requestable schomburg catalog item type ' + itemNumber
+    }
+    return Object.assign({}, deliveryInfo, { criteria })
   }
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -486,3 +486,16 @@ exports.isInRecap = (item) => {
     exports.itemHasRecapHoldingLocation(item) ||
     !isItemNyplOwned(item)
 }
+
+exports.isInSchomburg = (item) => {
+  const holdingLocation = exports.deepValue(item, 'holdingLocation[0].id')
+  if (holdingLocation) return holdingLocation.startsWith('loc:sc')
+}
+
+exports.isSchomburgRequestableItemType = (item) => {
+  const itemType = exports.deepValue(item, 'catalogItemType[0].id')
+  if (itemType) {
+    const itemNumber = itemType.split(':')[1]
+    return itemNumber === '26'
+  }
+}

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -10,7 +10,7 @@ var sampleItems = {
     'uri': 'i12227153',
     'holdingLocation': [
       {
-        'id': 'loc:scff2',
+        'id': 'loc:scff1',
         'label': 'Schomburg Center - Research & Reference'
       }
     ],

--- a/test/fixtures/query-4492e53fd966b7d8ff7400cc46e55c48.json
+++ b/test/fixtures/query-4492e53fd966b7d8ff7400cc46e55c48.json
@@ -1,0 +1,208 @@
+{
+  "took": 3,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 15.034133,
+    "hits": [
+      {
+        "_index": "resources-2020-05-08",
+        "_type": "resource",
+        "_id": "b10621616",
+        "_score": 15.034133,
+        "_source": {
+          "extent": [
+            "16 p.;"
+          ],
+          "note": [
+            {
+              "noteType": "Note",
+              "label": "Cover title.",
+              "type": "bf:Note"
+            },
+            {
+              "noteType": "Reproduction",
+              "label": "Microfiche.",
+              "type": "bf:Note"
+            }
+          ],
+          "nyplSource": [
+            "sierra-nypl"
+          ],
+          "subjectLiteral_exploded": [
+            "Puerto Rico",
+            "Puerto Rico -- Politics and government"
+          ],
+          "numItemDatesParsed": [
+            0
+          ],
+          "publisherLiteral": [
+            "[s. n.]"
+          ],
+          "language": [
+            {
+              "id": "lang:eng",
+              "label": "English"
+            }
+          ],
+          "numItemsTotal": [
+            0
+          ],
+          "createdYear": [
+            1909
+          ],
+          "title": [
+            "Porto Rico. The effort of the House of Delegates to revolutionize the government and coerce Congress by refusing to pass appropriation bills and the legislation necessary to maintain government and order in the Island. Speech of Hon. Chauncey M. Depew ... in the Senate of the United States, July 9, 1909."
+          ],
+          "type": [
+            "nypl:Item"
+          ],
+          "shelfMark": [
+            "Sc Micro F-1843"
+          ],
+          "numItemVolumesParsed": [
+            0
+          ],
+          "createdString": [
+            "1909"
+          ],
+          "creatorLiteral": [
+            "Depew, Chauncey M. (Chauncey Mitchell), 1834-1928."
+          ],
+          "numElectronicResources": [
+            0
+          ],
+          "dateStartYear": [
+            1909
+          ],
+          "idOclc": [
+            "NYPG804081658-B"
+          ],
+          "identifierV2": [
+            {
+              "type": "bf:ShelfMark",
+              "value": "Sc Micro F-1843"
+            },
+            {
+              "type": "nypl:Bnumber",
+              "value": "10621616"
+            },
+            {
+              "type": "nypl:Oclc",
+              "value": "NYPG804081658-B"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "NN804081658"
+            },
+            {
+              "type": "bf:Identifier",
+              "value": "(WaOLN)nyp0627286"
+            }
+          ],
+          "updatedAt": 1700086883065,
+          "publicationStatement": [
+            "Washington, D. C.; [s. n.] 1909."
+          ],
+          "identifier": [
+            "urn:shelfmark:Sc Micro F-1843",
+            "urn:bnum:10621616",
+            "urn:oclc:NYPG804081658-B",
+            "urn:identifier:NN804081658",
+            "urn:identifier:(WaOLN)nyp0627286"
+          ],
+          "numCheckinCardItems": [
+            0
+          ],
+          "materialType": [
+            {
+              "id": "resourcetypes:txt",
+              "label": "Text"
+            }
+          ],
+          "carrierType": [
+            {
+              "id": "carriertypes:nc",
+              "label": "volume"
+            }
+          ],
+          "dateString": [
+            "1909"
+          ],
+          "mediaType": [
+            {
+              "id": "mediatypes:n",
+              "label": "unmediated"
+            }
+          ],
+          "subjectLiteral": [
+            "Puerto Rico -- Politics and government."
+          ],
+          "titleDisplay": [
+            "Porto Rico. The effort of the House of Delegates to revolutionize the government and coerce Congress by refusing to pass appropriation bills and the legislation necessary to maintain government and order in the Island. Speech of Hon. Chauncey M. Depew ... in the Senate of the United States, July 9, 1909."
+          ],
+          "uri": "b10621616",
+          "placeOfPublication": [
+            "Washington, D. C.;"
+          ],
+          "issuance": [
+            {
+              "id": "urn:biblevel:m",
+              "label": "monograph/item"
+            }
+          ],
+          "dimensions": [
+            "25 cm."
+          ]
+        },
+        "inner_hits": {
+          "electronicResources": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          },
+          "items": {
+            "hits": {
+              "total": 0,
+              "max_score": null,
+              "hits": []
+            }
+          }
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "item_location": {
+      "doc_count": 0,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": []
+      }
+    },
+    "item_format": {
+      "doc_count": 0,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": []
+      }
+    },
+    "item_status": {
+      "doc_count": 0,
+      "_nested": {
+        "doc_count_error_upper_bound": 0,
+        "sum_other_doc_count": 0,
+        "buckets": []
+      }
+    }
+  }
+}

--- a/test/fixtures/schomburg.js
+++ b/test/fixtures/schomburg.js
@@ -1,0 +1,1104 @@
+module.exports = {
+  scff3Microfiche: {
+    'took': 817,
+    'timed_out': false,
+    '_shards': {
+      'total': 3,
+      'successful': 3,
+      'failed': 0
+    },
+    'hits': {
+      'total': 18434492,
+      'max_score': null,
+      'hits': [{
+        '_index': 'resources-2020-05-08',
+        '_type': 'resource',
+        '_id': 'b10769327',
+        '_version': 6,
+        'found': true,
+        '_source': {
+          'extent': [
+            'v, 107 leaves.'
+          ],
+          'note': [
+            {
+              'noteType': 'Thesis',
+              'label': 'Thesis (Ph. D.)--University of California, Berkeley, June 1977.',
+              'type': 'bf:Note'
+            },
+            {
+              'noteType': 'Bibliography',
+              'label': 'Bibliography: leaves 100-107.',
+              'type': 'bf:Note'
+            },
+            {
+              'noteType': 'Reproduction',
+              'label': 'Microfiche.',
+              'type': 'bf:Note'
+            }
+          ],
+          'nyplSource': 'sierra-nypl',
+          'subjectLiteral_exploded': [
+            'African American children',
+            'African American children -- Language',
+            'African Americans',
+            'African Americans -- Study and teaching',
+            'Black English',
+            'Reading (Elementary)'
+          ],
+          'language': [
+            {
+              'id': 'lang:eng',
+              'label': 'English'
+            }
+          ],
+          'createdYear': [
+            1977
+          ],
+          'type': [
+            'nypl:Item'
+          ],
+          'title': [
+            'The effect of Black examiners, who speak Black dialect or standard English, on the test performance of Black second and third grade students administered the survey of primary reading development [microform] / '
+          ],
+          'shelfMark': [
+            'Sc Micro F-10210'
+          ],
+          'creatorLiteral': [
+            'Fisch, Elaine.'
+          ],
+          'createdString': [
+            '1977'
+          ],
+          'materialType_packed': [
+            'resourcetypes:txt||Text'
+          ],
+          'language_packed': [
+            'lang:eng||English'
+          ],
+          'dateStartYear': [
+            1977
+          ],
+          'identifierV2': [
+            {
+              'type': 'bf:ShelfMark',
+              'value': 'Sc Micro F-10210'
+            },
+            {
+              'type': 'nypl:Bnumber',
+              'value': '10769327'
+            },
+            {
+              'type': 'bf:Identifier',
+              'value': '(WaOLN)nyp0776221'
+            }
+          ],
+          'creator_sort': [
+            'fisch, elaine.'
+          ],
+          'carrierType_packed': [
+            'carriertypes:nc||volume'
+          ],
+          'issuance_packed': [
+            'urn:biblevel:m||monograph/item'
+          ],
+          'holdings': [],
+          'updatedAt': 1619446503123,
+          'mediaType_packed': [
+            'mediatypes:n||unmediated'
+          ],
+          'publicationStatement': [
+            '1977.'
+          ],
+          'identifier': [
+            'urn:bnum:10769327',
+            'urn:undefined:(WaOLN)nyp0776221'
+          ],
+          'materialType': [
+            {
+              'id': 'resourcetypes:txt',
+              'label': 'Text'
+            }
+          ],
+          'carrierType': [
+            {
+              'id': 'carriertypes:nc',
+              'label': 'volume'
+            }
+          ],
+          'title_sort': [
+            'the effect of black examiners, who speak black dialect or standard english, on t'
+          ],
+          'dateString': [
+            '1977'
+          ],
+          'mediaType': [
+            {
+              'id': 'mediatypes:n',
+              'label': 'unmediated'
+            }
+          ],
+          'subjectLiteral': [
+            'African American children -- Language.',
+            'African Americans -- Study and teaching.',
+            'Black English.',
+            'Reading (Elementary)'
+          ],
+          'titleDisplay': [
+            'The effect of Black examiners, who speak Black dialect or standard English, on the test performance of Black second and third grade students administered the survey of primary reading development [microform] /  by Elaine Fisch.'
+          ],
+          'uri': 'b10769327',
+          'numItems': [
+            1
+          ],
+          'numAvailable': [
+            1
+          ],
+          'uris': [
+            'b10769327',
+            'b10769327-i13909591'
+          ],
+          'issuance': [
+            {
+              'id': 'urn:biblevel:m',
+              'label': 'monograph/item'
+            }
+          ],
+          'items': [
+            {
+              'owner': [
+                {
+                  'id': 'orgs:1114',
+                  'label': 'Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+                }
+              ],
+              'accessMessage_packed': [
+                'accessMessage:1||Use in library'
+              ],
+              'identifier': [
+                'urn:barcode:33433058833009'
+              ],
+              'shelfMark_sort': 'aSc Micro F-10210 no. 000001-2',
+              'catalogItemType_packed': [
+                'catalogItemType:26||microfiche'
+              ],
+              'accessMessage': [
+                {
+                  'id': 'accessMessage:1',
+                  'label': 'Use in library'
+                }
+              ],
+              'status_packed': [
+                'status:a||Available '
+              ],
+              'uri': 'i13909591',
+              'shelfMark': [
+                'Sc Micro F-10210 no. 1-2'
+              ],
+              'identifierV2': [
+                {
+                  'type': 'bf:ShelfMark',
+                  'value': 'Sc Micro F-10210 no. 1-2'
+                },
+                {
+                  'type': 'bf:Barcode',
+                  'value': '33433058833009'
+                }
+              ],
+              'holdingLocation_packed': [
+                'loc:scff3||Schomburg Center - Research & Reference - Desk'
+              ],
+              'idBarcode': [
+                '33433058833009'
+              ],
+              'owner_packed': [
+                'orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+              ],
+              'requestable': [
+                false
+              ],
+              'catalogItemType': [
+                {
+                  'id': 'catalogItemType:26',
+                  'label': 'microfiche'
+                }
+              ],
+              'status': [
+                {
+                  'id': 'status:a',
+                  'label': 'Available '
+                }
+              ],
+              'holdingLocation': [
+                {
+                  'id': 'loc:scff3',
+                  'label': 'Schomburg Center - Research & Reference - Desk'
+                }
+              ]
+            }
+          ]
+        }
+      }]
+    }
+  },
+  invalidTypeScff3: {
+    'took': 817,
+    'timed_out': false,
+    '_shards': {
+      'total': 3,
+      'successful': 3,
+      'failed': 0
+    },
+    'hits': {
+      'total': 18434492,
+      'max_score': null,
+      'hits': [
+        {
+          '_index': 'resources-2020-05-08',
+          '_type': 'resource',
+          '_id': 'b13643829',
+          '_version': 3,
+          'found': true,
+          '_source': {
+            'extent': [
+              '20 p. : ill. ;'
+            ],
+            'note': [
+              {
+                'noteType': 'Note',
+                'label': 'Cover title.',
+                'type': 'bf:Note'
+              },
+              {
+                'noteType': 'Note',
+                'label': 'At head of title: Dark & Lovely.',
+                'type': 'bf:Note'
+              }
+            ],
+            'nyplSource': 'sierra-nypl',
+            'subjectLiteral_exploded': [
+              'African American families',
+              'Family reunions',
+              'Family reunions -- United States',
+              'Family reunions -- United States -- Planning',
+              'Still family'
+            ],
+            'publisherLiteral': [
+              's.n.,'
+            ],
+            'language': [
+              {
+                'id': 'lang:eng',
+                'label': 'English'
+              }
+            ],
+            'createdYear': [
+              1994
+            ],
+            'dateEndString': [
+              '1995'
+            ],
+            'type': [
+              'nypl:Item'
+            ],
+            'title': [
+              'Proud heritage guide to planning a successful family reunion'
+            ],
+            'shelfMark': [
+              'Sc D 98-2481'
+            ],
+            'materialType_packed': [
+              'resourcetypes:txt||Text'
+            ],
+            'createdString': [
+              '1994'
+            ],
+            'language_packed': [
+              'lang:eng||English'
+            ],
+            'dateStartYear': [
+              1994
+            ],
+            'identifierV2': [
+              {
+                'type': 'bf:ShelfMark',
+                'value': 'Sc D 98-2481'
+              },
+              {
+                'type': 'nypl:Bnumber',
+                'value': '13643829'
+              }
+            ],
+            'carrierType_packed': [
+              'carriertypes:nc||volume'
+            ],
+            'issuance_packed': [
+              'urn:biblevel:m||monograph/item'
+            ],
+            'dateEndYear': [
+              1995
+            ],
+            'updatedAt': 1524981554942,
+            'mediaType_packed': [
+              'mediatypes:n||unmediated'
+            ],
+            'publicationStatement': [
+              '[S.l. : s.n., 1994 or 1995]'
+            ],
+            'identifier': [
+              'urn:bnum:13643829'
+            ],
+            'materialType': [
+              {
+                'id': 'resourcetypes:txt',
+                'label': 'Text'
+              }
+            ],
+            'carrierType': [
+              {
+                'id': 'carriertypes:nc',
+                'label': 'volume'
+              }
+            ],
+            'dateString': [
+              '1994'
+            ],
+            'title_sort': [
+              'proud heritage guide to planning a successful family reunion'
+            ],
+            'mediaType': [
+              {
+                'id': 'mediatypes:n',
+                'label': 'unmediated'
+              }
+            ],
+            'subjectLiteral': [
+              'African American families.',
+              'Family reunions -- United States -- Planning.',
+              'Still family.'
+            ],
+            'titleDisplay': [
+              'Proud heritage guide to planning a successful family reunion / compliments of the Still family.'
+            ],
+            'uri': 'b13643829',
+            'numItems': [
+              1
+            ],
+            'numAvailable': [
+              1
+            ],
+            'uris': [
+              'b13643829',
+              'b13643829-i11305566'
+            ],
+            'placeOfPublication': [
+              '[S.l. :'
+            ],
+            'issuance': [
+              {
+                'id': 'urn:biblevel:m',
+                'label': 'monograph/item'
+              }
+            ],
+            'items': [
+              {
+                'accessMessage_packed': [
+                  'accessMessage:1||Use in library'
+                ],
+                'owner': [
+                  {
+                    'id': 'orgs:1114',
+                    'label': 'Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+                  }
+                ],
+                'identifier': [
+                  'urn:barcode:33433015885043'
+                ],
+                'catalogItemType_packed': [
+                  'catalogItemType:2||book non-circ'
+                ],
+                'accessMessage': [
+                  {
+                    'id': 'accessMessage:1',
+                    'label': 'Use in library'
+                  }
+                ],
+                'status_packed': [
+                  'status:a||Available '
+                ],
+                'uri': 'i11305566',
+                'shelfMark': [
+                  'Sc D 98-2481'
+                ],
+                'identifierV2': [
+                  {
+                    'type': 'bf:ShelfMark',
+                    'value': 'Sc D 98-2481'
+                  },
+                  {
+                    'type': 'bf:Barcode',
+                    'value': '33433015885043'
+                  }
+                ],
+                'holdingLocation_packed': [
+                  'loc:scff3||Schomburg Center - Research & Reference - Desk'
+                ],
+                'idBarcode': [
+                  '33433015885043'
+                ],
+                'owner_packed': [
+                  'orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+                ],
+                'requestable': [
+                  false
+                ],
+                'catalogItemType': [
+                  {
+                    'id': 'catalogItemType:2',
+                    'label': 'book non-circ'
+                  }
+                ],
+                'status': [
+                  {
+                    'id': 'status:a',
+                    'label': 'Available '
+                  }
+                ],
+                'holdingLocation': [
+                  {
+                    'id': 'loc:scff3',
+                    'label': 'Schomburg Center - Research & Reference - Desk'
+                  }
+                ]
+              }
+            ],
+            'dimensions': [
+              '22 cm.'
+            ]
+          }
+        }]
+    }
+  },
+  scff2Microfilm: {
+    'took': 817,
+    'timed_out': false,
+    '_shards': {
+      'total': 3,
+      'successful': 3,
+      'failed': 0
+    },
+    'hits': {
+      'total': 18434492,
+      'max_score': null,
+      'hits': [{
+        '_index': 'resources-2020-05-08',
+        '_type': 'resource',
+        '_id': 'b10224367',
+        '_version': 6,
+        'found': true,
+        '_source': {
+          'extent': [
+            '223 p.'
+          ],
+          'note': [
+            {
+              'noteType': 'Reproduction',
+              'label': 'Microfilm.',
+              'type': 'bf:Note'
+            }
+          ],
+          'nyplSource': 'sierra-nypl',
+          'subjectLiteral_exploded': [
+            'Helper, Hinton Rowan, 1829-1909',
+            'Slavery',
+            'Slavery -- United States',
+            'Slavery -- United States -- Controversial literature',
+            'Slavery -- United States -- Controversial literature -- 1860-'
+          ],
+          'publisherLiteral': [
+            'J. T. Lloyd,'
+          ],
+          'language': [
+            {
+              'id': 'lang:eng',
+              'label': 'English'
+            }
+          ],
+          'createdYear': [
+            1860
+          ],
+          'type': [
+            'nypl:Item'
+          ],
+          'title': [
+            "Helper's Impending crisis dissected[microform]"
+          ],
+          'shelfMark': [
+            'Sc Micro R-864 [pt. G]'
+          ],
+          'creatorLiteral': [
+            'Wolfe, Samuel M.'
+          ],
+          'createdString': [
+            '1860'
+          ],
+          'materialType_packed': [
+            'resourcetypes:txt||Text'
+          ],
+          'idLccn': [
+            '11017853'
+          ],
+          'language_packed': [
+            'lang:eng||English'
+          ],
+          'dateStartYear': [
+            1860
+          ],
+          'identifierV2': [
+            {
+              'type': 'bf:ShelfMark',
+              'value': 'Sc Micro R-864 [pt. G]'
+            },
+            {
+              'type': 'nypl:Bnumber',
+              'value': '10224367'
+            },
+            {
+              'type': 'bf:Lccn',
+              'value': '11017853'
+            },
+            {
+              'type': 'bf:Identifier',
+              'value': 'NN754080857'
+            },
+            {
+              'type': 'bf:Identifier',
+              'value': '(WaOLN)nyp0226236'
+            }
+          ],
+          'creator_sort': [
+            'wolfe, samuel m.'
+          ],
+          'carrierType_packed': [
+            'carriertypes:nc||volume'
+          ],
+          'issuance_packed': [
+            'urn:biblevel:m||monograph/item'
+          ],
+          'holdings': [],
+          'updatedAt': 1619445163123,
+          'mediaType_packed': [
+            'mediatypes:n||unmediated'
+          ],
+          'publicationStatement': [
+            'Philadelphia: J. T. Lloyd, 1860.'
+          ],
+          'identifier': [
+            'urn:bnum:10224367',
+            'urn:lccn:11017853',
+            'urn:undefined:NN754080857',
+            'urn:undefined:(WaOLN)nyp0226236'
+          ],
+          'materialType': [
+            {
+              'id': 'resourcetypes:txt',
+              'label': 'Text'
+            }
+          ],
+          'carrierType': [
+            {
+              'id': 'carriertypes:nc',
+              'label': 'volume'
+            }
+          ],
+          'title_sort': [
+            "helper's impending crisis dissected[microform]"
+          ],
+          'dateString': [
+            '1860'
+          ],
+          'mediaType': [
+            {
+              'id': 'mediatypes:n',
+              'label': 'unmediated'
+            }
+          ],
+          'subjectLiteral': [
+            'Helper, Hinton Rowan, 1829-1909.',
+            'Slavery -- United States -- Controversial literature -- 1860-'
+          ],
+          'titleDisplay': [
+            "Helper's Impending crisis dissected[microform] / by Samuel M.Wolfe, Virginia."
+          ],
+          'uri': 'b10224367',
+          'numItems': [
+            2
+          ],
+          'numAvailable': [
+            2
+          ],
+          'uris': [
+            'b10224367',
+            'b10224367-i24028840',
+            'b10224367-i30547944',
+            'b10224367-i10053088'
+          ],
+          'placeOfPublication': [
+            'Philadelphia:'
+          ],
+          'issuance': [
+            {
+              'id': 'urn:biblevel:m',
+              'label': 'monograph/item'
+            }
+          ],
+          'items': [
+            {
+              'owner': [
+                {
+                  'id': 'orgs:1114',
+                  'label': 'Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+                }
+              ],
+              'accessMessage_packed': [
+                'accessMessage:1||Use in library'
+              ],
+              'identifier': [
+                'urn:barcode:33433016495024'
+              ],
+              'shelfMark_sort': 'aSc Micro R-000864',
+              'catalogItemType_packed': [
+                'catalogItemType:6||microfilm service copy'
+              ],
+              'accessMessage': [
+                {
+                  'id': 'accessMessage:1',
+                  'label': 'Use in library'
+                }
+              ],
+              'status_packed': [
+                'status:a||Available '
+              ],
+              'uri': 'i24028840',
+              'shelfMark': [
+                'Sc Micro R-864'
+              ],
+              'identifierV2': [
+                {
+                  'type': 'bf:ShelfMark',
+                  'value': 'Sc Micro R-864'
+                },
+                {
+                  'type': 'bf:Barcode',
+                  'value': '33433016495024'
+                }
+              ],
+              'holdingLocation_packed': [
+                'loc:scff2||Schomburg Center - Research & Reference'
+              ],
+              'idBarcode': [
+                '33433016495024'
+              ],
+              'owner_packed': [
+                'orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+              ],
+              'requestable': [
+                false
+              ],
+              'catalogItemType': [
+                {
+                  'id': 'catalogItemType:6',
+                  'label': 'microfilm service copy'
+                }
+              ],
+              'status': [
+                {
+                  'id': 'status:a',
+                  'label': 'Available '
+                }
+              ],
+              'holdingLocation': [
+                {
+                  'id': 'loc:scff2',
+                  'label': 'Schomburg Center - Research & Reference'
+                }
+              ]
+            },
+            {
+              'owner': [
+                {
+                  'id': 'orgs:1114',
+                  'label': 'Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+                }
+              ],
+              'accessMessage_packed': [
+                'accessMessage:1||Use in library'
+              ],
+              'shelfMark_sort': 'aSc Micro R-864 [pt. G]',
+              'catalogItemType_packed': [
+                'catalogItemType:6||microfilm service copy'
+              ],
+              'accessMessage': [
+                {
+                  'id': 'accessMessage:1',
+                  'label': 'Use in library'
+                }
+              ],
+              'status_packed': [
+                'status:a||Available'
+              ],
+              'uri': 'i10053088',
+              'shelfMark': [
+                'Sc Micro R-864 [pt. G]'
+              ],
+              'identifierV2': [
+                {
+                  'type': 'bf:ShelfMark',
+                  'value': 'Sc Micro R-864 [pt. G]'
+                }
+              ],
+              'holdingLocation_packed': [
+                'loc:scff2||Schomburg Center - Research & Reference'
+              ],
+              'owner_packed': [
+                'orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+              ],
+              'requestable': [
+                false
+              ],
+              'catalogItemType': [
+                {
+                  'id': 'catalogItemType:6',
+                  'label': 'microfilm service copy'
+                }
+              ],
+              'status': [
+                {
+                  'id': 'status:a',
+                  'label': 'Available'
+                }
+              ],
+              'holdingLocation': [
+                {
+                  'id': 'loc:scff2',
+                  'label': 'Schomburg Center - Research & Reference'
+                }
+              ]
+            }
+          ]
+        }
+      }]
+    }
+  },
+  invalidTypeScff2: {
+    'took': 817,
+    'timed_out': false,
+    '_shards': {
+      'total': 3,
+      'successful': 3,
+      'failed': 0
+    },
+    'hits': {
+      'total': 18434492,
+      'max_score': null,
+      'hits': [{
+        '_index': 'resources-2020-05-08',
+        '_type': 'resource',
+        '_id': 'b10224367',
+        '_version': 6,
+        'found': true,
+        '_source': {
+          'extent': [
+            '223 p.'
+          ],
+          'note': [
+            {
+              'noteType': 'Reproduction',
+              'label': 'Microfilm.',
+              'type': 'bf:Note'
+            }
+          ],
+          'nyplSource': 'sierra-nypl',
+          'subjectLiteral_exploded': [
+            'Helper, Hinton Rowan, 1829-1909',
+            'Slavery',
+            'Slavery -- United States',
+            'Slavery -- United States -- Controversial literature',
+            'Slavery -- United States -- Controversial literature -- 1860-'
+          ],
+          'publisherLiteral': [
+            'J. T. Lloyd,'
+          ],
+          'language': [
+            {
+              'id': 'lang:eng',
+              'label': 'English'
+            }
+          ],
+          'createdYear': [
+            1860
+          ],
+          'type': [
+            'nypl:Item'
+          ],
+          'title': [
+            "Helper's Impending crisis dissected[microform]"
+          ],
+          'shelfMark': [
+            'Sc Micro R-864 [pt. G]'
+          ],
+          'creatorLiteral': [
+            'Wolfe, Samuel M.'
+          ],
+          'createdString': [
+            '1860'
+          ],
+          'materialType_packed': [
+            'resourcetypes:txt||Text'
+          ],
+          'idLccn': [
+            '11017853'
+          ],
+          'language_packed': [
+            'lang:eng||English'
+          ],
+          'dateStartYear': [
+            1860
+          ],
+          'identifierV2': [
+            {
+              'type': 'bf:ShelfMark',
+              'value': 'Sc Micro R-864 [pt. G]'
+            },
+            {
+              'type': 'nypl:Bnumber',
+              'value': '10224367'
+            },
+            {
+              'type': 'bf:Lccn',
+              'value': '11017853'
+            },
+            {
+              'type': 'bf:Identifier',
+              'value': 'NN754080857'
+            },
+            {
+              'type': 'bf:Identifier',
+              'value': '(WaOLN)nyp0226236'
+            }
+          ],
+          'creator_sort': [
+            'wolfe, samuel m.'
+          ],
+          'carrierType_packed': [
+            'carriertypes:nc||volume'
+          ],
+          'issuance_packed': [
+            'urn:biblevel:m||monograph/item'
+          ],
+          'holdings': [],
+          'updatedAt': 1619445163123,
+          'mediaType_packed': [
+            'mediatypes:n||unmediated'
+          ],
+          'publicationStatement': [
+            'Philadelphia: J. T. Lloyd, 1860.'
+          ],
+          'identifier': [
+            'urn:bnum:10224367',
+            'urn:lccn:11017853',
+            'urn:undefined:NN754080857',
+            'urn:undefined:(WaOLN)nyp0226236'
+          ],
+          'materialType': [
+            {
+              'id': 'resourcetypes:txt',
+              'label': 'Text'
+            }
+          ],
+          'carrierType': [
+            {
+              'id': 'carriertypes:nc',
+              'label': 'volume'
+            }
+          ],
+          'title_sort': [
+            "helper's impending crisis dissected[microform]"
+          ],
+          'dateString': [
+            '1860'
+          ],
+          'mediaType': [
+            {
+              'id': 'mediatypes:n',
+              'label': 'unmediated'
+            }
+          ],
+          'subjectLiteral': [
+            'Helper, Hinton Rowan, 1829-1909.',
+            'Slavery -- United States -- Controversial literature -- 1860-'
+          ],
+          'titleDisplay': [
+            "Helper's Impending crisis dissected[microform] / by Samuel M.Wolfe, Virginia."
+          ],
+          'uri': 'b10224367',
+          'numItems': [
+            2
+          ],
+          'numAvailable': [
+            2
+          ],
+          'uris': [
+            'b10224367',
+            'b10224367-i24028840',
+            'b10224367-i30547944',
+            'b10224367-i10053088'
+          ],
+          'placeOfPublication': [
+            'Philadelphia:'
+          ],
+          'issuance': [
+            {
+              'id': 'urn:biblevel:m',
+              'label': 'monograph/item'
+            }
+          ],
+          'items': [
+            {
+              'owner': [
+                {
+                  'id': 'orgs:1114',
+                  'label': 'Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+                }
+              ],
+              'accessMessage_packed': [
+                'accessMessage:1||Use in library'
+              ],
+              'identifier': [
+                'urn:barcode:33433016495024'
+              ],
+              'shelfMark_sort': 'aSc Micro R-000864',
+              'catalogItemType_packed': [
+                'catalogItemType:6||microfilm service copy'
+              ],
+              'accessMessage': [
+                {
+                  'id': 'accessMessage:1',
+                  'label': 'Use in library'
+                }
+              ],
+              'status_packed': [
+                'status:a||Available '
+              ],
+              'uri': 'i24028840',
+              'shelfMark': [
+                'Sc Micro R-864'
+              ],
+              'identifierV2': [
+                {
+                  'type': 'bf:ShelfMark',
+                  'value': 'Sc Micro R-864'
+                },
+                {
+                  'type': 'bf:Barcode',
+                  'value': '33433016495024'
+                }
+              ],
+              'holdingLocation_packed': [
+                'loc:scff2||Schomburg Center - Research & Reference'
+              ],
+              'idBarcode': [
+                '33433016495024'
+              ],
+              'owner_packed': [
+                'orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+              ],
+              'requestable': [
+                false
+              ],
+              'catalogItemType': [
+                {
+                  'id': 'catalogItemType:4',
+                  'label': 'microfilm service copy'
+                }
+              ],
+              'status': [
+                {
+                  'id': 'status:a',
+                  'label': 'Available '
+                }
+              ],
+              'holdingLocation': [
+                {
+                  'id': 'loc:scff2',
+                  'label': 'Schomburg Center - Research & Reference'
+                }
+              ]
+            },
+            {
+              'owner': [
+                {
+                  'id': 'orgs:1114',
+                  'label': 'Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+                }
+              ],
+              'accessMessage_packed': [
+                'accessMessage:1||Use in library'
+              ],
+              'shelfMark_sort': 'aSc Micro R-864 [pt. G]',
+              'catalogItemType_packed': [
+                'catalogItemType:6||microfilm service copy'
+              ],
+              'accessMessage': [
+                {
+                  'id': 'accessMessage:1',
+                  'label': 'Use in library'
+                }
+              ],
+              'status_packed': [
+                'status:a||Available'
+              ],
+              'uri': 'i10053088',
+              'shelfMark': [
+                'Sc Micro R-864 [pt. G]'
+              ],
+              'identifierV2': [
+                {
+                  'type': 'bf:ShelfMark',
+                  'value': 'Sc Micro R-864 [pt. G]'
+                }
+              ],
+              'holdingLocation_packed': [
+                'loc:scff2||Schomburg Center - Research & Reference'
+              ],
+              'owner_packed': [
+                'orgs:1114||Schomburg Center for Research in Black Culture, Jean Blackwell Hutson Research and Reference Division'
+              ],
+              'requestable': [
+                false
+              ],
+              'catalogItemType': [
+                {
+                  'id': 'catalogItemType:6',
+                  'label': 'microfilm service copy'
+                }
+              ],
+              'status': [
+                {
+                  'id': 'status:a',
+                  'label': 'Available'
+                }
+              ],
+              'holdingLocation': [
+                {
+                  'id': 'loc:scff2',
+                  'label': 'Schomburg Center - Research & Reference'
+                }
+              ]
+            }
+          ]
+        }
+      }]
+    }
+  }
+}

--- a/test/requestability_resolver.test.js
+++ b/test/requestability_resolver.test.js
@@ -3,8 +3,31 @@ const elasticSearchResponse = require('./fixtures/elastic_search_response.js')
 const specRequestableElasticSearchResponse = require('./fixtures/specRequestable-es-response')
 const eddElasticSearchResponse = require('./fixtures/edd_elastic_search_response')
 const noBarcodeResponse = require('./fixtures/no_barcode_es_response')
+const { scff3Microfiche, invalidTypeScff3, scff2Microfilm, invalidTypeScff2 } = require('./fixtures/schomburg.js')
 
 describe('RequestabilityResolver', () => {
+  describe('Schomburg requestability', () => {
+    it('returns physRequestable true for scff3 microfiche', () => {
+      const resp = RequestabilityResolver.fixItemRequestability(scff3Microfiche)
+      const item = resp.hits.hits[0]._source.items[0]
+      expect(item.physRequestable).to.be.true
+    })
+    it('returns physRequestable false for invalid item type, scff3', () => {
+      const resp = RequestabilityResolver.fixItemRequestability(invalidTypeScff3)
+      const item = resp.hits.hits[0]._source.items[0]
+      expect(item.physRequestable).to.be.false
+    })
+    it('returns physRequestable true for scff2 microfilm', () => {
+      const resp = RequestabilityResolver.fixItemRequestability(scff2Microfilm)
+      const item = resp.hits.hits[0]._source.items[0]
+      expect(item.physRequestable).to.be.true
+    })
+    it('returns physRequestable false for invalid item type, scff2', () => {
+      const resp = RequestabilityResolver.fixItemRequestability(invalidTypeScff2)
+      const item = resp.hits.hits[0]._source.items[0]
+      expect(item.physRequestable).to.be.false
+    })
+  })
   describe('fixItemRequestability', function () {
     const NyplResponse = elasticSearchResponse.fakeElasticSearchResponseNyplItem()
     it('sets physRequestable false for items with no barcodes', () => {

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -10,7 +10,7 @@ dotenv.config({ path: './config/test.env' })
 before(() => {
   // If we're updating fixtures, load real production creds
   if (process.env.UPDATE_FIXTURES) {
-    const productionEnv = dotenv.parse(fs.readFileSync('./config/production.env'))
+    const productionEnv = dotenv.parse(fs.readFileSync('./config/qa.env'))
     return Promise.all(
       [
         // These are the config params that will allow us to build fixtures

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -3,6 +3,51 @@ const { expect } = require('chai')
 const util = require('../lib/util')
 
 describe('Util', function () {
+  describe('isSchomburg', () => {
+    it('returns false for non schomburg location', () => {
+      const item = {
+        'holdingLocation': [
+          {
+            'id': 'loc:mal'
+          }
+        ]
+      }
+      expect(util.isInSchomburg(item)).to.be.false
+    })
+    it('returns true for schomburg items', () => {
+      const item = {
+        'holdingLocation': [
+          {
+            'id': 'loc:scff3'
+          }
+        ]
+      }
+      expect(util.isInSchomburg(item)).to.be.true
+    })
+  })
+  describe('isSchomburgRequestableItemType', () => {
+    it('returns false for items with incorrect item type', () => {
+      const item = {
+        'catalogItemType': [
+          {
+            'id': 'catalogItemType:2'
+          }
+        ]
+      }
+      expect(util.isSchomburgRequestableItemType(item)).to.be.false
+    })
+    it('returns true for  correct item type', () => {
+      const item = {
+        'catalogItemType': [
+          {
+            'id': 'catalogItemType:26'
+          }
+        ]
+      }
+      expect(util.isSchomburgRequestableItemType(item)).to.be.true
+    })
+  })
+
   describe('backslashes', function () {
     it('escapes specials', function () {
       const result = util.backslashes('?', 2)
@@ -186,14 +231,14 @@ describe('Util', function () {
     it('extracts existant values', () => {
       expect(util.deepValue({ a: { b: { c: 'foo' } } }, 'a.b')).to.deep.equal({ c: 'foo' })
       expect(util.deepValue({ a: { b: { c: 'foo' } } }, 'a.b.c')).to.deep.equal('foo')
-      expect(util.deepValue({ a: { b: [ { b1: 'foo' }, { b2: 'foo2' } ] } }, 'a.b[1].b2')).to.deep.equal('foo2')
+      expect(util.deepValue({ a: { b: [{ b1: 'foo' }, { b2: 'foo2' }] } }, 'a.b[1].b2')).to.deep.equal('foo2')
     })
 
     it('returns null/undefined for nonexistant values', () => {
       expect(util.deepValue({ a: { b: { c: 'foo' } } }, 'a.b.x')).to.deep.equal(null)
       expect(util.deepValue({ a: { b: { c: 'foo' } } }, 'x.y')).to.deep.equal(null)
       expect(util.deepValue({ a: { b: { c: 'foo' } } }, 'a.b.c.d')).to.deep.equal(null)
-      expect(util.deepValue({ a: { b: [ { b1: 'foo' } ] } }, 'a.b[1].b2')).to.deep.equal(null)
+      expect(util.deepValue({ a: { b: [{ b1: 'foo' }] } }, 'a.b[1].b2')).to.deep.equal(null)
     })
 
     it('resorts to default for nonexistant values', () => {
@@ -203,29 +248,29 @@ describe('Util', function () {
 
   describe('itemHasRecapHoldingLocation', () => {
     it('identifies an item with a rc location', () => {
-      expect(util.itemHasRecapHoldingLocation({ holdingLocation: [ { id: 'loc:rc' } ] })).to.equal(true)
-      expect(util.itemHasRecapHoldingLocation({ holdingLocation: [ { id: 'loc:rc2ma' } ] })).to.equal(true)
+      expect(util.itemHasRecapHoldingLocation({ holdingLocation: [{ id: 'loc:rc' }] })).to.equal(true)
+      expect(util.itemHasRecapHoldingLocation({ holdingLocation: [{ id: 'loc:rc2ma' }] })).to.equal(true)
     })
 
     it('rejects an item with a non-rc location', () => {
-      expect(util.itemHasRecapHoldingLocation({ holdingLocation: [ { id: 'loc:xx' } ] })).to.equal(false)
+      expect(util.itemHasRecapHoldingLocation({ holdingLocation: [{ id: 'loc:xx' }] })).to.equal(false)
       expect(util.itemHasRecapHoldingLocation({ holdingLocation: [] })).to.equal(false)
-      expect(util.itemHasRecapHoldingLocation({ })).to.equal(false)
+      expect(util.itemHasRecapHoldingLocation({})).to.equal(false)
     })
   })
 
   describe('barcodeFromItem', () => {
     it('extracts barcode from item', () => {
-      expect(util.barcodeFromItem({ identifier: [ 'urn:barcode:1234' ] })).to.equal('1234')
-      expect(util.barcodeFromItem({ identifier: [ 'urn:another:foo', 'urn:barcode:1234' ] })).to.equal('1234')
-      expect(util.barcodeFromItem({ identifier: [ '', null, 'fladeedle', 'urn:barcode:1234' ] })).to.equal('1234')
+      expect(util.barcodeFromItem({ identifier: ['urn:barcode:1234'] })).to.equal('1234')
+      expect(util.barcodeFromItem({ identifier: ['urn:another:foo', 'urn:barcode:1234'] })).to.equal('1234')
+      expect(util.barcodeFromItem({ identifier: ['', null, 'fladeedle', 'urn:barcode:1234'] })).to.equal('1234')
     })
 
     it('gracefully handles missing identifier prop', () => {
-      expect(util.barcodeFromItem({ })).to.equal(null)
+      expect(util.barcodeFromItem({})).to.equal(null)
       expect(util.barcodeFromItem({ identifier: null })).to.equal(null)
       expect(util.barcodeFromItem({ identifier: [] })).to.equal(null)
-      expect(util.barcodeFromItem({ identifier: [ null ] })).to.equal(null)
+      expect(util.barcodeFromItem({ identifier: [null] })).to.equal(null)
     })
   })
 })

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -25,28 +25,6 @@ describe('Util', function () {
       expect(util.isInSchomburg(item)).to.be.true
     })
   })
-  describe('isSchomburgRequestableItemType', () => {
-    it('returns false for items with incorrect item type', () => {
-      const item = {
-        'catalogItemType': [
-          {
-            'id': 'catalogItemType:2'
-          }
-        ]
-      }
-      expect(util.isSchomburgRequestableItemType(item)).to.be.false
-    })
-    it('returns true for  correct item type', () => {
-      const item = {
-        'catalogItemType': [
-          {
-            'id': 'catalogItemType:26'
-          }
-        ]
-      }
-      expect(util.isSchomburgRequestableItemType(item)).to.be.true
-    })
-  })
 
   describe('backslashes', function () {
     it('escapes specials', function () {


### PR DESCRIPTION
Introduces schomburg requestability logic.
After other delivery location is generated, any item with a schomburg location will be given an extra check for combination location/item type of either scff3/microfiche or scff2/microfilm. Also adds specific physRequestableCriteria for this check.

This implementation is dependent on NYPL-core v2.12