### PR TITLE
Scc 4725

### DIFF
--- a/lib/elasticsearch/elastic-query-builder.js
+++ b/lib/elasticsearch/elastic-query-builder.js
@@ -151,8 +151,7 @@ class ElasticQueryBuilder {
     this.boostNyplOwned()
     this.boostOnSite()
     this.boostPopular()
-
-    // TODO: Boost on subjectLiteral prefix and term matching
+    this.boostSubjectMatches(this.request.params.q)
   }
 
   applySubjectPrefix () {
@@ -343,8 +342,8 @@ class ElasticQueryBuilder {
   /**
   * Boost bibs with strong subjectLiteral matches
   **/
-  boostSubjectMatches () {
-    const q = this.request.params.subject_prefix
+  boostSubjectMatches (q = null) {
+    q = q || this.request.params.subject_prefix
     this.query.addShoulds([
       phraseMatch('subjectLiteral.raw', q, 50),
       phraseMatch('parallelSubjectLiteral.raw', q, 50),

--- a/lib/elasticsearch/elastic-query-builder.js
+++ b/lib/elasticsearch/elastic-query-builder.js
@@ -346,6 +346,10 @@ class ElasticQueryBuilder {
   boostSubjectMatches () {
     const q = this.request.params.subject_prefix
     this.query.addShoulds([
+      phraseMatch('subjectLiteral.raw', q, 25),
+      phraseMatch('parallelSubjectLiteral.raw', q, 25),
+      prefixMatch('subjectLiteral.raw', q, 50),
+      prefixMatch('parallelSubjectLiteral.raw', q, 50),
       termMatch('subjectLiteral.raw', q, 50),
       termMatch('parallelSubjectLiteral.raw', q, 50)
     ])

--- a/lib/elasticsearch/elastic-query-builder.js
+++ b/lib/elasticsearch/elastic-query-builder.js
@@ -151,7 +151,7 @@ class ElasticQueryBuilder {
     this.boostNyplOwned()
     this.boostOnSite()
     this.boostPopular()
-    this.boostSubjectMatches(this.request.params.q)
+    this.boostSubjectMatches()
   }
 
   applySubjectPrefix () {
@@ -164,7 +164,8 @@ class ElasticQueryBuilder {
         ]
       }
     })
-    this.boostSubjectMatches()
+    termMatch('subjectLiteral.raw', q, 50),
+    termMatch('parallelSubjectLiteral.raw', q, 50)
   }
 
   /**
@@ -342,8 +343,8 @@ class ElasticQueryBuilder {
   /**
   * Boost bibs with strong subjectLiteral matches
   **/
-  boostSubjectMatches (q = null) {
-    q = q || this.request.params.subject_prefix
+  boostSubjectMatches () {
+    q = this.request.querySansQuotes()
     this.query.addShoulds([
       phraseMatch('subjectLiteral.raw', q, 50),
       phraseMatch('parallelSubjectLiteral.raw', q, 50),

--- a/lib/elasticsearch/elastic-query-builder.js
+++ b/lib/elasticsearch/elastic-query-builder.js
@@ -346,8 +346,8 @@ class ElasticQueryBuilder {
   boostSubjectMatches () {
     const q = this.request.params.subject_prefix
     this.query.addShoulds([
-      phraseMatch('subjectLiteral.raw', q, 25),
-      phraseMatch('parallelSubjectLiteral.raw', q, 25),
+      phraseMatch('subjectLiteral.raw', q, 50),
+      phraseMatch('parallelSubjectLiteral.raw', q, 50),
       prefixMatch('subjectLiteral.raw', q, 50),
       prefixMatch('parallelSubjectLiteral.raw', q, 50),
       termMatch('subjectLiteral.raw', q, 50),

--- a/lib/elasticsearch/elastic-query-builder.js
+++ b/lib/elasticsearch/elastic-query-builder.js
@@ -164,8 +164,10 @@ class ElasticQueryBuilder {
         ]
       }
     })
-    termMatch('subjectLiteral.raw', q, 50),
-    termMatch('parallelSubjectLiteral.raw', q, 50)
+    this.query.addShoulds([
+      termMatch('subjectLiteral.raw', q, 50),
+      termMatch('parallelSubjectLiteral.raw', q, 50)
+    ])
   }
 
   /**
@@ -344,7 +346,7 @@ class ElasticQueryBuilder {
   * Boost bibs with strong subjectLiteral matches
   **/
   boostSubjectMatches () {
-    q = this.request.querySansQuotes()
+    const q = this.request.querySansQuotes()
     this.query.addShoulds([
       phraseMatch('subjectLiteral.raw', q, 50),
       phraseMatch('parallelSubjectLiteral.raw', q, 50),

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -193,9 +193,10 @@ describe('ElasticQueryBuilder', () => {
         .include({ 'bool.must[0].multi_match.fields[0]': 'subjectLiteral^2' })
 
       // Expect only common boosting clauses because RC doesn't use this search-scope at writing
+      console.log('should: ', JSON.stringify(inst.query.toJson().bool.should, null, 2))
       expect(inst.query.toJson().bool.should)
         .to.be.a('array')
-        .have.lengthOf(4)
+        .have.lengthOf(10)
     })
   })
 

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -347,8 +347,6 @@ describe('ElasticQueryBuilder', () => {
 
         const query = inst.query.toJson()
 
-        console.log('query: ', JSON.stringify(query, null, 2))
-
         expect(query.bool.must[0].bool.should.length).to.equal(2)
         expect(query.bool.must[0].bool.should[0])
         expect(query.bool.must[0].bool.should[0]).to.deep.equal({

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -193,7 +193,6 @@ describe('ElasticQueryBuilder', () => {
         .include({ 'bool.must[0].multi_match.fields[0]': 'subjectLiteral^2' })
 
       // Expect only common boosting clauses because RC doesn't use this search-scope at writing
-      console.log('should: ', JSON.stringify(inst.query.toJson().bool.should, null, 2))
       expect(inst.query.toJson().bool.should)
         .to.be.a('array')
         .have.lengthOf(10)

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -366,8 +366,6 @@ describe('ElasticQueryBuilder', () => {
           }
         })
 
-        console.log('Should: ', JSON.stringify(query.bool.should), null, 2)
-
         expect(query.bool.should[0]).to.deep.equal(
           {
             match_phrase: {

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -347,6 +347,8 @@ describe('ElasticQueryBuilder', () => {
 
         const query = inst.query.toJson()
 
+        console.log('query: ', JSON.stringify(query, null, 2))
+
         expect(query.bool.must[0].bool.should.length).to.equal(2)
         expect(query.bool.must[0].bool.should[0])
         expect(query.bool.must[0].bool.should[0]).to.deep.equal({
@@ -366,47 +368,7 @@ describe('ElasticQueryBuilder', () => {
           }
         })
 
-        expect(query.bool.should[0]).to.deep.equal(
-          {
-            match_phrase: {
-              'subjectLiteral.raw': {
-                query: 'toast',
-                boost: 50
-              }
-            }
-          }
-        )
-
-        expect(query.bool.should[1]).to.deep.equal(
-          {
-            match_phrase: {
-              'parallelSubjectLiteral.raw': {
-                query: 'toast',
-                boost: 50
-              }
-            }
-          }
-        )
-
-        expect(query.bool.should[2]).to.deep.equal({
-          prefix: {
-            'subjectLiteral.raw': {
-              value: 'toast',
-              boost: 50
-            }
-          }
-        })
-
-        expect(query.bool.should[3]).to.deep.equal({
-          prefix: {
-            'parallelSubjectLiteral.raw': {
-              value: 'toast',
-              boost: 50
-            }
-          }
-        })
-
-        expect(query.bool.should[4]).to.deep.equal({
+        expect(query.bool.should[0]).to.deep.equal({
           term: {
             'subjectLiteral.raw': {
               value: 'toast',
@@ -415,7 +377,7 @@ describe('ElasticQueryBuilder', () => {
           }
         })
 
-        expect(query.bool.should[5]).to.deep.equal({
+        expect(query.bool.should[1]).to.deep.equal({
           term: {
             'parallelSubjectLiteral.raw': {
               value: 'toast',

--- a/test/elastic-query-builder.test.js
+++ b/test/elastic-query-builder.test.js
@@ -365,7 +365,50 @@ describe('ElasticQueryBuilder', () => {
             }
           }
         })
-        expect(query.bool.should[0]).to.deep.equal({
+
+        console.log('Should: ', JSON.stringify(query.bool.should), null, 2)
+
+        expect(query.bool.should[0]).to.deep.equal(
+          {
+            match_phrase: {
+              'subjectLiteral.raw': {
+                query: 'toast',
+                boost: 50
+              }
+            }
+          }
+        )
+
+        expect(query.bool.should[1]).to.deep.equal(
+          {
+            match_phrase: {
+              'parallelSubjectLiteral.raw': {
+                query: 'toast',
+                boost: 50
+              }
+            }
+          }
+        )
+
+        expect(query.bool.should[2]).to.deep.equal({
+          prefix: {
+            'subjectLiteral.raw': {
+              value: 'toast',
+              boost: 50
+            }
+          }
+        })
+
+        expect(query.bool.should[3]).to.deep.equal({
+          prefix: {
+            'parallelSubjectLiteral.raw': {
+              value: 'toast',
+              boost: 50
+            }
+          }
+        })
+
+        expect(query.bool.should[4]).to.deep.equal({
           term: {
             'subjectLiteral.raw': {
               value: 'toast',
@@ -373,7 +416,8 @@ describe('ElasticQueryBuilder', () => {
             }
           }
         })
-        expect(query.bool.should[1]).to.deep.equal({
+
+        expect(query.bool.should[5]).to.deep.equal({
           term: {
             'parallelSubjectLiteral.raw': {
               value: 'toast',


### PR DESCRIPTION
- Adds some boosting for exact/prefix matches for subject search scope
- Doesn't seem to fix the problem called out in the ticket.
- Do we want to do this anyway?