### PR TITLE
put format in an array to match what front end expects

### DIFF
--- a/lib/jsonld_serializers.js
+++ b/lib/jsonld_serializers.js
@@ -289,10 +289,10 @@ class ResourceSerializer extends JsonLdItemSerializer {
 ResourceSerializer.getFormattedFormat = function (formatId) {
   const prefLabel = nyplCore.formats()[formatId]?.label
   if (!prefLabel) return null
-  return {
+  return [{
     '@id': formatId,
     prefLabel
-  }
+  }]
 }
 
 ResourceSerializer.formatElectronicResourceBlankNode = function (link, rdfsType) {

--- a/test/jsonld-serializers.test.js
+++ b/test/jsonld-serializers.test.js
@@ -77,10 +77,10 @@ describe('JSONLD Serializers', () => {
         const serialized = await ResourceSerializer.serialize({
           formatId: 'a'
         })
-        expect(serialized.format).to.deep.equal({
+        expect(serialized.format).to.deep.equal([{
           '@id': 'a',
           prefLabel: 'Book/Text'
-        })
+        }])
       })
 
       it('removes invalid format', async () => {

--- a/test/resource_serializer.test.js
+++ b/test/resource_serializer.test.js
@@ -4,7 +4,7 @@ const esResponse = require('./fixtures/item-filter-aggregations.json')
 describe('Resource Serializer', () => {
   describe('formatformat', () => {
     it('should format properly', () => {
-      expect(ResourceSerializer.getFormattedFormat('a')).to.deep.equal({ '@id': 'a', prefLabel: 'Book/Text' })
+      expect(ResourceSerializer.getFormattedFormat('a')).to.deep.equal([{ '@id': 'a', prefLabel: 'Book/Text' }])
     })
   })
   describe('.formatItemFilterAggregations()', () => {

--- a/test/resources-responses.test.js
+++ b/test/resources-responses.test.js
@@ -266,7 +266,7 @@ describe('Test Resources responses', function () {
 
         assert(doc.itemAggregations)
 
-        assert.deepEqual(doc.format, { '@id': 'a', prefLabel: 'Book/Text' })
+        assert.deepEqual(doc.format, [{ '@id': 'a', prefLabel: 'Book/Text' }])
 
         done()
       })


### PR DESCRIPTION
The front end is expecting format to be an object in an array. I assume we would like to continue that data structure? I personally feel that it is unnecessary but I do not feel strongly about it either way.