### PR TITLE
move fulfillment resolver to after the requestablilty

### DIFF
--- a/lib/response_massager.js
+++ b/lib/response_massager.js
@@ -76,8 +76,8 @@ class ResponseMassager {
         return (new LocationLabelUpdater(response))
           .responseWithUpdatedLabels()
       })
-      .then((response) => new FulfillmentResolver(response).responseWithFulfillment())
       .then((response) => RequestabilityResolver.fixItemRequestability(response))
+      .then((response) => new FulfillmentResolver(response).responseWithFulfillment())
   }
 }
 


### PR DESCRIPTION
Fulfillment resolver requires requestability to function, but was being calculated before requestability. This switches requestability and fulfillment calculations.