### PR TITLE
Fix broken test

### DIFF
--- a/test/location_label_updater.test.js
+++ b/test/location_label_updater.test.js
@@ -15,7 +15,7 @@ describe('Location LabelUpdater', function () {
     }
 
     let updatedResponse = new LocationLabelUpdater(fakeESResponse).responseWithUpdatedLabels()
-    expect(updatedResponse.hits.hits[0]._source.items[0].holdingLocation[0].label).to.equal('Schwarzman Building M1 - Microforms Room 315')
+    expect(updatedResponse.hits.hits[0]._source.items[0].holdingLocation[0].label).to.equal('Schwarzman Building - Microforms Room 315')
   })
 
   it('will overwrite an ElasticSearch Response\'s holdings record location label', function () {


### PR DESCRIPTION
Remove `M1` from expected location label in tests following NYPL-Core changes.