### PR TITLE
Change test for overwriting location label to use non-obsolete location

### DIFF
--- a/test/location_label_updater.test.js
+++ b/test/location_label_updater.test.js
@@ -8,14 +8,14 @@ describe('Location LabelUpdater', function () {
       '_id': 'b10980129',
       '_source': {
         'items': [{
-          'holdingLocation': [{'id': 'mai87', 'label': 'Some disgusting room'}]
+          'holdingLocation': [{'id': 'mai82', 'label': 'Some disgusting room'}]
         }]
       }
     }]}
     }
 
     let updatedResponse = new LocationLabelUpdater(fakeESResponse).responseWithUpdatedLabels()
-    expect(updatedResponse.hits.hits[0]._source.items[0].holdingLocation[0].label).to.equal('Schwarzman Building - Periodicals and Microforms Room 119')
+    expect(updatedResponse.hits.hits[0]._source.items[0].holdingLocation[0].label).to.equal('Schwarzman Building M1 - Microforms Room 315')
   })
 
   it('will overwrite an ElasticSearch Response\'s holdings record location label', function () {


### PR DESCRIPTION
`mai87` no longer exists following recent updated to `nypl-core`, which is causing tests to fail.

This PR changes the test to use an up-to-date location

We should probably also be mocking `nypl-core` in these tests, but this PR doesn't do that, since it seems good to have up-to-date examples anyway and that fixes the issue for now.