### PR TITLE
NOREF - fix broken debugging

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -650,7 +650,7 @@ module.exports = function (app, _private = null) {
                 out.push(`${ind + 1}: ${r.searchResultScore} score > ${r.result.uri}:`)
                 if (params.search_scope === 'contributor') out.push(`(${r.result.creatorLiteral || r.result.contributorLiteral})`)
                 if (['standard_number', 'callnumber'].includes(params.search_scope)) out.push(`(${r.result.items && r.result.items[0]?.shelfMark})`)
-                out.push(`${r.result.title && r.result.title[0]} (displayed as "${r.result.titleDisplay && r.result.titleDisplay[0]}")`)
+                out.push(`${r.result.title} (displayed as "${r.result.titleDisplay}")`)
                 if (r.matchedQueries) out.push(`\n  ${r.matchedQueries.join(', ')}`)
                 return out.join(' ')
               })

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -650,7 +650,7 @@ module.exports = function (app, _private = null) {
                 out.push(`${ind + 1}: ${r.searchResultScore} score > ${r.result.uri}:`)
                 if (params.search_scope === 'contributor') out.push(`(${r.result.creatorLiteral || r.result.contributorLiteral})`)
                 if (['standard_number', 'callnumber'].includes(params.search_scope)) out.push(`(${r.result.items && r.result.items[0]?.shelfMark})`)
-                out.push(`${r.result.title[0]} (displayed as "${r.result.titleDisplay[0]}")`)
+                out.push(`${r.result.title && r.result.title[0]} (displayed as "${r.result.titleDisplay && r.result.titleDisplay[0]}")`)
                 if (r.matchedQueries) out.push(`\n  ${r.matchedQueries.join(', ')}`)
                 return out.join(' ')
               })


### PR DESCRIPTION
We add a `debug` prop to the response while we assess search changes. It is currently populated with bad assumptions about the availability of `title` and `titleDisplay`. This fixes that.