### PR TITLE
Scc 4549/phys override spec

### DIFF
--- a/lib/requestability_resolver.js
+++ b/lib/requestability_resolver.js
@@ -10,21 +10,7 @@ class RequestabilityResolver {
         const parentBibHasFindingAid = !!hit._source.supplementaryContent?.find((el) => el.label.toLowerCase() === 'finding aid')
         hit._source.items = hit._source.items.map((item) => {
           if (item.electronicLocator) return item
-          let deliveryInfo
-          const itemIsInRecap = isInRecap(item)
-          let physRequestableCriteria
-          const hasRecapCustomerCode = item.recapCustomerCode?.[0]
-          if (itemIsInRecap) {
-            // recap items missing codes should default to true for phys and edd
-            // requestable, unless it has a non-requestable holding location
-            deliveryInfo = DeliveryLocationsResolver.getRecapDeliveryInfo(item)
-            physRequestableCriteria = hasRecapCustomerCode
-              ? `${(deliveryInfo.deliveryLocation?.length) || 0} delivery locations.`
-              : 'Missing customer code'
-          } else if (!itemIsInRecap) {
-            deliveryInfo = DeliveryLocationsResolver.getOnsiteDeliveryInfo(item)
-            physRequestableCriteria = `${(deliveryInfo.deliveryLocation?.length) || 0} delivery locations.`
-          }
+          let { deliveryInfo, physRequestableCriteria } = this.buildPhysRequestable(item)
           item.specRequestable = this.buildSpecRequestable(item, parentBibHasFindingAid)
           item.physRequestable = !!deliveryInfo.deliveryLocation?.length
           item.eddRequestable = !!deliveryInfo.eddRequestable && !item.specRequestable
@@ -44,6 +30,25 @@ class RequestabilityResolver {
         })
       })
     return elasticSearchResponse
+  }
+
+  static buildPhysRequestable (item) {
+    let deliveryInfo
+    let physRequestableCriteria
+    const itemIsInRecap = isInRecap(item)
+    const hasRecapCustomerCode = item.recapCustomerCode?.[0]
+    if (itemIsInRecap) {
+      // recap items missing codes should default to true for phys and edd
+      // requestable, unless it has a non-requestable holding location
+      deliveryInfo = DeliveryLocationsResolver.getRecapDeliveryInfo(item)
+      physRequestableCriteria = hasRecapCustomerCode
+        ? `${(deliveryInfo.deliveryLocation?.length) || 0} delivery locations.`
+        : 'Missing customer code'
+    } else if (!itemIsInRecap) {
+      deliveryInfo = DeliveryLocationsResolver.getOnsiteDeliveryInfo(item)
+      physRequestableCriteria = `${(deliveryInfo.deliveryLocation?.length) || 0} delivery locations.`
+    }
+    return { deliveryInfo, physRequestableCriteria }
   }
 
   static buildSpecRequestable (item, parentBibHasFindingAid) {

--- a/lib/requestability_resolver.js
+++ b/lib/requestability_resolver.js
@@ -7,7 +7,6 @@ class RequestabilityResolver {
   static fixItemRequestability (elasticSearchResponse) {
     elasticSearchResponse.hits.hits
       .forEach((hit) => {
-        const parentBibHasFindingAid = !!hit._source.supplementaryContent?.find((el) => el.label.toLowerCase() === 'finding aid')
         hit._source.items = hit._source.items.map((item) => {
           if (item.electronicLocator) return item
           const itemIsInRecap = isInRecap(item)
@@ -15,7 +14,7 @@ class RequestabilityResolver {
             ? DeliveryLocationsResolver.getRecapDeliveryInfo(item)
             : DeliveryLocationsResolver.getOnsiteDeliveryInfo(item)
           const numDeliveryLocations = deliveryInfo.deliveryLocation?.length
-          item.specRequestable = this.buildSpecRequestable(item, parentBibHasFindingAid)
+          item.specRequestable = this.buildSpecRequestable(item)
           item.physRequestable = this.buildPhysRequestable(item, numDeliveryLocations)
           item.eddRequestable = !!deliveryInfo.eddRequestable && !item.specRequestable
           item.requestable = [item.eddRequestable || item.physRequestable || item.specRequestable]
@@ -55,11 +54,11 @@ class RequestabilityResolver {
     return physRequestable
   }
 
-  static buildSpecRequestable (item, parentBibHasFindingAid) {
+  static buildSpecRequestable (item) {
     const holdingLocation = DeliveryLocationsResolver.extractLocationCode(item)
     const nyplCoreLocation = DeliveryLocationsResolver.nyplCoreLocation(holdingLocation)
     const isSpecialCollectionsOnlyAccessType = !!(nyplCoreLocation?.collectionAccessType === 'special')
-    return !!item.aeonUrl || parentBibHasFindingAid || isSpecialCollectionsOnlyAccessType
+    return !!item.aeonUrl || isSpecialCollectionsOnlyAccessType
   }
 }
 

--- a/lib/requestability_resolver.js
+++ b/lib/requestability_resolver.js
@@ -14,9 +14,9 @@ class RequestabilityResolver {
           const deliveryInfo = itemIsInRecap
             ? DeliveryLocationsResolver.getRecapDeliveryInfo(item)
             : DeliveryLocationsResolver.getOnsiteDeliveryInfo(item)
-
+          const numDeliveryLocations = deliveryInfo.deliveryLocation?.length
           item.specRequestable = this.buildSpecRequestable(item, parentBibHasFindingAid)
-          item.physRequestable = this.buildPhysRequestable(item, deliveryInfo)
+          item.physRequestable = this.buildPhysRequestable(item, numDeliveryLocations)
           item.eddRequestable = !!deliveryInfo.eddRequestable && !item.specRequestable
           item.requestable = [item.eddRequestable || item.physRequestable || item.specRequestable]
           return item
@@ -25,16 +25,26 @@ class RequestabilityResolver {
     return elasticSearchResponse
   }
 
-  static buildPhysRequestable (item, deliveryInfo) {
+  static buildPhysRequestable (item, numDeliveryLocations) {
     let physRequestableCriteria
     let physRequestable
     const hasRecapCustomerCode = item.recapCustomerCode?.[0]
     const itemIsInRecapMissingRecapCustomerCode = isInRecap(item) && !hasRecapCustomerCode
     // recap items missing codes should default to true for phys and edd
     // requestable, unless it has a non-requestable holding location
-    if (itemIsInRecapMissingRecapCustomerCode) physRequestableCriteria = 'Missing customer code'
-    if (deliveryInfo.deliveryLocation?.length > 0) physRequestableCriteria = `${(deliveryInfo.deliveryLocation?.length) || 0} delivery locations.`
-    physRequestable = itemIsInRecapMissingRecapCustomerCode || !!deliveryInfo.deliveryLocation?.length
+    if (itemIsInRecapMissingRecapCustomerCode) {
+      physRequestable = true
+      physRequestableCriteria = 'Missing customer code'
+    }
+    if (numDeliveryLocations > 0) {
+      physRequestableCriteria = `${numDeliveryLocations} delivery locations.`
+      physRequestable = true
+    }
+    if (!numDeliveryLocations) {
+      physRequestableCriteria = 'No delivery locations.'
+      physRequestable = false
+    }
+    // physRequestable = itemIsInRecapMissingRecapCustomerCode || !!deliveryInfo.deliveryLocation?.length
     // items without barcodes should not be requestable
     const hasBarcode = (item.identifier || []).some((identifier) => /^(urn|bf):[bB]arcode:\w+/.test(identifier))
     if (isItemNyplOwned(item) && !hasBarcode) {

--- a/lib/requestability_resolver.js
+++ b/lib/requestability_resolver.js
@@ -10,21 +10,14 @@ class RequestabilityResolver {
         const parentBibHasFindingAid = !!hit._source.supplementaryContent?.find((el) => el.label.toLowerCase() === 'finding aid')
         hit._source.items = hit._source.items.map((item) => {
           if (item.electronicLocator) return item
-          let { deliveryInfo, physRequestableCriteria } = this.buildPhysRequestable(item)
+          const itemIsInRecap = isInRecap(item)
+          const deliveryInfo = itemIsInRecap
+            ? DeliveryLocationsResolver.getRecapDeliveryInfo(item)
+            : DeliveryLocationsResolver.getOnsiteDeliveryInfo(item)
+
           item.specRequestable = this.buildSpecRequestable(item, parentBibHasFindingAid)
-          item.physRequestable = !!deliveryInfo.deliveryLocation?.length
+          item.physRequestable = this.buildPhysRequestable(item, deliveryInfo)
           item.eddRequestable = !!deliveryInfo.eddRequestable && !item.specRequestable
-          // items without barcodes should not be requestable
-          const hasBarcode = (item.identifier || []).some((identifier) => /^(urn|bf):[bB]arcode:\w+/.test(identifier))
-          if (isItemNyplOwned(item) && !hasBarcode) {
-            physRequestableCriteria = 'NYPL item missing barcode'
-            item.physRequestable = false
-          }
-          if (item.specRequestable && item.physRequestable) {
-            item.physRequestable = false
-            physRequestableCriteria = 'specRequestable overrides physRequestable location'
-          }
-          logger.debug(`item ${item.uri}: `, { physRequestable: item.physRequestable, physRequestableCriteria })
           item.requestable = [item.eddRequestable || item.physRequestable || item.specRequestable]
           return item
         })
@@ -32,23 +25,25 @@ class RequestabilityResolver {
     return elasticSearchResponse
   }
 
-  static buildPhysRequestable (item) {
-    let deliveryInfo
+  static buildPhysRequestable (item, deliveryInfo) {
     let physRequestableCriteria
-    const itemIsInRecap = isInRecap(item)
+    let physRequestable
     const hasRecapCustomerCode = item.recapCustomerCode?.[0]
-    if (itemIsInRecap) {
-      // recap items missing codes should default to true for phys and edd
-      // requestable, unless it has a non-requestable holding location
-      deliveryInfo = DeliveryLocationsResolver.getRecapDeliveryInfo(item)
-      physRequestableCriteria = hasRecapCustomerCode
-        ? `${(deliveryInfo.deliveryLocation?.length) || 0} delivery locations.`
-        : 'Missing customer code'
-    } else if (!itemIsInRecap) {
-      deliveryInfo = DeliveryLocationsResolver.getOnsiteDeliveryInfo(item)
-      physRequestableCriteria = `${(deliveryInfo.deliveryLocation?.length) || 0} delivery locations.`
+    const itemIsInRecapMissingRecapCustomerCode = isInRecap(item) && !hasRecapCustomerCode
+    // recap items missing codes should default to true for phys and edd
+    // requestable, unless it has a non-requestable holding location
+    if (itemIsInRecapMissingRecapCustomerCode) physRequestableCriteria = 'Missing customer code'
+    if (deliveryInfo.deliveryLocation?.length > 0) physRequestableCriteria = `${(deliveryInfo.deliveryLocation?.length) || 0} delivery locations.`
+    physRequestable = itemIsInRecapMissingRecapCustomerCode || !!deliveryInfo.deliveryLocation?.length
+    // items without barcodes should not be requestable
+    const hasBarcode = (item.identifier || []).some((identifier) => /^(urn|bf):[bB]arcode:\w+/.test(identifier))
+    if (isItemNyplOwned(item) && !hasBarcode) {
+      physRequestableCriteria = 'NYPL item missing barcode'
+      physRequestable = false
     }
-    return { deliveryInfo, physRequestableCriteria }
+    logger.debug(`item ${item.uri}: `, { physRequestable: item.physRequestable, physRequestableCriteria })
+
+    return physRequestable
   }
 
   static buildSpecRequestable (item, parentBibHasFindingAid) {

--- a/lib/requestability_resolver.js
+++ b/lib/requestability_resolver.js
@@ -24,24 +24,28 @@ class RequestabilityResolver {
     return elasticSearchResponse
   }
 
-  static buildPhysRequestable (item, numDeliveryLocations) {
+  static buildPhysRequestable (item, numDeliveryLocations, requestableBasedOnHoldingLocation) {
     let physRequestableCriteria
     let physRequestable
     const hasRecapCustomerCode = item.recapCustomerCode?.[0]
     const itemIsInRecapMissingRecapCustomerCode = isInRecap(item) && !hasRecapCustomerCode
-    // recap items missing codes should default to true for phys and edd
-    // requestable, unless it has a non-requestable holding location
+    // The following cases are NOT mutually exclusive
     if (itemIsInRecapMissingRecapCustomerCode) {
+      // recap items missing codes should default to true for phys and edd
+      // requestable, unless it has a non-requestable holding location.
       physRequestable = true
       physRequestableCriteria = 'Missing customer code'
+    } else if (!DeliveryLocationsResolver.requestableBasedOnHoldingLocation(item)) {
+      physRequestableCriteria = 'Unrequestable holding location'
+      physRequestable = false
+    } else if (numDeliveryLocations === 0) {
+      physRequestableCriteria = 'No delivery locations.'
+      physRequestable = false
     }
+    // This case is mutually exclusive with the prior 3
     if (numDeliveryLocations > 0) {
       physRequestableCriteria = `${numDeliveryLocations} delivery locations.`
       physRequestable = true
-    }
-    if (!numDeliveryLocations) {
-      physRequestableCriteria = 'No delivery locations.'
-      physRequestable = false
     }
     // items without barcodes should not be requestable
     const hasBarcode = (item.identifier || []).some((identifier) => /^(urn|bf):[bB]arcode:\w+/.test(identifier))

--- a/lib/requestability_resolver.js
+++ b/lib/requestability_resolver.js
@@ -44,7 +44,6 @@ class RequestabilityResolver {
       physRequestableCriteria = 'No delivery locations.'
       physRequestable = false
     }
-    // physRequestable = itemIsInRecapMissingRecapCustomerCode || !!deliveryInfo.deliveryLocation?.length
     // items without barcodes should not be requestable
     const hasBarcode = (item.identifier || []).some((identifier) => /^(urn|bf):[bB]arcode:\w+/.test(identifier))
     if (isItemNyplOwned(item) && !hasBarcode) {

--- a/lib/requestability_resolver.js
+++ b/lib/requestability_resolver.js
@@ -24,38 +24,49 @@ class RequestabilityResolver {
     return elasticSearchResponse
   }
 
-  static buildPhysRequestable (item, numDeliveryLocations, requestableBasedOnHoldingLocation) {
+  static buildPhysRequestable (item, numDeliveryLocations) {
     let physRequestableCriteria
     let physRequestable
     const hasRecapCustomerCode = item.recapCustomerCode?.[0]
     const itemIsInRecapMissingRecapCustomerCode = isInRecap(item) && !hasRecapCustomerCode
-    // The following cases are NOT mutually exclusive
-    if (itemIsInRecapMissingRecapCustomerCode) {
-      // recap items missing codes should default to true for phys and edd
-      // requestable, unless it has a non-requestable holding location.
-      physRequestable = true
-      physRequestableCriteria = 'Missing customer code'
-    } else if (!DeliveryLocationsResolver.requestableBasedOnHoldingLocation(item)) {
-      physRequestableCriteria = 'Unrequestable holding location'
-      physRequestable = false
-    } else if (numDeliveryLocations === 0) {
-      physRequestableCriteria = 'No delivery locations.'
-      physRequestable = false
-    }
-    // This case is mutually exclusive with the prior 3
-    if (numDeliveryLocations > 0) {
-      physRequestableCriteria = `${numDeliveryLocations} delivery locations.`
-      physRequestable = true
-    }
     // items without barcodes should not be requestable
     const hasBarcode = (item.identifier || []).some((identifier) => /^(urn|bf):[bB]arcode:\w+/.test(identifier))
     if (isItemNyplOwned(item) && !hasBarcode) {
-      physRequestableCriteria = 'NYPL item missing barcode'
       physRequestable = false
+      physRequestableCriteria = 'NYPL item missing barcode'
+      this.logPhysRequestableInfo(physRequestable, physRequestableCriteria, item.uri)
+      return physRequestable
     }
-    logger.debug(`item ${item.uri}: `, { physRequestable: item.physRequestable, physRequestableCriteria })
+    if (isItemNyplOwned(item) && !DeliveryLocationsResolver.requestableBasedOnHoldingLocation(item)) {
+      physRequestableCriteria = 'Unrequestable holding location'
+      physRequestable = false
+      this.logPhysRequestableInfo(physRequestable, physRequestableCriteria, item.uri)
+      return physRequestable
+    }
+    if (itemIsInRecapMissingRecapCustomerCode) {
+      // recap items missing codes should default to true for phys and edd
+      // requestable, if it has a requestable holding location.
+      physRequestable = true
+      physRequestableCriteria = 'Missing customer code'
+      this.logPhysRequestableInfo(physRequestable, physRequestableCriteria, item.uri)
+      return physRequestable
+    }
+    if (numDeliveryLocations === 0) {
+      physRequestableCriteria = 'No delivery locations.'
+      physRequestable = false
+      this.logPhysRequestableInfo(physRequestable, physRequestableCriteria, item.uri)
+      return physRequestable
+    }
+    if (numDeliveryLocations > 0) {
+      physRequestableCriteria = `${numDeliveryLocations} delivery locations.`
+      physRequestable = true
+      this.logPhysRequestableInfo(physRequestable, physRequestableCriteria, item.uri)
+      return physRequestable
+    }
+  }
 
-    return physRequestable
+  static logPhysRequestableInfo (physRequestable, criteria, uri) {
+    logger.debug(`item ${uri}: ${{ physRequestable, criteria }}`)
   }
 
   static buildSpecRequestable (item) {

--- a/test/fixtures/no_recap_response.js
+++ b/test/fixtures/no_recap_response.js
@@ -305,7 +305,7 @@ exports.fakeElasticSearchResponseNyplItem = () => {
                 holdingLocation: [
                   {
                     label: 'OFFSITE - Request in Advance',
-                    id: 'loc:dya0f'
+                    id: 'loc:rcpt8'
                   }
                 ],
                 status_packed: [

--- a/test/requestability_resolver.test.js
+++ b/test/requestability_resolver.test.js
@@ -184,13 +184,6 @@ describe('RequestabilityResolver', () => {
       expect(specRequestableItem.specRequestable).to.equal(true)
     })
 
-    it('marks items as specRequestable when there is a finding aid on the parent bib', function () {
-      const response = RequestabilityResolver.fixItemRequestability(findingAidElasticSearchResponse())
-
-      const items = response.hits.hits[0]._source.items
-      expect(items.every((item) => item.specRequestable)).to.equal(true)
-    })
-
     it('leaves item as specRequestable false when there is no finding aid, aeon url, or special holding location', () => {
       const response = RequestabilityResolver.fixItemRequestability(elasticSearchResponse.fakeElasticSearchResponseNyplItem())
       const items = response.hits.hits[0]._source.items

--- a/test/requestability_resolver.test.js
+++ b/test/requestability_resolver.test.js
@@ -5,8 +5,6 @@ const eddElasticSearchResponse = require('./fixtures/edd_elastic_search_response
 const findingAidElasticSearchResponse = require('./fixtures/specRequestable/findingAid-es-response.js')
 const noBarcodeResponse = require('./fixtures/no_barcode_es_response')
 const noRecapResponse = require('./fixtures/no_recap_response')
-const physRequestableOverride = require('./fixtures/specRequestable/phys-requestable-override.js')
-const DeliveryLocationsResolver = require('../lib/delivery-locations-resolver.js')
 
 describe('RequestabilityResolver', () => {
   describe('fixItemRequestability', function () {
@@ -18,17 +16,6 @@ describe('RequestabilityResolver', () => {
       const noBarcode = noBarcodeResponse()
       const resp = RequestabilityResolver.fixItemRequestability(noBarcode)
       expect(resp.hits.hits[0]._source.items.every((item) => item.physRequestable === false)).to.equal(true)
-    })
-    it('specRequestable overrides physRequestable, when items have phys requestable holding location', () => {
-      const esResponseItems = physRequestableOverride.hits.hits[0]._source.items
-      const isPhysRequestable = (item) => !!item.deliveryLocation.length
-      const resp = RequestabilityResolver.fixItemRequestability(physRequestableOverride)
-      // verify that items are phys requestable based on location...
-      expect(esResponseItems
-        .map(DeliveryLocationsResolver.getOnsiteDeliveryInfo)
-        .every(isPhysRequestable)).to.equal(true)
-      // ...but overridden by specRequestability
-      expect(resp.hits.hits[0]._source.items.every((item) => !item.physRequestable && item.specRequestable)).to.equal(true)
     })
 
     it('will set requestable to false for an item not found in ReCAP', function () {

--- a/test/requestability_resolver.test.js
+++ b/test/requestability_resolver.test.js
@@ -2,7 +2,6 @@ const RequestabilityResolver = require('../lib/requestability_resolver')
 const elasticSearchResponse = require('./fixtures/elastic_search_response.js')
 const specRequestableElasticSearchResponse = require('./fixtures/specRequestable/specRequestable-es-response.js')
 const eddElasticSearchResponse = require('./fixtures/edd_elastic_search_response')
-const findingAidElasticSearchResponse = require('./fixtures/specRequestable/findingAid-es-response.js')
 const noBarcodeResponse = require('./fixtures/no_barcode_es_response')
 const noRecapResponse = require('./fixtures/no_recap_response')
 
@@ -228,16 +227,16 @@ describe('RequestabilityResolver', () => {
 
     it('marks edd and physical requestability correctly', function () {
       const items = resolved.hits.hits[0]._source.items
-      const firstItem = items.find((item) => {
+      const requestableLocationNoRecapCode = items.find((item) => {
         return item.uri === 'i102836649'
       })
-      const secondItem = items.find((item) => {
+      const nonRequestableLocationNoRecapCode = items.find((item) => {
         return item.uri === 'i102836659'
       })
-      expect(firstItem.physRequestable).to.equal(true)
-      expect(firstItem.eddRequestable).to.equal(true)
-      expect(secondItem.physRequestable).to.equal(false)
-      expect(secondItem.eddRequestable).to.equal(false)
+      expect(requestableLocationNoRecapCode.physRequestable).to.equal(true)
+      expect(requestableLocationNoRecapCode.eddRequestable).to.equal(true)
+      expect(nonRequestableLocationNoRecapCode.physRequestable).to.equal(false)
+      expect(nonRequestableLocationNoRecapCode.eddRequestable).to.equal(false)
     })
   })
 })


### PR DESCRIPTION
https://newyorkpubliclibrary.atlassian.net/browse/SCC-4549

- refactor physRequestable function to be extremely explicit about what determines physical requestability
- removes finding aid from spec requestability criteria
- removes specRequestable overriding physRequestable. Looking closer at our nypl-core data, I'm pretty sure this is not necessary at all. All but two special collections locations are actually listed as `requestable: false`. I do think these locations should be updated to false, but it doesn't affect this work, because they don't have any `deliverableTo` locations anyway. Similarly, I believe we should leave all the deliverableTo locations, but it doesn't actually impact this work. 
- update one fixture with extant customer code

This update should be QA'd pretty closely, looking at examples that:
- have deliverableTo and special collections locations
- have requestable:false, no delivery locations, and special collections access type
- are partner records mentioned in the ticket