### PR TITLE
ensure subject literals have trailing periods removed

### DIFF
--- a/lib/elasticsearch/config.js
+++ b/lib/elasticsearch/config.js
@@ -1,3 +1,5 @@
+const util = require('../util')
+
 // Configure search scopes:
 const SEARCH_SCOPES = {
   all: {
@@ -78,17 +80,11 @@ const FILTER_CONFIG = {
   owner: { operator: 'match', field: ['items.owner.id', 'items.owner.label'], repeatable: true, path: 'items' },
   subjectLiteral: {
     transform: (val, logger) => {
-      const removePeriod = (x) => {
-        if (x.slice(-1) === '.') {
-          logger.debug('Removing terminal period', JSON.stringify(val, null, 4))
-          return x.slice(0, -1)
-        } else return x
-      }
       if (typeof val === 'string') {
-        return removePeriod(val)
+        return util.removeTrailingPeriod(val, logger)
       }
       if (Array.isArray(val)) {
-        return val.map(removePeriod)
+        return val.map((val) => util.removeTrailingPeriod(val, logger))
       }
     },
     operator: 'match',

--- a/lib/elasticsearch/config.js
+++ b/lib/elasticsearch/config.js
@@ -78,18 +78,18 @@ const FILTER_CONFIG = {
   owner: { operator: 'match', field: ['items.owner.id', 'items.owner.label'], repeatable: true, path: 'items' },
   subjectLiteral: {
     transform: (val, logger) => {
-      if (typeof val === 'string' && val.slice(-1) === '.') {
-        val = val.slice(0, -1)
-        logger.debug('Removing terminal period', JSON.stringify(val, null, 4))
-      } else if (Array.isArray(val)) {
-        val.forEach((sub, i) => {
-          if (sub.slice(-1) === '.') {
-            val[i] = sub.slice(0, -1)
-            logger.debug('Removing terminal period', JSON.stringify(sub, null, 4))
-          }
-        })
+      const removePeriod = (x) => {
+        if (x.slice(-1) === '.') {
+          logger.debug('Removing terminal period', JSON.stringify(val, null, 4))
+          return x.slice(0, -1)
+        } else return x
       }
-      return val
+      if (typeof val === 'string') {
+        return removePeriod(val)
+      }
+      if (Array.isArray(val)) {
+        return val.map(removePeriod)
+      }
     },
     operator: 'match',
     field: ['subjectLiteral_exploded'],

--- a/lib/elasticsearch/config.js
+++ b/lib/elasticsearch/config.js
@@ -76,7 +76,25 @@ const SEARCH_SCOPES = {
 const FILTER_CONFIG = {
   recordType: { operator: 'match', field: ['recordTypeId'], repeatable: true },
   owner: { operator: 'match', field: ['items.owner.id', 'items.owner.label'], repeatable: true, path: 'items' },
-  subjectLiteral: { operator: 'match', field: ['subjectLiteral_exploded'], repeatable: true },
+  subjectLiteral: {
+    transform: (val, logger) => {
+      if (typeof val === 'string' && val.slice(-1) === '.') {
+        val = val.slice(0, -1)
+        logger.debug('Removing terminal period', JSON.stringify(val, null, 4))
+      } else if (Array.isArray(val)) {
+        val.forEach((sub, i) => {
+          if (sub.slice(-1) === '.') {
+            val[i] = sub.slice(0, -1)
+            logger.debug('Removing terminal period', JSON.stringify(sub, null, 4))
+          }
+        })
+      }
+      return val
+    },
+    operator: 'match',
+    field: ['subjectLiteral_exploded'],
+    repeatable: true
+  },
   holdingLocation: { operator: 'match', field: ['items.holdingLocation.id', 'items.holdingLocation.label'], repeatable: true, path: 'items' },
   buildingLocation: { operator: 'match', field: ['buildingLocationIds'], repeatable: true },
   language: { operator: 'match', field: ['language.id', 'language.label'], repeatable: true },

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,13 @@
 const logger = require('./logger')
 const { isItemNyplOwned } = require('./ownership_determination')
 
+exports.removeTrailingPeriod = (x, logger) => {
+  if (x.slice(-1) === '.') {
+    logger.debug('Removing terminal period', JSON.stringify(x, null, 4))
+    return x.slice(0, -1)
+  } else return x
+}
+
 exports.sortOnPropWithUndefinedLast = (property) => {
   return function (a, b) {
     // equal items sort equally

--- a/lib/util.js
+++ b/lib/util.js
@@ -120,9 +120,8 @@ exports.parseParams = function (params, spec) {
 //   `fields`: Hash - When `type` is 'hash', this property provides field spec to validate internal fields against
 //   `repeatable`: Boolean - If true, array of values may be returned. Otherwise will select last. Default false
 exports.parseParam = function (val, spec) {
-  // TODO: In the case that other fields require a transformation, this should be generalized to look through spec and apply any transformations to relevant values.
-  if (spec?.fields?.subjectLiteral) {
-    val.subjectLiteral = spec.fields.subjectLiteral.transform(val.subjectLiteral, logger)
+  if (spec.transform) {
+    val = spec.transform(val, logger)
   }
 
   // Unless it's marked repeatable, convert arrays of values to just last value:

--- a/lib/util.js
+++ b/lib/util.js
@@ -120,9 +120,7 @@ exports.parseParams = function (params, spec) {
 //   `fields`: Hash - When `type` is 'hash', this property provides field spec to validate internal fields against
 //   `repeatable`: Boolean - If true, array of values may be returned. Otherwise will select last. Default false
 exports.parseParam = function (val, spec) {
-  if (spec.fields &&
-    spec.fields.subjectLiteral &&
-    spec.fields.subjectLiteral.field === 'subjectLiteral_exploded' &&
+  if (spec.fields?.subjectLiteral?.field?.[0] === 'subjectLiteral_exploded' &&
     val.subjectLiteral
   ) {
     if (typeof val.subjectLiteral === 'string' && val.subjectLiteral.slice(-1) === '.') {

--- a/lib/util.js
+++ b/lib/util.js
@@ -120,20 +120,9 @@ exports.parseParams = function (params, spec) {
 //   `fields`: Hash - When `type` is 'hash', this property provides field spec to validate internal fields against
 //   `repeatable`: Boolean - If true, array of values may be returned. Otherwise will select last. Default false
 exports.parseParam = function (val, spec) {
-  if (spec.fields?.subjectLiteral?.field?.[0] === 'subjectLiteral_exploded' &&
-    val.subjectLiteral
-  ) {
-    if (typeof val.subjectLiteral === 'string' && val.subjectLiteral.slice(-1) === '.') {
-      val.subjectLiteral = val.subjectLiteral.slice(0, -1)
-      logger.debug('Removing terminal period', JSON.stringify(val, null, 4))
-    } else if (Array.isArray(val.subjectLiteral)) {
-      val.subjectLiteral.forEach((sub, i) => {
-        if (sub.slice(-1) === '.') {
-          val.subjectLiteral[i] = sub.slice(0, -1)
-          logger.debug('Removing terminal period', JSON.stringify(sub, null, 4))
-        }
-      })
-    }
+  // TODO: In the case that other fields require a transformation, this should be generalized to look through spec and apply any transformations to relevant values.
+  if (spec?.fields?.subjectLiteral) {
+    val.subjectLiteral = spec.fields.subjectLiteral.transform(val.subjectLiteral, logger)
   }
 
   // Unless it's marked repeatable, convert arrays of values to just last value:

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -65,19 +65,14 @@ describe('Util', function () {
         filters: {
           subjectLiteral: 'cats',
           contributorLiteral: ['Contrib 1', 'Contrib 2'],
-          date: '2012',
+          dateAfter: '2012',
           badNumeric: 'blah'
         }
       }
       const spec = {
         filters: {
           type: 'hash',
-          fields: {
-            subjectLiteral: { type: 'string' },
-            contributorLiteral: { type: 'string' },
-            date: { type: 'int' },
-            badNumeric: { type: 'int' }
-          }
+          fields: { ...FILTER_CONFIG, badNumeric: { type: 'int' } }
         }
       }
       const outgoing = util.parseParams(incoming, spec)
@@ -88,8 +83,8 @@ describe('Util', function () {
       expect(outgoing.filters.subjectLiteral).to.be.a('string')
       expect(outgoing.filters.subjectLiteral).to.equal('cats')
 
-      expect(outgoing.filters.date).to.be.a('number')
-      expect(outgoing.filters.date).to.equal(2012)
+      expect(outgoing.filters.dateAfter).to.be.a('number')
+      expect(outgoing.filters.dateAfter).to.equal(2012)
 
       expect(outgoing.filters.badNumeric).to.be.a('undefined')
     })

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai')
 const mangledEnumerationChronologyItems = require('./fixtures/mangled_enumerationChronology_items.json')
 
 const util = require('../lib/util')
+const { FILTER_CONFIG } = require('../lib/elasticsearch/config')
 
 describe('Util', function () {
   describe('sortOnPropWithUndefinedLast', () => {
@@ -131,15 +132,7 @@ describe('Util', function () {
     }
 
     const spec = {
-      filters: {
-        type: 'hash',
-        fields: {
-          subjectLiteral: {
-            type: 'string',
-            field: 'subjectLiteral_exploded'
-          }
-        }
-      }
+      filters: { type: 'hash', fields: FILTER_CONFIG }
     }
 
     const outgoing = util.parseParams(incoming, spec)
@@ -154,16 +147,7 @@ describe('Util', function () {
     }
 
     const spec = {
-      filters: {
-        type: 'hash',
-        fields: {
-          subjectLiteral: {
-            type: 'string',
-            field: 'subjectLiteral_exploded',
-            repeatable: true
-          }
-        }
-      }
+      filters: { type: 'hash', fields: FILTER_CONFIG }
     }
 
     const outgoing = util.parseParams(incoming, spec)


### PR DESCRIPTION
I updated the filter_config structure, but tests were building their own config, so did not break on update. The trailing periods were not being removed, so subject literal filters were not returning properly. 