### PR TITLE
Stronger typing for variant vs. preferred term, fix sorting

### DIFF
--- a/lib/subjects.js
+++ b/lib/subjects.js
@@ -30,13 +30,13 @@ const PAINLESS_ALPHA_PREFIX_SORT_ASC = `
       for (String variant : params._source['variants']) {
           if (variant.toLowerCase().startsWith(searchValue)) {
               if (sortValue == null || variant.compareTo(sortValue) < 0) {
-                sortValue = variant;
+                sortValue = variant.toLowerCase();
               }
           }
       }
   }
   if (sortValue == null || params._source['preferredTerm'].toLowerCase().startsWith(searchValue)) {
-      sortValue = params._source['preferredTerm'];
+      sortValue = params._source['preferredTerm'].toLowerCase();
   }
   return sortValue;
 `
@@ -48,13 +48,13 @@ const PAINLESS_ALPHA_PREFIX_SORT_DESC = `
       for (String variant : params._source['variants']) {
           if (variant.toLowerCase().startsWith(searchValue)) {
               if (sortValue == null || variant.compareTo(sortValue) > 0) {
-                sortValue = variant;
+                sortValue = variant.toLowerCase();
               }
           }
       }
   }
   if (sortValue == null || params._source['preferredTerm'].toLowerCase().startsWith(searchValue)) {
-      sortValue = params._source['preferredTerm'];
+      sortValue = params._source['preferredTerm'].toLowerCase();
   }
   return sortValue;
 `
@@ -94,19 +94,32 @@ module.exports = function (app, _private = null) {
             if ('preferredTerm.keyword' in hit.highlight) {
               // if match is on preferredTerm, use that regardless of variant matches
               return {
-                preferredTerm: hit._source.preferredTerm,
+                '@type': 'preferredTerm',
+                termLabel: hit._source.preferredTerm,
                 count: hit._source.count,
-                broaderTerms: hit._source.broaderTerms,
-                narrowerTerms: hit._source.narrowerTerms,
-                seeAlso: hit._source.seeAlso,
+                broaderTerms: hit._source.broaderTerms?.map((term) => ({ label: term })),
+                narrowerTerms: hit._source.narrowerTerms?.map((term) => ({ label: term })),
+                seeAlso: hit._source.seeAlso?.map((term) => ({ label: term })),
                 uri: hit._source.uri
               }
             } else {
               // Match was only on a variant- use that in the response.
+              let term = hit.highlight['variants.keyword'][0]
+              const sortedTerm = hit.sort != null && hit.sort.length > 0 ? hit.sort[0] : ''
+              hit.highlight['variants.keyword'].forEach((highlight) => {
+                if (highlight.toLowerCase() === sortedTerm) {
+                  // we're alphabetically sorted on a specific variant, use that in results
+                  term = highlight
+                }
+              })
               return {
-                variantTerm: hit.highlight['variants.keyword'][0],
+                '@type': 'variant',
+                termLabel: term,
                 preferredTerms: [
-                  { [hit._source.preferredTerm]: hit._source.count }
+                  {
+                    label: hit._source.preferredTerm,
+                    count: hit._source.count
+                  }
                 ]
               }
             }

--- a/test/subjects.test.js
+++ b/test/subjects.test.js
@@ -39,9 +39,11 @@ describe('Subjects query', function () {
       const searchBody = esSearchStub.getCall(0).args[0]
       expect(results['@type']).to.equal('subjectList')
       expect(results.subjects.length).to.equal(2)
-      expect(results.subjects[0].preferredTerm).to.equal('cat')
+      expect(results.subjects[0].termLabel).to.equal('cat')
+      expect(results.subjects[0]['@type']).to.equal('preferredTerm')
       expect(results.subjects[0].count).to.equal(1)
-      expect(results.subjects[1].preferredTerm).to.equal('dog')
+      expect(results.subjects[1].termLabel).to.equal('dog')
+      expect(results.subjects[1]['@type']).to.equal('preferredTerm')
       expect(results.subjects[1].count).to.equal(2)
       expect(searchBody.query.bool.must[0].bool.should[0].term['preferredTerm.keyword'].value).to.equal('cat')
     })
@@ -60,8 +62,8 @@ describe('Subjects query', function () {
                 {
                   hits:
                     [
-                      { _source: { variants: ['cat'], preferredTerm: 'kitty', count: 1 }, highlight: { 'variants.keyword': ['cat'] } },
-                      { _source: { variants: ['dog'], preferredTerm: 'puppy', count: 2 }, highlight: { 'variants.keyword': ['dog'] } }
+                      { _source: { variants: ['cat'], preferredTerm: 'kitty', count: 1 }, highlight: { 'variants.keyword': ['Cat'] }, sort: ['cat'] },
+                      { _source: { variants: ['dog'], preferredTerm: 'puppy', count: 2 }, highlight: { 'variants.keyword': ['Dog'] }, sort: ['dog'] }
                     ]
                 }
             }
@@ -71,10 +73,14 @@ describe('Subjects query', function () {
       const searchBody = esSearchStub.getCall(0).args[0]
       expect(results['@type']).to.equal('subjectList')
       expect(results.subjects.length).to.equal(2)
-      expect(results.subjects[0].variantTerm).to.equal('cat')
-      expect(results.subjects[0].preferredTerms[0].kitty).to.equal(1)
-      expect(results.subjects[1].variantTerm).to.equal('dog')
-      expect(results.subjects[1].preferredTerms[0].puppy).to.equal(2)
+      expect(results.subjects[0].termLabel).to.equal('Cat')
+      expect(results.subjects[0]['@type']).to.equal('variant')
+      expect(results.subjects[0].preferredTerms[0].label).to.equal('kitty')
+      expect(results.subjects[0].preferredTerms[0].count).to.equal(1)
+      expect(results.subjects[1].termLabel).to.equal('Dog')
+      expect(results.subjects[1]['@type']).to.equal('variant')
+      expect(results.subjects[1].preferredTerms[0].label).to.equal('puppy')
+      expect(results.subjects[1].preferredTerms[0].count).to.equal(2)
       expect(searchBody.query.bool.must[0].bool.should[0].term['preferredTerm.keyword'].value).to.equal('cat')
     })
   })


### PR DESCRIPTION
* This addresses some of the things we discussed last week, mainly:
 * Changes `variantTerm` and `preferredTerm` in the subject list objects to just `termLabel`
 * Adds a `@type` indicating whether an entry in the result list is a `variant` or a `preferredTerm` 
 * `broaderTerms`, `narrowerTerms`, `seeAlso` and `preferredTerms` for variants are all lists of objects with a `label` for their associated term, and in the case of `preferredTerms`, a `count` field, whereas before they were a key-value map of term to count.
* Additionally fixes the issue of sort not respecting case by updating our painless script sort term results.

Results now look like this:

```
[
  {
    "@type": "variant",
    "termLabel": "M'Baye, Mariétou",
    "preferredTerms": [
      {
        "label": "Ken Bugul",
        "count": 2
      }
    ]
  },
  {
    "@type": "preferredTerm",
    "termLabel": "M'Bayero.",
    "count": 1
  },
  {
    "@type": "preferredTerm",
    "termLabel": "M'boom",
    "count": 1
  },
  {
    "@type": "preferredTerm",
    "termLabel": "M'Boom (Musical group)",
    "count": 1,
    "broaderTerms": [],
    "seeAlso": [
      {
        "label": "Founder: Roach, Max, 1924-2007"
      }
    ],
    "uri": 13002932
  }
]
```