### PR TITLE
 SCC-3958/one-scholar-2 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 install: npm install
-script: NYPL_CORE_VERSION=v1.x-rom-com-prerelease-1.1 npm test && npm test
+script: npm test
 before_deploy: echo 'All unit tests passed; Successfull built distribution assets;
   Preparing to deploy Discovery-API to AWS.'
 deploy:

--- a/lib/available_delivery_location_types.js
+++ b/lib/available_delivery_location_types.js
@@ -3,18 +3,18 @@ const { makeNyplDataApiClient } = require('./data-api-client')
 
 
 class AvailableDeliveryLocationTypes {
-  static getByPatronId (patronID) {
+  static getScholarRoomByPatronId (patronID) {
     // If patronID is falsy (i.e. patron is not logged in) they're just a Rearcher:
     if (!patronID) return Promise.resolve(['Research'])
 
     const patronTypeMapping = require('@nypl/nypl-core-objects')('by-patron-type')
-
     return this._getPatronTypeOf(patronID)
       .then((patronType) => {
-        const accessibleDeliveryLocationTypes = this._isUnfamiliarPatronType(patronTypeMapping, patronType)
-          ? ['Research'] : patronTypeMapping[patronType]['accessibleDeliveryLocationTypes']
-
-        return accessibleDeliveryLocationTypes
+        if (this._isUnfamiliarPatronType(patronTypeMapping, patronType)) {
+          return
+        }
+        const patronTypeData = patronTypeMapping[patronType]
+        return patronTypeData.scholarRoom && patronTypeData.scholarRoom.code
       })
   }
 

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -1,4 +1,4 @@
-const { arrayIntersection, itemHasRecapHoldingLocation, barcodeFromItem } = require('./util')
+const { itemHasRecapHoldingLocation, barcodeFromItem } = require('./util')
 const SCSBRestClient = require('@nypl/scsb-rest-client')
 const recapCustomerCodes = require('@nypl/nypl-core-objects')('by-recap-customer-code')
 const sierraLocations = require('@nypl/nypl-core-objects')('by-sierra-location')
@@ -187,21 +187,14 @@ class DeliveryLocationsResolver {
   static formatLocations (locations, deliveryLocationTypes) {
     if (!locations) return []
     return (
-      // Filter out anything not matching the specified deliveryLocationType
-      locations.filter((location) => {
-        if (deliveryLocationTypes) {
-          return location.deliveryLocationTypes &&
-            arrayIntersection(location.deliveryLocationTypes, deliveryLocationTypes).length > 0
-        } else return true
+      // Format locations in the manner api consumers expect
+      locations.map((location) => {
+        return {
+          id: `loc:${location.code}`,
+          label: location.label,
+          sortPosition: this.sortPosition(location)
+        }
       })
-        // Format locations in the manner api consumers expect
-        .map((location) => {
-          return {
-            id: `loc:${location.code}`,
-            label: location.label,
-            sortPosition: this.sortPosition(location)
-          }
-        })
         // Either way, sort deliveryLocation entries by name:
         .sort((l1, l2) => {
           if (l1.sortPosition < l2.sortPosition) return -1
@@ -283,15 +276,32 @@ class DeliveryLocationsResolver {
     return deliveryInfo
   }
 
+  // Given an array of locations and scholar room code (eg 'mal17'), filters out
+  // irrelevant scholar rooms, all scholar rooms if no code is provided or if
+  // item is only deliverable to LPA or SC.
+  static filterLocations (locations, scholarRoom) {
+    if (!locations || !locations.length) return []
+    const onlyDeliverabletToLpaOrSchomburg = locations.filter((location) => {
+      return location.code.startsWith('ma')
+    }).length === 0
+    // remove scholar locations that are not the scholar room, if a specific
+    // scholar room exists.s
+    // Filter out anything not matching the specified deliveryLocationType
+    return locations.filter((location) => {
+      const locationIsNotScholarRoom = !location.deliveryLocationTypes.includes('Scholar')
+      // If an item is not deliverable to SASB, don't return scholar rooms
+      if (onlyDeliverabletToLpaOrSchomburg) {
+        return locationIsNotScholarRoom
+      } else return locationIsNotScholarRoom || (location.code === scholarRoom)
+    })
+  }
+
   /**
    * Given an array of items (ES hits), returns the same items with `eddRequestable` & `deliveryLocations`
    *
    * @return Promise<Array<items>> A Promise that resolves and array of items, modified to include `eddRequestable` & `deliveryLocations`
    */
-  static attachDeliveryLocationsAndEddRequestability (items, deliveryLocationTypes) {
-    // Assert sensible default for location types:
-    if (!Array.isArray(deliveryLocationTypes) || deliveryLocationTypes.length === 0) deliveryLocationTypes = ['Research']
-
+  static attachDeliveryLocationsAndEddRequestability (items, scholarRoom) {
     // Extract ReCAP barcodes from items:
     const recapBarcodes = this.extractRecapBarcodes(items)
     // Get a map from barcodes to ReCAP customercodes:
@@ -311,10 +321,13 @@ class DeliveryLocationsResolver {
           }
           // Establish default for Electronic Document Delivery flag:
           item.eddRequestable = !!item.eddRequestable
-          item.deliveryLocation = this.formatLocations(item.deliveryLocation, deliveryLocationTypes)
+          const filteredDeliveryLocationsWithScholarRoom = this.filterLocations(item.deliveryLocation, scholarRoom)
+          item.deliveryLocation = this.formatLocations(filteredDeliveryLocationsWithScholarRoom)
           return item
         })
       })
   }
+
 }
+
 module.exports = DeliveryLocationsResolver

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -277,22 +277,16 @@ class DeliveryLocationsResolver {
   }
 
   // Given an array of locations and scholar room code (eg 'mal17'), filters out
-  // irrelevant scholar rooms, all scholar rooms if no code is provided or if
-  // item is only deliverable to LPA or SC.
+  // irrelevant scholar rooms, or filters out all scholar rooms if no code is
+  // provided
   static filterLocations (locations, scholarRoom) {
     if (!locations || !locations.length) return []
-    const onlyDeliverabletToLpaOrSchomburg = locations.filter((location) => {
-      return location.code.startsWith('ma')
-    }).length === 0
     // remove scholar locations that are not the scholar room, if a specific
-    // scholar room exists.s
+    // scholar room exists.
     // Filter out anything not matching the specified deliveryLocationType
     return locations.filter((location) => {
       const locationIsNotScholarRoom = !location.deliveryLocationTypes.includes('Scholar')
-      // If an item is not deliverable to SASB, don't return scholar rooms
-      if (onlyDeliverabletToLpaOrSchomburg) {
-        return locationIsNotScholarRoom
-      } else return locationIsNotScholarRoom || (location.code === scholarRoom)
+      return locationIsNotScholarRoom || (location.code === scholarRoom)
     })
   }
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -375,10 +375,10 @@ module.exports = function (app, _private = null) {
       .then((resp) => {
         // The resolved values of Promise.all are strictly ordered based on original array of promises
         let items = resp[0]
-        let deliveryLocationTypes = resp[1]
+        let scholarRoom = resp[1]
 
         // Use HTC API and nypl-core mappings to ammend ES response with deliveryLocations:
-        return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability(items, deliveryLocationTypes)
+        return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability(items, scholarRoom)
           .catch((e) => {
             // An error here is likely an HTC API outage
             // Let's return items unmodified:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-u1BFecHK6SPmV2pPXaQ9Jfl729k="
     },
     "@nypl/nypl-core-objects": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@nypl/nypl-core-objects/-/nypl-core-objects-1.6.1.tgz",
-      "integrity": "sha512-3S2Tys4XG3nfzT32jxijZGJ/X42JxvTG+WU785d91xnUlhjSc+wA4Fe4pX3N/BjRq8o8NGwq4Cp5nWLECpbakA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@nypl/nypl-core-objects/-/nypl-core-objects-1.7.0.tgz",
+      "integrity": "sha512-ZmuFT6ytZND3u+14LcVNDHRW30LlYppigJcMpZyXJUmz69LhUMCDZAeHMdwpP0PMdoFS5udgWkuzE3SU+EKe2A==",
       "requires": {
         "just-flatten": "^1.0.0",
         "sync-request": "^4.1.0"
@@ -290,7 +290,7 @@
         "uuid": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+          "integrity": "sha1-vGzPkbX/CsB7vNvxx8ThUNtNu2w=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "analyze": true,
   "author": "NYPL Digital",
   "dependencies": {
-    "@nypl/nypl-core-objects": "^1.6.1",
+    "@nypl/nypl-core-objects": "^1.7.0",
     "@nypl/nypl-data-api-client": "^1.0.1",
     "@nypl/scsb-rest-client": "1.0.6",
     "config": "1.12.0",

--- a/test/available_delivery_location_types.test.js
+++ b/test/available_delivery_location_types.test.js
@@ -16,21 +16,21 @@ describe('AvailableDeliveryLocationTypes', function () {
     fixtures.disableDataApiFixtures()
   })
 
-  it('maps patron type 10 to [\'Research\']', function () {
-    return AvailableDeliveryLocationTypes.getByPatronId('branch-patron-id').then((deliveryLocationTypes) => {
-      expect(deliveryLocationTypes).to.eql(['Research'])
+  it('returns no scholar room code for ptype 10 (research)', function () {
+    return AvailableDeliveryLocationTypes.getScholarRoomByPatronId('branch-patron-id').then((deliveryLocationTypes) => {
+      expect(deliveryLocationTypes).to.eql(undefined)
     })
   })
 
-  it('maps patron type 78 to [\'Scholar\', \'Research\']', function () {
-    return AvailableDeliveryLocationTypes.getByPatronId('scholar-patron-id').then((deliveryLocationTypes) => {
-      expect(deliveryLocationTypes).to.eql(['Scholar', 'Research'])
+  it('returns scholar room code for ptype 87 (research)', function () {
+    return AvailableDeliveryLocationTypes.getScholarRoomByPatronId('scholar-patron-id').then((deliveryLocationTypes) => {
+      expect(deliveryLocationTypes).to.eql('mala')
     })
   })
 
-  it('maps an unrecognizable patron type to [\'Research\']', function () {
-    return AvailableDeliveryLocationTypes.getByPatronId('unrecognizable-ptype-patron-id').then((deliveryLocationTypes) => {
-      expect(deliveryLocationTypes).to.eql(['Research'])
+  it('returns no scholar room code for unrecognizable ptype', function () {
+    return AvailableDeliveryLocationTypes.getScholarRoomByPatronId('unrecognizable-ptype-patron-id').then((deliveryLocationTypes) => {
+      expect(deliveryLocationTypes).to.eql(undefined)
     })
   })
 })

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -1,6 +1,40 @@
 var DeliveryLocationsResolver = require('../lib/delivery-locations-resolver')
 
 var sampleItems = {
+  onsiteOnlySchomburg:
+  {
+    '@id': 'res:i11982421',
+    '@type': [
+      'bf:Item'
+    ],
+    'holdingLocation': [
+      {
+        'id': 'loc:scff3',
+        'prefLabel': 'Schomburg Center - Research & Reference - Desk'
+      }
+    ],
+    'idBarcode': [
+      '33433036951154'
+    ],
+    'identifier': [
+      {
+        '@type': 'bf:ShelfMark',
+        '@value': 'Sc Micro F-1843'
+      },
+      {
+        '@type': 'bf:Barcode',
+        '@value': '33433036951154'
+      }
+    ],
+    'specRequestable': false,
+    'status': [
+      {
+        '@id': 'status:a',
+        'prefLabel': 'Available'
+      }
+    ],
+    'uri': 'i11982421'
+  },
   onsiteNypl: {
     'identifier': [
       'urn:bnum:b11995345',
@@ -115,6 +149,17 @@ function takeThisPartyPartiallyOffline () {
 describe('Delivery-locations-resolver', function () {
   before(takeThisPartyPartiallyOffline)
 
+  it('will hide "Scholar" deliveryLocation for LPA or SC only deliverable items, patron is scholar type', function () {
+    return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability([sampleItems.onsiteOnlySchomburg], 'mala').then((items) => {
+      expect(items[0].deliveryLocation).to.not.be.empty
+
+      // Confirm the known scholar rooms are not included:
+      scholarRooms.forEach((scholarRoom) => {
+        expect(items[0].deliveryLocation).to.not.include(scholarRoom)
+      })
+    })
+  })
+
   it('will return empty delivery locations for an unrequestable onsite location code', function () {
     return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability([sampleItems.onsiteNypl]).then((items) => {
       expect(items[0].deliveryLocation).to.be.empty
@@ -164,7 +209,7 @@ describe('Delivery-locations-resolver', function () {
   })
 
   it('will hide "Scholar" deliveryLocation for non-scholars', function () {
-    return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability([sampleItems.offsiteNyplDeliverableToScholarRooms], ['Research']).then((items) => {
+    return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability([sampleItems.offsiteNyplDeliverableToScholarRooms]).then((items) => {
       expect(items[0].deliveryLocation).to.not.be.empty
 
       // Confirm the known scholar rooms are not included:
@@ -180,6 +225,8 @@ describe('Delivery-locations-resolver', function () {
 
     return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability([offsiteItemInNonRequestableLocation])
       .then((items) => {
+        console.log('spaghetti')
+        console.log(items[0])
         expect(items[0].deliveryLocation).to.be.a('array')
         expect(items[0].deliveryLocation).to.have.lengthOf(1)
       })
@@ -197,13 +244,26 @@ describe('Delivery-locations-resolver', function () {
       })
   })
 
-  it('will reveal "Scholar" deliveryLocation for scholars', function () {
-    return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability([sampleItems.offsiteNyplDeliverableToScholarRooms], ['Research', 'Scholar']).then((items) => {
+  it('will reveal specific scholar room deliveryLocation when specified', function () {
+    return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability([sampleItems.offsiteNyplDeliverableToScholarRooms], 'mal17').then((items) => {
       expect(items[0].deliveryLocation).to.not.be.empty
 
-      // Confirm the known scholar rooms are not included:
+      // Confirm the non specified scholar rooms are not included:
       scholarRooms.forEach((scholarRoom) => {
-        expect(items[0].deliveryLocation.map((location) => location.id)).to.include(scholarRoom.id)
+        if (scholarRoom.id !== 'loc:mal17') {
+          expect(items[0].deliveryLocation.map((location) => location.id)).not.to.include(scholarRoom.id)
+        }
+      })
+    })
+  })
+
+  it('will hide "Scholar" deliveryLocations for scholars with no specific scholar room', function () {
+    return DeliveryLocationsResolver.attachDeliveryLocationsAndEddRequestability([sampleItems.offsiteNyplDeliverableToScholarRooms]).then((items) => {
+      expect(items[0].deliveryLocation).to.not.be.empty
+
+      // Confirm that all scholar rooms are included:
+      scholarRooms.forEach((scholarRoom) => {
+        expect(items[0].deliveryLocation.map((location) => location.id)).not.to.include(scholarRoom.id)
       })
     })
   })
@@ -315,7 +375,7 @@ describe('Delivery-locations-resolver', function () {
         holdingLocation: [{ id: requestableM2Location }]
       }]
       return DeliveryLocationsResolver
-        .attachDeliveryLocationsAndEddRequestability(items, ['Research'])
+        .attachDeliveryLocationsAndEddRequestability(items)
         .then((items) => {
           expect(items[0].deliveryLocation).to.deep.equal([
             { id: 'loc:mal', label: 'Schwarzman Building - Main Reading Room 315', sortPosition: 1 },
@@ -336,7 +396,7 @@ describe('Delivery-locations-resolver', function () {
         holdingLocation: [{ id: nonrequestableM2Location }]
       }]
       return DeliveryLocationsResolver
-        .attachDeliveryLocationsAndEddRequestability(items, ['Research'])
+        .attachDeliveryLocationsAndEddRequestability(items)
         .then((items) => {
           expect(items[0].deliveryLocation).to.be.empty
         })
@@ -349,26 +409,24 @@ describe('Delivery-locations-resolver', function () {
         holdingLocation: [{ id: requestableM2Location }]
       }]
       return DeliveryLocationsResolver
-        .attachDeliveryLocationsAndEddRequestability(items, ['Research'])
+        .attachDeliveryLocationsAndEddRequestability(items)
         .then((items) => {
           expect(items[0].deliveryLocation).to.be.empty
         })
     })
 
-    it('returns scholar delivery locations for requestable M2 items when Scholar rooms requested', () => {
+    it('returns scholar delivery locations for requestable M2 items when scholar room is provided', () => {
       const items = [{
         uri: 'b123',
         m2CustomerCode: ['XA'],
         holdingLocation: [{ id: requestableM2Location }]
       }]
+      const scholarRoom = 'malc'
       return DeliveryLocationsResolver
-        .attachDeliveryLocationsAndEddRequestability(items, ['Research', 'Scholar'])
+        .attachDeliveryLocationsAndEddRequestability(items, scholarRoom)
         .then((items) => {
           expect(items[0].deliveryLocation).to.deep.include.members([
-            { id: 'loc:mala', label: 'Schwarzman Building - Allen Scholar Room', sortPosition: 0 },
             { id: 'loc:malc', label: 'Schwarzman Building - Cullman Center', sortPosition: 0 },
-            { id: 'loc:maln', label: 'Schwarzman Building - Noma Scholar Room', sortPosition: 0 },
-            { id: 'loc:malw', label: 'Schwarzman Building - Wertheim Scholar Room', sortPosition: 0 },
             { id: 'loc:mal', label: 'Schwarzman Building - Main Reading Room 315', sortPosition: 1 },
             { id: 'loc:mab', label: 'Schwarzman Building - Art & Architecture Room 300', sortPosition: 2 },
             { id: 'loc:maf', label: 'Schwarzman Building - Dorot Jewish Division Room 111', sortPosition: 2 },
@@ -385,7 +443,7 @@ describe('Delivery-locations-resolver', function () {
         holdingLocation: [{ id: requestableM2Location }]
       }]
       return DeliveryLocationsResolver
-        .attachDeliveryLocationsAndEddRequestability(items, ['Research', 'Scholar'])
+        .attachDeliveryLocationsAndEddRequestability(items)
         .then((deliveryLocations) => {
           expect(deliveryLocations[0].deliveryLocation).to.deep.equal([])
         })
@@ -397,7 +455,7 @@ describe('Delivery-locations-resolver', function () {
         holdingLocation: [{ id: requestableM2Location }]
       }]
       return DeliveryLocationsResolver
-        .attachDeliveryLocationsAndEddRequestability(items, ['Research', 'Scholar'])
+        .attachDeliveryLocationsAndEddRequestability(items)
         .then((deliveryLocations) => {
           expect(deliveryLocations[0].deliveryLocation).to.deep.equal([])
         })
@@ -408,7 +466,7 @@ describe('Delivery-locations-resolver', function () {
         holdingLocation: [{ id: 'fake' }]
       }]
       return DeliveryLocationsResolver
-        .attachDeliveryLocationsAndEddRequestability(items, ['Research', 'Scholar'])
+        .attachDeliveryLocationsAndEddRequestability(items)
         .then((deliveryLocations) => {
           expect(deliveryLocations[0].deliveryLocation).to.deep.equal([])
         })

--- a/test/fixtures/patron-scholar.json
+++ b/test/fixtures/patron-scholar.json
@@ -41,7 +41,7 @@
       },
       "47": {
         "label": "Patron Type",
-        "value": "78",
+        "value": "87",
         "display": null
       },
       "48": {


### PR DESCRIPTION
Delivery location types array eg `['Research', 'Scholar']` was basically being overwritten in the[ previous implementation ](https://github.com/NYPL/discovery-api/pull/359)of this work. I branched from main again, and reimplemented to not use that property. I ported the tests from the other implementation to verify results. 