### PR TITLE
NOREF fix edd status check

### DIFF
--- a/data/onsite-edd-criteria.json
+++ b/data/onsite-edd-criteria.json
@@ -1,6 +1,7 @@
 {
   "status": [
-    "a"
+    "a",
+    "na"
   ],
   "accessMessage": [
     "-",

--- a/lib/delivery-locations-resolver.js
+++ b/lib/delivery-locations-resolver.js
@@ -84,6 +84,8 @@ class DeliveryLocationsResolver {
     const eddCriteriaChecks = [
       // Check the following properties for agreement with required values
       // rm status because we have separated availability and requestability - VK 7/27/2023
+      // Add status because status 'o' actually makes holds impossible - PB 3/21/2024
+      'status',
       'catalogItemType',
       'holdingLocation',
       'accessMessage'

--- a/test/delivery-locations-resolver.test.js
+++ b/test/delivery-locations-resolver.test.js
@@ -309,7 +309,7 @@ describe('Delivery-locations-resolver', function () {
     })
 
     it('will return true for on-site item failing status check', function () {
-      item.status[0].id = 'status:co'
+      item.status[0].id = 'status:na'
       expect(DeliveryLocationsResolver.eddRequestableByOnSiteCriteria(item)).to.equal(true)
     })
 


### PR DESCRIPTION
Fixes an issue where we are currently enabling Request Scan buttons on on-site
materials that have item status 'Use in library' (o). Currently, Sierra rejects all holds
on all items with that status.

With this update, an on-site item will only be `eddRequestable` if it meets all previous on-site EDD criteria _plus_ having an Available or Not Available status. This will enable RC to show the "Request Scan" button only for on-site materials that meet the status requirement (rejecting any item with status 'o' or other lesser-used unavailable statuses). When the item's status is Available, RC will activate the button.