### PR TITLE
[SCC-4425] Trim whitespace on call number search

### DIFF
--- a/lib/elasticsearch/elastic-query-builder.js
+++ b/lib/elasticsearch/elastic-query-builder.js
@@ -255,7 +255,7 @@ class ElasticQueryBuilder {
   * Require strong match on queried callnumber
   **/
   requireCallnumberMatch () {
-    const q = this.request.querySansQuotes()
+    const q = this.request.querySansQuotes().trim()
 
     this.query.addMust({
       bool: {

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -218,7 +218,8 @@ describe('ElasticQueryBuilder', () => {
 
   describe('search_scope callnumber', () => {
     it('generates a "callnumber" query', () => {
-      const request = new ApiRequest({ q: 'toast', search_scope: 'callnumber' })
+      // including leading and trailing whitespace to validate that query is trimmed
+      const request = new ApiRequest({ q: ' toast   ', search_scope: 'callnumber' })
       const inst = ElasticQueryBuilder.forApiRequest(request)
 
       // Expect multiple term/prefix matches on identifier fields:


### PR DESCRIPTION
Keeping things light for my first PR- let me know if there's some part of the process that I'm missing or doing incorrectly!

#### Ticket
https://newyorkpubliclibrary.atlassian.net/browse/SCC-4425

#### Testing
Tested in my local server. Before, querying by call number with a leading space (i.e. [like so](http://localhost:8082/api/v0.1/discovery/resources?q=%22%20JFE%2086-3252%22&search_scope=callnumber)) would return 0 results. After adding this `trim()` any leading / trailing whitespace is ignored and we get results.