### PR TITLE
Don't remove trailing periods from subject filter

### DIFF
--- a/lib/elasticsearch/config.js
+++ b/lib/elasticsearch/config.js
@@ -1,5 +1,3 @@
-const util = require('../util')
-
 // Configure search scopes:
 const SEARCH_SCOPES = {
   all: {
@@ -81,19 +79,7 @@ const FILTER_CONFIG = {
   format: { operator: 'match', field: ['formatId'], repeatable: true },
   recordType: { operator: 'match', field: ['recordTypeId'], repeatable: true },
   owner: { operator: 'match', field: ['items.owner.id', 'items.owner.label'], repeatable: true, path: 'items' },
-  subjectLiteral: {
-    transform: (val, logger) => {
-      if (typeof val === 'string') {
-        return util.removeTrailingPeriod(val, logger)
-      }
-      if (Array.isArray(val)) {
-        return val.map((val) => util.removeTrailingPeriod(val, logger))
-      }
-    },
-    operator: 'match',
-    field: ['subjectLiteral.raw'],
-    repeatable: true
-  },
+  subjectLiteral: { operator: 'match', field: ['subjectLiteral.raw'], repeatable: true },
   holdingLocation: { operator: 'match', field: ['items.holdingLocation.id', 'items.holdingLocation.label'], repeatable: true, path: 'items' },
   buildingLocation: { operator: 'match', field: ['buildingLocationIds'], repeatable: true },
   language: { operator: 'match', field: ['language.id', 'language.label'], repeatable: true },

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -119,7 +119,7 @@ describe('Util', function () {
     })
   })
 
-  it('should strip a terminal period from a single subjectLiteral', () => {
+  it('should not strip a terminal period from a single subjectLiteral', () => {
     const incoming = {
       filters: {
         subjectLiteral: 'Cats.'
@@ -131,10 +131,10 @@ describe('Util', function () {
     }
 
     const outgoing = util.parseParams(incoming, spec)
-    expect(outgoing.filters.subjectLiteral).to.equal('Cats')
+    expect(outgoing.filters.subjectLiteral).to.equal('Cats.')
   })
 
-  it('should string a terminal period from each subjectLiteral in an array', () => {
+  it('should not strip a terminal period from each subjectLiteral in an array', () => {
     const incoming = {
       filters: {
         subjectLiteral: ['Cats.', 'Dogs.']
@@ -147,8 +147,8 @@ describe('Util', function () {
 
     const outgoing = util.parseParams(incoming, spec)
     expect(outgoing.filters.subjectLiteral.length).to.equal(2)
-    expect(outgoing.filters.subjectLiteral[0]).to.equal('Cats')
-    expect(outgoing.filters.subjectLiteral[1]).to.equal('Dogs')
+    expect(outgoing.filters.subjectLiteral[0]).to.equal('Cats.')
+    expect(outgoing.filters.subjectLiteral[1]).to.equal('Dogs.')
   })
 
   describe('parseParam', () => {


### PR DESCRIPTION
* Per https://newyorkpubliclibrary.atlassian.net/browse/SCC-4801, this is the last piece of the puzzle that is being prescriptive about trailing periods instead of just deferring to the data that we actually have in the index.
* We are no longer stripping trailing periods on the frontend as of https://github.com/NYPL/research-catalog/pull/553 and we are using exact-match filtering on subjects as of https://github.com/NYPL/discovery-api/pull/512 so this change will bring everything in line so that the filter aggregations, bib page data, and subjects index all are in agreement and we're not transforming the subject strings that reach the end user.