### PR TITLE
Fix bug incorporating offsites in item status agg

### DIFF
--- a/lib/elasticsearch/client.js
+++ b/lib/elasticsearch/client.js
@@ -115,7 +115,7 @@ clientWrapper.nonRecapItemStatusAggregation = (bnum) => {
 
   return clientWrapper.search(esQuery)
     .then((resp) => {
-      return deepValue(resp, 'body.aggregations.statuses.nonrecap_statuses.nonrecap_status_buckets.buckets')
+      return deepValue(resp, 'aggregations.statuses.nonrecap_statuses.nonrecap_status_buckets.buckets')
     })
 }
 

--- a/test/elasticsearch-client.test.js
+++ b/test/elasticsearch-client.test.js
@@ -1,0 +1,28 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+const esClient = require('../lib/elasticsearch/client')
+
+describe('Elasticsearch Client', () => {
+  describe('nonRecapItemStatusAggregation', () => {
+    beforeEach(() => {
+      // We expect these tests to trigger an ES query to retrieve aggregated
+      // non-reap-statuses for the bib:
+      sinon.stub(esClient, 'search')
+        .callsFake(() => {
+          return Promise.resolve(require('./fixtures/es-response-b1234-just-non-recap-statuses.json'))
+        })
+    })
+
+    afterEach(() => esClient.search.restore())
+
+    it('retrieves item status aggregation', async () => {
+      const resp = await esClient.nonRecapItemStatusAggregation('b1234')
+
+      expect(resp).to.be.a('array')
+      expect(resp).to.deep.equal([
+        { key: 'status:a||Available', doc_count: 2 }
+      ])
+    })
+  })
+})

--- a/test/fixtures/es-response-b1234-just-non-recap-statuses.json
+++ b/test/fixtures/es-response-b1234-just-non-recap-statuses.json
@@ -1,32 +1,30 @@
 {
-  "body": {
-    "took": 11,
-    "timed_out": false,
-    "_shards": {
-      "total": 3,
-      "successful": 3,
-      "failed": 0
-    },
-    "hits": {
-      "total": 1,
-      "max_score": 0.0,
-      "hits": []
-    },
-    "aggregations": {
-      "statuses": {
-        "doc_count": 4,
-        "nonrecap_statuses": {
-          "doc_count": 2,
-          "nonrecap_status_buckets": {
-            "doc_count_error_upper_bound": 0,
-            "sum_other_doc_count": 0,
-            "buckets": [
-              {
-                "key": "status:a||Available",
-                "doc_count": 2
-              }
-            ]
-          }
+  "took": 11,
+  "timed_out": false,
+  "_shards": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "hits": {
+    "total": 1,
+    "max_score": 0.0,
+    "hits": []
+  },
+  "aggregations": {
+    "statuses": {
+      "doc_count": 4,
+      "nonrecap_statuses": {
+        "doc_count": 2,
+        "nonrecap_status_buckets": {
+          "doc_count_error_upper_bound": 0,
+          "sum_other_doc_count": 0,
+          "buckets": [
+            {
+              "key": "status:a||Available",
+              "doc_count": 2
+            }
+          ]
         }
       }
     }


### PR DESCRIPTION
Fix bug when merging offsite and on-site item statuses into a single item status aggregation. The es-client util function for getting the on-site item status agggregation was still using the root 'body' property (a v7 client vestige). Tests didn't catch this because the fixture was also stale. Fixed that and added a test to assert correct parsing.

Discovered in QA for https://newyorkpubliclibrary.atlassian.net/browse/SCC-4328