### PR TITLE
Scc 3958/one scholar

### DIFF
--- a/lib/available_delivery_location_types.js
+++ b/lib/available_delivery_location_types.js
@@ -13,8 +13,12 @@ class AvailableDeliveryLocationTypes {
       .then((patronType) => {
         const accessibleDeliveryLocationTypes = this._isUnfamiliarPatronType(patronTypeMapping, patronType)
           ? ['Research'] : patronTypeMapping[patronType]['accessibleDeliveryLocationTypes']
-
-        return accessibleDeliveryLocationTypes
+        const patronTypeIsScholar = (locationTypes) => locationTypes.includes('Scholar')
+        const scholarRoom = patronTypeIsScholar(accessibleDeliveryLocationTypes) ? patronTypeMapping[patronType].scholarRoom : null
+        return {
+          deliveryLocationTypes: accessibleDeliveryLocationTypes,
+          scholarRoom
+        }
       })
   }
 

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -186,6 +186,9 @@ class DeliveryLocationsResolver {
 
   static formatLocations (locations, deliveryLocationTypes, scholarRoom) {
     if (!locations) return []
+    const onlyDeliverabletToLpaOrSchomburg = locations.filter((location) => {
+      return location.code.startsWith('ma')
+    }).length === 0
     return (
       // Filter out anything not matching the specified deliveryLocationType
       locations.filter((location) => {
@@ -197,8 +200,13 @@ class DeliveryLocationsResolver {
         // remove scholar locations that are not the scholar room, if a specific
         // scholar room exists.
         .filter((location) => {
-          if (scholarRoom) {
-            return !location.deliveryLocationTypes.includes('Scholar') || location.code === scholarRoom.code
+          const locationIsNotScholarRoom = !location.deliveryLocationTypes.includes('Scholar')
+          // If an item is not deliverable to SASB, don't return scholar rooms
+          if (onlyDeliverabletToLpaOrSchomburg) {
+            console.log('xxx')
+            return locationIsNotScholarRoom
+          } else if (scholarRoom) {
+            return locationIsNotScholarRoom || location.code === scholarRoom.code
           } else return true
         })
         // Format locations in the manner api consumers expect

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -194,12 +194,12 @@ class DeliveryLocationsResolver {
             arrayIntersection(location.deliveryLocationTypes, deliveryLocationTypes).length > 0
         } else return true
       })
-      // remove scholar locations that are not the scholar room, if a specific
-      // scholar room exists.
+        // remove scholar locations that are not the scholar room, if a specific
+        // scholar room exists.
         .filter((location) => {
-          if(scholarRoom){
+          if (scholarRoom) {
             return !location.deliveryLocationTypes.includes('Scholar') || location.code === scholarRoom.code
-        } else return true
+          } else return true
         })
         // Format locations in the manner api consumers expect
         .map((location) => {

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -184,39 +184,17 @@ class DeliveryLocationsResolver {
     return 5
   }
 
-  static formatLocations (locations, deliveryLocationTypes, scholarRoom) {
+  static formatLocations (locations) {
     if (!locations) return []
-    const onlyDeliverabletToLpaOrSchomburg = locations.filter((location) => {
-      return location.code.startsWith('ma')
-    }).length === 0
     return (
-      // Filter out anything not matching the specified deliveryLocationType
-      locations.filter((location) => {
-        if (deliveryLocationTypes) {
-          return location.deliveryLocationTypes &&
-            arrayIntersection(location.deliveryLocationTypes, deliveryLocationTypes).length > 0
-        } else return true
+      // Format locations in the manner api consumers expect
+      locations.map((location) => {
+        return {
+          id: `loc:${location.code}`,
+          label: location.label,
+          sortPosition: this.sortPosition(location)
+        }
       })
-        // remove scholar locations that are not the scholar room, if a specific
-        // scholar room exists.
-        .filter((location) => {
-          const locationIsNotScholarRoom = !location.deliveryLocationTypes.includes('Scholar')
-          // If an item is not deliverable to SASB, don't return scholar rooms
-          if (onlyDeliverabletToLpaOrSchomburg) {
-            console.log('xxx')
-            return locationIsNotScholarRoom
-          } else if (scholarRoom) {
-            return locationIsNotScholarRoom || location.code === scholarRoom.code
-          } else return true
-        })
-        // Format locations in the manner api consumers expect
-        .map((location) => {
-          return {
-            id: `loc:${location.code}`,
-            label: location.label,
-            sortPosition: this.sortPosition(location)
-          }
-        })
         // Either way, sort deliveryLocation entries by name:
         .sort((l1, l2) => {
           if (l1.sortPosition < l2.sortPosition) return -1
@@ -326,10 +304,34 @@ class DeliveryLocationsResolver {
           }
           // Establish default for Electronic Document Delivery flag:
           item.eddRequestable = !!item.eddRequestable
-          item.deliveryLocation = this.formatLocations(item.deliveryLocation, deliveryLocationTypes, scholarRoom)
+          const deliveryLocationsWithFilteredScholarRooms = this.filterByTypeAndScholarLocations(item.deliveryLocation, deliveryLocationTypes, scholarRoom)
+          item.deliveryLocation = this.formatLocations(deliveryLocationsWithFilteredScholarRooms)
           return item
         })
       })
   }
+  static filterByTypeAndScholarLocations (locations, deliveryLocationTypes, scholarRoom) {
+    if (!locations || !locations.length) return []
+    const onlyDeliverabletToLpaOrSchomburg = locations.filter((location) => {
+      return location.code.startsWith('ma')
+    }).length === 0
+    // remove scholar locations that are not the scholar room, if a specific
+    // scholar room exists.s
+    // Filter out anything not matching the specified deliveryLocationType
+    return locations.filter((location) => {
+      if (deliveryLocationTypes) {
+        return location.deliveryLocationTypes &&
+          arrayIntersection(location.deliveryLocationTypes, deliveryLocationTypes).length > 0
+      } else return true
+    })
+      .filter((location) => {
+        const locationIsNotScholarRoom = !location.deliveryLocationTypes.includes('Scholar')
+        // If an item is not deliverable to SASB, don't return scholar rooms
+        if (onlyDeliverabletToLpaOrSchomburg) {
+          return locationIsNotScholarRoom
+        } else return locationIsNotScholarRoom || (scholarRoom && location.code === scholarRoom.code)
+      })
+  }
 }
+
 module.exports = DeliveryLocationsResolver

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -184,7 +184,7 @@ class DeliveryLocationsResolver {
     return 5
   }
 
-  static formatLocations (locations, deliveryLocationTypes) {
+  static formatLocations (locations, deliveryLocationTypes, scholarRoom) {
     if (!locations) return []
     return (
       // Filter out anything not matching the specified deliveryLocationType
@@ -194,6 +194,13 @@ class DeliveryLocationsResolver {
             arrayIntersection(location.deliveryLocationTypes, deliveryLocationTypes).length > 0
         } else return true
       })
+      // remove scholar locations that are not the scholar room, if a specific
+      // scholar room exists.
+        .filter((location) => {
+          if(scholarRoom){
+            return !location.deliveryLocationTypes.includes('Scholar') || location.code === scholarRoom.code
+        } else return true
+        })
         // Format locations in the manner api consumers expect
         .map((location) => {
           return {
@@ -288,7 +295,7 @@ class DeliveryLocationsResolver {
    *
    * @return Promise<Array<items>> A Promise that resolves and array of items, modified to include `eddRequestable` & `deliveryLocations`
    */
-  static attachDeliveryLocationsAndEddRequestability (items, deliveryLocationTypes) {
+  static attachDeliveryLocationsAndEddRequestability (items, { deliveryLocationTypes, scholarRoom }) {
     // Assert sensible default for location types:
     if (!Array.isArray(deliveryLocationTypes) || deliveryLocationTypes.length === 0) deliveryLocationTypes = ['Research']
 
@@ -311,7 +318,7 @@ class DeliveryLocationsResolver {
           }
           // Establish default for Electronic Document Delivery flag:
           item.eddRequestable = !!item.eddRequestable
-          item.deliveryLocation = this.formatLocations(item.deliveryLocation, deliveryLocationTypes)
+          item.deliveryLocation = this.formatLocations(item.deliveryLocation, deliveryLocationTypes, scholarRoom)
           return item
         })
       })

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -295,7 +295,7 @@ class DeliveryLocationsResolver {
    *
    * @return Promise<Array<items>> A Promise that resolves and array of items, modified to include `eddRequestable` & `deliveryLocations`
    */
-  static attachDeliveryLocationsAndEddRequestability (items, { deliveryLocationTypes, scholarRoom }) {
+  static attachDeliveryLocationsAndEddRequestability (items, deliveryLocationTypes, scholarRoom) {
     // Assert sensible default for location types:
     if (!Array.isArray(deliveryLocationTypes) || deliveryLocationTypes.length === 0) deliveryLocationTypes = ['Research']
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -353,7 +353,7 @@ module.exports = function (app, _private = null) {
     var identifierValues = barcodes.map((barcode) => `urn:barcode:${barcode}`)
 
     // Create promise to resolve deliveryLocationTypes by patron type:
-    let lookupPatronType = AvailableDeliveryLocationTypes.getByPatronId(params.patronId)
+    let patronTypeDependentData = AvailableDeliveryLocationTypes.getByPatronId(params.patronId)
       .catch((e) => {
         throw new errors.InvalidParameterError('Invalid patronId')
       })
@@ -371,14 +371,13 @@ module.exports = function (app, _private = null) {
     })
 
     // Run both item fetch and patron fetch in parallel:
-    return Promise.all([fetchItems, lookupPatronType])
+    return Promise.all([fetchItems, patronTypeDependentData])
       .then((resp) => {
         // The resolved values of Promise.all are strictly ordered based on original array of promises
         let items = resp[0]
-        let deliveryLocationTypes = resp[1]
-
+        let patronTypeDeliveryInfo = resp[1]
         // Use HTC API and nypl-core mappings to ammend ES response with deliveryLocations:
-        return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability(items, deliveryLocationTypes)
+        return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability(items, patronTypeDeliveryInfo)
           .catch((e) => {
             // An error here is likely an HTC API outage
             // Let's return items unmodified:

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -375,9 +375,9 @@ module.exports = function (app, _private = null) {
       .then((resp) => {
         // The resolved values of Promise.all are strictly ordered based on original array of promises
         let items = resp[0]
-        let patronTypeDeliveryInfo = resp[1]
+        const { deliveryLocationTypes, scholarRoom } = resp[1]
         // Use HTC API and nypl-core mappings to ammend ES response with deliveryLocations:
-        return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability(items, patronTypeDeliveryInfo)
+        return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability(items, deliveryLocationTypes, scholarRoom)
           .catch((e) => {
             // An error here is likely an HTC API outage
             // Let's return items unmodified:
@@ -463,7 +463,7 @@ module.exports = function (app, _private = null) {
           path: 'items',
           query: {
             bool: {
-              must_not: [ { exists: { field: 'items.electronicLocator' } } ]
+              must_not: [{ exists: { field: 'items.electronicLocator' } }]
             }
           },
           inner_hits: { name: 'allItems' }
@@ -639,8 +639,8 @@ module.exports = function (app, _private = null) {
     // Item's ReCAP status agrees with filter:
     const itemRecapStatusAgreesWithFilterClause =
       selectedRecapStatus === 'status:na'
-      ? itemIsUnavailableInRecapClause
-      : { bool: { must_not: itemIsUnavailableInRecapClause } }
+        ? itemIsUnavailableInRecapClause
+        : { bool: { must_not: itemIsUnavailableInRecapClause } }
 
     return {
       bool: {
@@ -710,15 +710,15 @@ module.exports = function (app, _private = null) {
     app.logger.debug('Resources#search', RESOURCES_INDEX, body)
 
     return app.esClient.search(body)
-    .then((resp) => {
-      let massagedResponse = new ResponseMassager(resp)
-      return massagedResponse.massagedResponse(request)
-        .catch((e) => {
-          // If error hitting HTC, just return response un-modified:
-          return resp
-        })
-        .then((updatedResponse) => ResourceResultsSerializer.serialize(updatedResponse, opts))
-    })
+      .then((resp) => {
+        let massagedResponse = new ResponseMassager(resp)
+        return massagedResponse.massagedResponse(request)
+          .catch((e) => {
+            // If error hitting HTC, just return response un-modified:
+            return resp
+          })
+          .then((updatedResponse) => ResourceResultsSerializer.serialize(updatedResponse, opts))
+      })
   }
 
   // Get all aggregations:
@@ -744,21 +744,21 @@ module.exports = function (app, _private = null) {
 
     app.logger.debug('Resources#aggregations:', body)
     return app.esClient.search(body)
-    .then((resp) => {
-      // Transform response slightly before serialization:
-      resp.aggregations = Object.keys(resp.aggregations)
-        .reduce((aggs, field) => {
-          let aggregation = resp.aggregations[field]
+      .then((resp) => {
+        // Transform response slightly before serialization:
+        resp.aggregations = Object.keys(resp.aggregations)
+          .reduce((aggs, field) => {
+            let aggregation = resp.aggregations[field]
 
-          // If it's nested, it will be in our special '_nested' prop:
-          if (aggregation._nested) aggregation = aggregation._nested
+            // If it's nested, it will be in our special '_nested' prop:
+            if (aggregation._nested) aggregation = aggregation._nested
 
-          aggs[field] = aggregation
-          return aggs
-        }, {})
+            aggs[field] = aggregation
+            return aggs
+          }, {})
 
-      return AggregationsSerializer.serialize(resp, serializationOpts)
-    })
+        return AggregationsSerializer.serialize(resp, serializationOpts)
+      })
   }
 
   // Get a single aggregation:
@@ -788,12 +788,12 @@ module.exports = function (app, _private = null) {
 
     app.logger.debug('Resources#aggregation:', body)
     return app.esClient.search(body)
-    .then((resp) => {
-      // If it's nested, it will be in our special '_nested' prop:
-      resp = resp.aggregations[params.field]._nested || resp.aggregations[params.field]
-      resp.id = params.field
-      return AggregationSerializer.serialize(resp, serializationOpts)
-    })
+      .then((resp) => {
+        // If it's nested, it will be in our special '_nested' prop:
+        resp = resp.aggregations[params.field]._nested || resp.aggregations[params.field]
+        resp.id = params.field
+        return AggregationSerializer.serialize(resp, serializationOpts)
+      })
   }
 
   // This is TK

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-u1BFecHK6SPmV2pPXaQ9Jfl729k="
     },
     "@nypl/nypl-core-objects": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@nypl/nypl-core-objects/-/nypl-core-objects-1.6.1.tgz",
-      "integrity": "sha512-3S2Tys4XG3nfzT32jxijZGJ/X42JxvTG+WU785d91xnUlhjSc+wA4Fe4pX3N/BjRq8o8NGwq4Cp5nWLECpbakA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@nypl/nypl-core-objects/-/nypl-core-objects-1.7.1.tgz",
+      "integrity": "sha512-rjwCcJhl4jih0itOEV9CgaIfKmVgwIoKwzIPfCpiIy/XfEoyDPMam9j15x9vrZT9h/GZzDLPzcAF70o8Q4f6KA==",
       "requires": {
         "just-flatten": "^1.0.0",
         "sync-request": "^4.1.0"
@@ -290,7 +290,7 @@
         "uuid": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+          "integrity": "sha1-vGzPkbX/CsB7vNvxx8ThUNtNu2w=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "analyze": true,
   "author": "NYPL Digital",
   "dependencies": {
-    "@nypl/nypl-core-objects": "^1.6.1",
+    "@nypl/nypl-core-objects": "^1.7.1",
     "@nypl/nypl-data-api-client": "^1.0.1",
     "@nypl/scsb-rest-client": "1.0.6",
     "config": "1.12.0",

--- a/test/available_delivery_location_types.test.js
+++ b/test/available_delivery_location_types.test.js
@@ -23,8 +23,12 @@ describe('AvailableDeliveryLocationTypes', function () {
   })
 
   it('maps patron type 78 to [\'Scholar\', \'Research\']', function () {
-    return AvailableDeliveryLocationTypes.getByPatronId('scholar-patron-id').then(({ deliveryLocationTypes }) => {
+    return AvailableDeliveryLocationTypes.getByPatronId('scholar-patron-id').then(({ deliveryLocationTypes, scholarRoom }) => {
       expect(deliveryLocationTypes).to.eql(['Research', 'Scholar'])
+      expect(scholarRoom).to.eql({
+        code: 'mal17',
+        label: 'Schwarzman Building - Scholar Room 217'
+      })
     })
   })
 

--- a/test/available_delivery_location_types.test.js
+++ b/test/available_delivery_location_types.test.js
@@ -17,19 +17,19 @@ describe('AvailableDeliveryLocationTypes', function () {
   })
 
   it('maps patron type 10 to [\'Research\']', function () {
-    return AvailableDeliveryLocationTypes.getByPatronId('branch-patron-id').then((deliveryLocationTypes) => {
+    return AvailableDeliveryLocationTypes.getByPatronId('branch-patron-id').then(({ deliveryLocationTypes }) => {
       expect(deliveryLocationTypes).to.eql(['Research'])
     })
   })
 
   it('maps patron type 78 to [\'Scholar\', \'Research\']', function () {
-    return AvailableDeliveryLocationTypes.getByPatronId('scholar-patron-id').then((deliveryLocationTypes) => {
-      expect(deliveryLocationTypes).to.eql(['Scholar', 'Research'])
+    return AvailableDeliveryLocationTypes.getByPatronId('scholar-patron-id').then(({ deliveryLocationTypes }) => {
+      expect(deliveryLocationTypes).to.eql(['Research', 'Scholar'])
     })
   })
 
   it('maps an unrecognizable patron type to [\'Research\']', function () {
-    return AvailableDeliveryLocationTypes.getByPatronId('unrecognizable-ptype-patron-id').then((deliveryLocationTypes) => {
+    return AvailableDeliveryLocationTypes.getByPatronId('unrecognizable-ptype-patron-id').then(({ deliveryLocationTypes }) => {
       expect(deliveryLocationTypes).to.eql(['Research'])
     })
   })

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -197,11 +197,24 @@ describe('Delivery-locations-resolver', function () {
       })
   })
 
-  it('will reveal "Scholar" deliveryLocation for scholars', function () {
+  it('will reveal "Scholar" deliveryLocation for scholars with specific scholar room', function () {
+    return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability([sampleItems.offsiteNyplDeliverableToScholarRooms], ['Research', 'Scholar'], { code: 'mal17' }).then((items) => {
+      expect(items[0].deliveryLocation).to.not.be.empty
+
+      // Confirm the non specified scholar rooms are not included:
+      scholarRooms.forEach((scholarRoom) => {
+        if (scholarRoom.id !== 'loc:mal17') {
+          expect(items[0].deliveryLocation.map((location) => location.id)).not.to.include(scholarRoom.id)
+        }
+      })
+    })
+  })
+
+  it('will reveal all "Scholar" deliveryLocations for scholars with no specific scholar room', function () {
     return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability([sampleItems.offsiteNyplDeliverableToScholarRooms], ['Research', 'Scholar']).then((items) => {
       expect(items[0].deliveryLocation).to.not.be.empty
 
-      // Confirm the known scholar rooms are not included:
+      // Confirm that all scholar rooms are included:
       scholarRooms.forEach((scholarRoom) => {
         expect(items[0].deliveryLocation.map((location) => location.id)).to.include(scholarRoom.id)
       })

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -180,6 +180,8 @@ describe('Delivery-locations-resolver', function () {
 
     return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability([offsiteItemInNonRequestableLocation])
       .then((items) => {
+        console.log('spaghetti')
+        console.log(items[0])
         expect(items[0].deliveryLocation).to.be.a('array')
         expect(items[0].deliveryLocation).to.have.lengthOf(1)
       })

--- a/test/fixtures/patron-scholar.json
+++ b/test/fixtures/patron-scholar.json
@@ -41,7 +41,7 @@
       },
       "47": {
         "label": "Patron Type",
-        "value": "78",
+        "value": "76",
         "display": null
       },
       "48": {


### PR DESCRIPTION
Incorporates updates to nypl-core and nypl-core-objects to filter out the scholar locations. A scholar with a specific scholar room will only see that one returned. A scholar type without a specific room will return all of the scholar room options.