### PR TITLE
Scc 3874

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ build
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+
+config/local*

--- a/lib/api-request.js
+++ b/lib/api-request.js
@@ -8,7 +8,7 @@ const QUOTE_CHARS = '"\u201C\u201D\u201E\u201F\u2033\u2036'
 const IN_QUOTES_PATTERN = new RegExp(`^[${QUOTE_CHARS}][^${QUOTE_CHARS}]+[${QUOTE_CHARS}]$`)
 
 class ApiRequest {
-  static ADVANCED_SEARCH_PARAMS = ['title', 'subject', 'contributor', 'callnumber', 'standard_number']
+  static ADVANCED_SEARCH_PARAMS = ['title', 'subject', 'subject_prefix', 'contributor', 'callnumber', 'standard_number']
   static IDENTIFIER_NUMBER_PARAMS = ['isbn', 'issn', 'lccn', 'oclc']
 
   constructor (params) {

--- a/lib/api-request.js
+++ b/lib/api-request.js
@@ -8,7 +8,7 @@ const QUOTE_CHARS = '"\u201C\u201D\u201E\u201F\u2033\u2036'
 const IN_QUOTES_PATTERN = new RegExp(`^[${QUOTE_CHARS}][^${QUOTE_CHARS}]+[${QUOTE_CHARS}]$`)
 
 class ApiRequest {
-  static ADVANCED_SEARCH_PARAMS = ['title', 'subject', 'subject_prefix', 'contributor', 'callnumber', 'standard_number']
+  static ADVANCED_SEARCH_PARAMS = ['title', 'subject', 'contributor', 'callnumber', 'standard_number']
   static IDENTIFIER_NUMBER_PARAMS = ['isbn', 'issn', 'lccn', 'oclc']
 
   constructor (params) {
@@ -67,6 +67,10 @@ class ApiRequest {
   hasIdentifierNumberParam () {
     return Object.keys(this.params)
       .some((userParam) => ApiRequest.IDENTIFIER_NUMBER_PARAMS.includes(userParam))
+  }
+
+  hasSubjectPrefix () {
+    return this.params.subject_prefix
   }
 
   static fromParams (params) {

--- a/lib/elasticsearch/config.js
+++ b/lib/elasticsearch/config.js
@@ -61,6 +61,9 @@ const SEARCH_SCOPES = {
   subject: {
     fields: ['subjectLiteral^2', 'subjectLiteral.folded', 'parallelSubjectLiteral.folded']
   },
+  subject_prefix: {
+    fields: ['subjectLiteral.raw']
+  },
   series: {
     fields: ['seriesStatement.folded']
   },

--- a/lib/elasticsearch/config.js
+++ b/lib/elasticsearch/config.js
@@ -61,9 +61,6 @@ const SEARCH_SCOPES = {
   subject: {
     fields: ['subjectLiteral^2', 'subjectLiteral.folded', 'parallelSubjectLiteral.folded']
   },
-  subject_prefix: {
-    fields: ['subjectLiteral.raw']
-  },
   series: {
     fields: ['seriesStatement.folded']
   },

--- a/lib/elasticsearch/elastic-query-builder.js
+++ b/lib/elasticsearch/elastic-query-builder.js
@@ -351,9 +351,7 @@ class ElasticQueryBuilder {
   boostSubjectMatches () {
     const q = this.request.params.subject_prefix
     this.query.addShoulds([
-      termMatch('subjectLiteral.raw', q, 50)
-    ])
-    this.query.addShoulds([
+      termMatch('subjectLiteral.raw', q, 50),
       termMatch('parallelSubjectLiteral.raw', q, 50)
     ])
   }

--- a/lib/elasticsearch/elastic-query-builder.js
+++ b/lib/elasticsearch/elastic-query-builder.js
@@ -30,6 +30,9 @@ class ElasticQueryBuilder {
       case 'subject':
         this.buildSubjectQuery()
         break
+      case 'subject_prefix':
+        this.buildSubjectPrefixQuery()
+        break
       case 'standard_number':
         this.buildStandardNumberQuery()
         break
@@ -56,6 +59,7 @@ class ElasticQueryBuilder {
   * identifier searches like those coming from Worldcat
   */
   buildAllQuery () {
+    console.log('buildAllQuery: ', this.request);
     // Require a basic multi-match when keyword used:
     if (this.request.params.q) {
       this.requireMultiMatch(SEARCH_SCOPES.all.fields)
@@ -154,6 +158,13 @@ class ElasticQueryBuilder {
     this.boostPopular()
 
     // TODO: Boost on subjectLiteral prefix and term matching
+  }
+
+  buildSubjectPrefixQuery () {
+    console.log('prefix request: ', this.request);
+    if (!this.request.hasSearch()) return
+    const q = this.request.querySansQuotes()
+    this.query.addMust(prefixMatch('subjectLiteral.raw', q))
   }
 
   /**
@@ -467,6 +478,7 @@ class ElasticQueryBuilder {
     // We're specifically interested in params that match supported search-
     // scopes because we can build a whole ES query just using the existing
     // logic for that search scope:
+    console.log('advancedSearchParamsThatAreAlsoScopes: ', this.request.advancedSearchParamsThatAreAlsoScopes())
     if (this.request.advancedSearchParamsThatAreAlsoScopes()) {
       this.request
         .advancedSearchParamsThatAreAlsoScopes()

--- a/lib/elasticsearch/elastic-query-builder.js
+++ b/lib/elasticsearch/elastic-query-builder.js
@@ -30,9 +30,6 @@ class ElasticQueryBuilder {
       case 'subject':
         this.buildSubjectQuery()
         break
-      case 'subject_prefix':
-        this.buildSubjectPrefixQuery()
-        break
       case 'standard_number':
         this.buildStandardNumberQuery()
         break
@@ -90,6 +87,10 @@ class ElasticQueryBuilder {
     // add those clauses:
     if (this.request.hasIdentifierNumberParam()) {
       this.requireSpecificIdentifierMatch()
+    }
+
+    if (this.request.hasSubjectPrefix()) {
+      this.applySubjectPrefix()
     }
   }
 
@@ -159,9 +160,8 @@ class ElasticQueryBuilder {
     // TODO: Boost on subjectLiteral prefix and term matching
   }
 
-  buildSubjectPrefixQuery () {
-    if (!this.request.hasSearch()) return
-    const q = this.request.querySansQuotes()
+  applySubjectPrefix () {
+    const q = this.request.params.subject_prefix
     this.query.addMust({
       bool: {
         should: [
@@ -349,7 +349,7 @@ class ElasticQueryBuilder {
   * Boost bibs with strong subjectLiteral matches
   **/
   boostSubjectMatches () {
-    const q = this.request.querySansQuotes()
+    const q = this.request.params.subject_prefix
     this.query.addShoulds([
       termMatch('subjectLiteral.raw', q, 50)
     ])

--- a/lib/elasticsearch/elastic-query-builder.js
+++ b/lib/elasticsearch/elastic-query-builder.js
@@ -353,6 +353,9 @@ class ElasticQueryBuilder {
     this.query.addShoulds([
       termMatch('subjectLiteral.raw', q, 50)
     ])
+    this.query.addShoulds([
+      termMatch('parallelSubjectLiteral.raw', q, 50)
+    ])
   }
 
   /**

--- a/lib/elasticsearch/elastic-query-builder.js
+++ b/lib/elasticsearch/elastic-query-builder.js
@@ -59,7 +59,6 @@ class ElasticQueryBuilder {
   * identifier searches like those coming from Worldcat
   */
   buildAllQuery () {
-    console.log('buildAllQuery: ', this.request);
     // Require a basic multi-match when keyword used:
     if (this.request.params.q) {
       this.requireMultiMatch(SEARCH_SCOPES.all.fields)
@@ -161,10 +160,17 @@ class ElasticQueryBuilder {
   }
 
   buildSubjectPrefixQuery () {
-    console.log('prefix request: ', this.request);
     if (!this.request.hasSearch()) return
     const q = this.request.querySansQuotes()
-    this.query.addMust(prefixMatch('subjectLiteral.raw', q))
+    this.query.addMust({
+      bool: {
+        should: [
+          prefixMatch('subjectLiteral.raw', q),
+          prefixMatch('parallelSubjectLiteral.raw', q)
+        ]
+      }
+    })
+    this.boostSubjectMatches()
   }
 
   /**
@@ -336,6 +342,16 @@ class ElasticQueryBuilder {
       termMatch('title.keywordLowercasedStripped', q, 105),
       termMatch('title.keywordLowercased', q, 110),
       termMatch('title.keyword', q, 150)
+    ])
+  }
+
+  /**
+  * Boost bibs with strong subjectLiteral matches
+  **/
+  boostSubjectMatches () {
+    const q = this.request.querySansQuotes()
+    this.query.addShoulds([
+      termMatch('subjectLiteral.raw', q, 50)
     ])
   }
 

--- a/lib/elasticsearch/elastic-query-builder.js
+++ b/lib/elasticsearch/elastic-query-builder.js
@@ -494,7 +494,6 @@ class ElasticQueryBuilder {
     // We're specifically interested in params that match supported search-
     // scopes because we can build a whole ES query just using the existing
     // logic for that search scope:
-    console.log('advancedSearchParamsThatAreAlsoScopes: ', this.request.advancedSearchParamsThatAreAlsoScopes())
     if (this.request.advancedSearchParamsThatAreAlsoScopes()) {
       this.request
         .advancedSearchParamsThatAreAlsoScopes()

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -621,10 +621,10 @@ module.exports = function (app, _private = null) {
 
   // Conduct a search across resources:
   app.resources.search = function (params, opts, request) {
-    app.logger.debug("Unparsed params: ", params);
+    app.logger.debug('Unparsed params: ', params)
     params = parseSearchParams(params)
 
-    app.logger.debug("Parsed params: ", params)
+    app.logger.debug('Parsed params: ', params)
 
     let body = buildElasticBody(params)
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -93,6 +93,7 @@ const parseSearchParams = function (params) {
     contributor: { type: 'string' },
     title: { type: 'string' },
     subject: { type: 'string' },
+    subject_prefix: { type: 'string' },
     isbn: { type: 'string' },
     issn: { type: 'string' },
     lccn: { type: 'string' },
@@ -620,7 +621,10 @@ module.exports = function (app, _private = null) {
 
   // Conduct a search across resources:
   app.resources.search = function (params, opts, request) {
+    app.logger.debug("Unparsed params: ", params);
     params = parseSearchParams(params)
+
+    app.logger.debug("Parsed params: ", params)
 
     let body = buildElasticBody(params)
 

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -373,6 +373,14 @@ describe('ElasticQueryBuilder', () => {
             }
           }
         })
+        expect(query.bool.should[1]).to.deep.equal({
+          term: {
+            'parallelSubjectLiteral.raw': {
+              value: 'toast',
+              boost: 50
+            }
+          }
+        })
       })
     })
 

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -347,9 +347,9 @@ describe('ElasticQueryBuilder', () => {
 
         const query = inst.query.toJson()
 
-        expect(query.bool.must[0].bool.must[0].bool.should.length).to.equal(2)
-        expect(query.bool.must[0].bool.must[0].bool.should[0])
-        expect(query.bool.must[0].bool.must[0].bool.should[0]).to.deep.equal({
+        expect(query.bool.must[0].bool.should.length).to.equal(2)
+        expect(query.bool.must[0].bool.should[0])
+        expect(query.bool.must[0].bool.should[0]).to.deep.equal({
           prefix: {
             'subjectLiteral.raw': {
               value: 'toast',
@@ -357,7 +357,7 @@ describe('ElasticQueryBuilder', () => {
             }
           }
         })
-        expect(query.bool.must[0].bool.must[0].bool.should[1]).to.deep.equal({
+        expect(query.bool.must[0].bool.should[1]).to.deep.equal({
           prefix: {
             'parallelSubjectLiteral.raw': {
               value: 'toast',
@@ -365,7 +365,7 @@ describe('ElasticQueryBuilder', () => {
             }
           }
         })
-        expect(query.bool.must[0].bool.should[0]).to.deep.equal({
+        expect(query.bool.should[0]).to.deep.equal({
           term: {
             'subjectLiteral.raw': {
               value: 'toast',

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -340,6 +340,42 @@ describe('ElasticQueryBuilder', () => {
       })
     })
 
+    describe('subject_prefix=', () => {
+      it('applies subject_prefix clauses to query', () => {
+        const request = new ApiRequest({ subject_prefix: 'toast' })
+        const inst = ElasticQueryBuilder.forApiRequest(request)
+
+        const query = inst.query.toJson()
+
+        expect(query.bool.must[0].bool.must[0].bool.should.length).to.equal(2)
+        expect(query.bool.must[0].bool.must[0].bool.should[0])
+        expect(query.bool.must[0].bool.must[0].bool.should[0]).to.deep.equal({
+          prefix: {
+            'subjectLiteral.raw': {
+              value: 'toast',
+              boost: 1
+            }
+          }
+        })
+        expect(query.bool.must[0].bool.must[0].bool.should[1]).to.deep.equal({
+          prefix: {
+            'parallelSubjectLiteral.raw': {
+              value: 'toast',
+              boost: 1
+            }
+          }
+        })
+        expect(query.bool.must[0].bool.should[0]).to.deep.equal({
+          term: {
+            'subjectLiteral.raw': {
+              value: 'toast',
+              boost: 50
+            }
+          }
+        })
+      })
+    })
+
     describe('multiple adv search params', () => {
       it('applies multiple param clauses to query', () => {
         const request = new ApiRequest({


### PR DESCRIPTION
Adds support for a new `subject_prefix` search parameter for [SCC-3874](https://newyorkpubliclibrary.atlassian.net/jira/software/c/projects/SCC/boards/126?assignee=5b23d57c1d2d6643d2c85618&selectedIssue=SCC-3874)
The approach taken parallels the existing implementation of the `subject` param.
Specific Changes:
- Adds `subject_prefix` in `ADVANCED_SEARCH_PARAMS` and `SEARCH_SCOPES` for param extraction
- Adds `subject_prefix` as a new case in building the `ElasticQueryBuilder` query
- Currently adds some boosting for exact matches on `subjectLiteral.raw` in this case. The current boost is `50`, could change that value
- Adds a new test for this case
Also:
- a small unrelated addition to `.gitignore` for local files

[SCC-3874]: https://newyorkpubliclibrary.atlassian.net/browse/SCC-3874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ